### PR TITLE
editorconfig: initial config file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file, utf-8 charset
+[*]
+end_of_line = lf
+insert_final_newline = false
+trim_trailing_whitespace = false
+charset = utf-8
+
+# 4 tab indentation
+[*.{c,h,cpp}]
+indent_style = space
+indent_size = 3
+
+# 4 space indentation
+[*.F90]
+indent_style = space
+indent_size = 4
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+[CMakeLists.txt]
+indent_style = space
+indent_size = 3
+


### PR DESCRIPTION
This commit introduces the file .editorconfig which is a configuration
for EditorConfig [1]:
" EditorConfig helps maintain consistent coding styles for multiple
developers working on the same project across various editors and IDEs.
The EditorConfig project consists of a file format for defining coding
styles and a collection of text editor plugins that enable editors to
read the file format and adhere to defined styles. EditorConfig files
are easily readable and they work nicely with version control systems."

This patch tries to configure the coding style seen so far. It's
indented to be updated, for example changing:
````
insert_final_newline = false
trim_trailing_whitespace = false
````
to
````
insert_final_newline = true
trim_trailing_whitespace = true
```
to remove whitespaces.

[1] https://editorconfig.org