### PR TITLE
cmake: don't recompile at each build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,10 +16,7 @@ set(FESOM_ORIGINAL_VERSION_FILE ${src_home}/fesom_version_info.F90)
 set(FESOM_GENERATED_VERSION_FILE ${CMAKE_CURRENT_BINARY_DIR}/fesom_version_info-generated.F90)
 list(REMOVE_ITEM sources_Fortran ${FESOM_ORIGINAL_VERSION_FILE}) # we want to compile the generated file instead
 list(APPEND sources_Fortran ${FESOM_GENERATED_VERSION_FILE})
-add_custom_command(OUTPUT 5303B6F4_E4F4_45B2_A6E5_8E2B9FB5CDC4 ${FESOM_GENERATED_VERSION_FILE} # the first arg to OUTPUT is a name for a file we never create to make sure this command will run on every re-build (let our file be the second arg, as the first file is inadvertently removed by make)
-                   COMMAND ${CMAKE_COMMAND} -DFESOM_ORIGINAL_VERSION_FILE=${FESOM_ORIGINAL_VERSION_FILE} -DFESOM_GENERATED_VERSION_FILE=${FESOM_GENERATED_VERSION_FILE} -P GitRepositoryInfo.cmake
-                   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-                   COMMENT "determining ${PROJECT_NAME} git SHA ...")
+include(GitRepositoryInfo.cmake)
 
 #if(${FESOM_STANDALONE})
 #   list(REMOVE_ITEM sources_Fortran ${src_home}/cpl_driver.F90)

--- a/src/GitRepositoryInfo.cmake
+++ b/src/GitRepositoryInfo.cmake
@@ -9,4 +9,18 @@ else()
    message("git not found, setting FESOM_GIT_SHA to: ${FESOM_GIT_SHA}")
 endif()
 
-configure_file(${FESOM_ORIGINAL_VERSION_FILE} ${FESOM_GENERATED_VERSION_FILE} @ONLY)
+set(SHORT_HASH_FILE ${CMAKE_BINARY_DIR}/short_hash.txt)
+if (EXISTS "${SHORT_HASH_FILE}")
+    file(READ ${SHORT_HASH_FILE} READ_IN_SHORT_HASH)
+else()
+    set(READ_IN_SHORT_HASH "")
+endif()
+
+message(STATUS "FESOM_GIT_SHA: '${FESOM_GIT_SHA}'")
+if (NOT ("${READ_IN_SHORT_HASH}" STREQUAL "${FESOM_GIT_SHA}"))
+    message(STATUS "previous FESOM_GIT_SHA: '${READ_IN_SHORT_HASH}' regenerating ${FESOM_GENERATED_VERSION_FILE}")
+    # This will update short_hash.txt, causing cmake to reconfigure
+    file(WRITE ${SHORT_HASH_FILE} ${FESOM_GIT_SHA})
+    configure_file(${FESOM_ORIGINAL_VERSION_FILE} ${FESOM_GENERATED_VERSION_FILE} @ONLY)
+endif()
+


### PR DESCRIPTION
Without this patch, the file `fesom_version_info-generated.F90` is generated
at each build, rebuilding all its dependencies up to the fesom executable.

The patch generates the fesom_version_info-generated.F90 only when the
FESOM_GIT_SHA value changes to reflect the current git status at the
time of building Fesom.
With this patch it allows to not recompile Fesom if not necessary. For
example calling make; make (in a row), without any new commits between
the two make will compile fesom only once. Currently, with this example,
fesom_version_info-generated.F90 is recompiled because of a new
timestamp, thus recompiling fesom.