### PR TITLE
Add IDEMIX paths to the namelist

### DIFF
--- a/config/namelist.cvmix
+++ b/config/namelist.cvmix
@@ -23,7 +23,9 @@ idemix_gamma       = 1.570      ! constant of order one derived from the shape o
 idemix_jstar       = 10.0       ! spectral bandwidth in modes (dimensionless)
 idemix_mu0         = 1.33333333 ! dissipation parameter (dimensionless)
 idemix_sforcusage  = 0.2
-idemix_n_hor_iwe_prop_iter = 5  ! iterations for contribution from horiz. wave propagation 
+idemix_n_hor_iwe_prop_iter = 5  ! iterations for contribution from horiz. wave propagation
+idemix_surforc_file = '/work/ollie/clidyn/forcing/IDEMIX/fourier_smooth_2005_cfsr_inert_rgrid.nc'
+idemix_botforc_file = '/work/ollie/clidyn/forcing/IDEMIX/tidal_energy_gx1v6_20090205_rgrid.nc'
 /
 
 ! namelist for PP

--- a/src/gen_modules_cvmix_idemix.F90
+++ b/src/gen_modules_cvmix_idemix.F90
@@ -58,10 +58,10 @@ module g_cvmix_idemix
     integer       :: idemix_n_hor_iwe_prop_iter = 1
     
     ! filelocation for idemix surface forcing 
-    character(200):: idemix_surforc_file = '/work/ollie/pscholz/FORCING/IDEMIX/fourier_smooth_2005_cfsr_inert_rgrid.nc'
+    character(1000):: idemix_surforc_file = './fourier_smooth_2005_cfsr_inert_rgrid.nc'
     
     ! filelocation for idemix bottom forcing 
-    character(200):: idemix_botforc_file = '/work/ollie/pscholz/FORCING/IDEMIX/tidal_energy_gx1v6_20090205_rgrid.nc'
+    character(1000):: idemix_botforc_file = './tidal_energy_gx1v6_20090205_rgrid.nc'
     
     namelist /param_idemix/ idemix_tau_v, idemix_tau_h, idemix_gamma, idemix_jstar, idemix_mu0, idemix_n_hor_iwe_prop_iter, & 
                             idemix_sforcusage, idemix_surforc_file, idemix_botforc_file


### PR DESCRIPTION
@patrickscholz I suggest to change from hardcoded paths to the IDEMIX files to just specifying in the namelist.
- I copied IDEMIX directory from your folder to default place on ollie and mistral and specify this path as a default.
- I change defaults in the code to files in the local directory, to avoid confusion during development.