### PR TITLE
Partitioner fix

### DIFF
--- a/.github/workflows/fesom2_urot.yml
+++ b/.github/workflows/fesom2_urot.yml
@@ -49,5 +49,15 @@ jobs:
         cd work_souf
         fcheck .    
         
+    - name: Check partitioner compilation
+      run: |
+        cd mesh_part
+        bash -l configure.sh ubuntu
+    - name: Run partitioner
+      run: |
+        cd work_pi
+        cp ../bin/fesom_ini.x .
+        ./fesom_ini.x
+        
     
 

--- a/src/fvom_init.F90
+++ b/src/fvom_init.F90
@@ -71,6 +71,20 @@ interface
    end subroutine communication_ini
 end interface
 
+interface
+   subroutine read_mesh_cavity(mesh)
+     use mod_mesh
+     type(t_mesh), intent(inout)  , target :: mesh
+   end subroutine read_mesh_cavity
+end interface
+
+interface
+   subroutine find_levels_cavity(mesh)
+     use mod_mesh
+     type(t_mesh), intent(inout)  , target :: mesh
+   end subroutine find_levels_cavity
+end interface
+
   character(len=MAX_PATH)         :: nmlfile  !> name of configuration namelist file
   integer                     :: start_t, interm_t, finish_t, rate_t
   type(t_mesh), target, save  :: mesh


### PR DESCRIPTION
Partitioner was broken with `gfortran` due to missing interfaces. I just stupidly add them, but since they are related to cavities, I might miss something. Please, @patrickscholz have a look and merge if you are OK with that. 

I also added tests for the partitioner now (simple compiles and runs). 