### PR TITLE
A new option in namelist.oce -> smooth_bh_tra. A tracer biharmonic di…

### DIFF
--- a/config/namelist.oce
+++ b/config/namelist.oce
@@ -53,6 +53,11 @@ use_windmix   = .false.     ! enhance mixing trough wind only for PP mixing (for
 windmix_kv    = 1.e-3
 windmix_nl    = 2
 
+smooth_bh_tra =.false.     ! use biharmonic diffusion (filter implementation) for tracers
+gamma0_tra    = 0.0005     ! gammaX_tra are analogous to those in the dynamical part
+gamma1_tra    = 0.0125
+gamma2_tra    = 0.
+
 diff_sh_limit=5.0e-3            ! for KPP, max diff due to shear instability
 Kv0_const=.false.
 double_diffusion=.false.               ! for KPP,dd switch

--- a/src/oce_ale_tracer.F90
+++ b/src/oce_ale_tracer.F90
@@ -83,6 +83,16 @@ module bc_surface_interface
     end function
   end interface
 end module
+module diff_part_bh_interface
+  interface
+    subroutine diff_part_bh(ttf, mesh)
+      use MOD_MESH
+      use g_PARSUP
+      type(t_mesh) , intent(in),    target :: mesh
+      real(kind=WP), intent(inout), target :: ttf(mesh%nl-1, myDim_nod2D+eDim_nod2D)
+    end subroutine
+  end interface
+end module
 
 !
 !
@@ -246,6 +256,7 @@ subroutine diff_tracers_ale(tr_num, mesh)
     use diff_ver_part_expl_ale_interface
     use diff_ver_part_redi_expl_interface
     use diff_ver_part_impl_ale_interface
+    use diff_part_bh_interface
     implicit none
     
     integer, intent(in)      :: tr_num
@@ -304,6 +315,10 @@ subroutine diff_tracers_ale(tr_num, mesh)
     
     !We DO not set del_ttf to zero because it will not be used in this timestep anymore
     !init_tracers will set it to zero for the next timestep
+    !init_tracers will set it to zero for the next timestep
+    if (smooth_bh_tra) then
+       call diff_part_bh(tr_arr(:,:,tr_num), mesh) ! alpply biharmonic diffusion (implemented as filter)                                                
+    end if
 end subroutine diff_tracers_ale
 !
 !
@@ -913,6 +928,75 @@ subroutine diff_part_hor_redi(mesh)
         
     end do
 end subroutine diff_part_hor_redi
+!
+!
+!===============================================================================
+SUBROUTINE diff_part_bh(ttf, mesh)
+    use o_ARRAYS
+    use g_PARSUP
+    use MOD_MESH
+    use O_MESH
+    use o_param
+    use g_config
+    use g_comm_auto
+
+    IMPLICIT NONE
+    type(t_mesh),  intent(in),    target :: mesh
+    real(kind=WP), intent(inout), target :: ttf(mesh%nl-1, myDim_nod2D+eDim_nod2D)
+    real(kind=WP)                        :: u1, v1, len, vi, tt, ww 
+    integer                              :: nz, ed, el(2), en(2), k, elem, nl1
+    real(kind=WP), allocatable           :: temporary_ttf(:,:)
+
+#include "associate_mesh.h"
+
+    ed=myDim_nod2D+eDim_nod2D
+    allocate(temporary_ttf(nl-1, ed))
+
+    temporary_ttf=0.0_8
+    DO ed=1, myDim_edge2D+eDim_edge2D
+       if (myList_edge2D(ed)>edge2D_in) cycle
+       el=edge_tri(:,ed)
+       en=edges(:,ed)
+       len=sqrt(sum(elem_area(el)))
+       nl1=maxval(nlevels_nod2D_min(en))-1
+       DO  nz=1,nl1
+           u1=UV(1, nz,el(1))-UV(1, nz,el(2))
+           v1=UV(2, nz,el(1))-UV(2, nz,el(2))
+           vi=u1*u1+v1*v1
+           tt=ttf(nz,en(1))-ttf(nz,en(2))
+           vi=sqrt(max(gamma0, max(gamma1*sqrt(vi), gamma2*vi))*len)
+           !vi=sqrt(max(sqrt(u1*u1+v1*v1),0.04)*le)  ! 10m^2/s for 10 km (0.04 h/50)
+           !vi=sqrt(10.*le)
+           tt=tt*vi
+           temporary_ttf(nz,en(1))=temporary_ttf(nz,en(1))-tt
+           temporary_ttf(nz,en(2))=temporary_ttf(nz,en(2))+tt
+       END DO 
+    END DO
+    call exchange_nod(temporary_ttf)
+    ! ===========
+    ! Second round: 
+    ! ===========
+    DO ed=1, myDim_edge2D+eDim_edge2D
+       if (myList_edge2D(ed)>edge2D_in) cycle
+          el=edge_tri(:,ed)
+          en=edges(:,ed)
+          len=sqrt(sum(elem_area(el)))
+          nl1=maxval(nlevels_nod2D_min(en))-1
+          DO  nz=1,nl1
+              u1=UV(1, nz,el(1))-UV(1, nz,el(2))
+              v1=UV(2, nz,el(1))-UV(2, nz,el(2))
+              vi=u1*u1+v1*v1
+              tt=temporary_ttf(nz,en(1))-temporary_ttf(nz,en(2))
+              vi=sqrt(max(gamma0, max(gamma1*sqrt(vi), gamma2*vi))*len)
+              !vi=sqrt(max(sqrt(u1*u1+v1*v1),0.04)*le)  ! 10m^2/s for 10 km (0.04 h/50)
+              !vi=sqrt(10.*le) 
+              tt=-tt*vi*dt
+              ttf(nz,en(1))=ttf(nz,en(1))-tt/area(nz,en(1))
+              ttf(nz,en(2))=ttf(nz,en(2))+tt/area(nz,en(2))
+          END DO 
+    END DO  
+    deallocate(temporary_ttf)
+end subroutine diff_part_bh
 !
 !
 !===============================================================================

--- a/src/oce_modules.F90
+++ b/src/oce_modules.F90
@@ -134,6 +134,11 @@ logical                       :: use_windmix   = .false.
 real(kind=WP)                 :: windmix_kv    = 1.e-3
 integer                       :: windmix_nl    = 2
 
+! bharmonic diffusion for tracers. We recommend to use this option in very high resolution runs (Redi is generally off there).
+logical                       :: smooth_bh_tra = .false.
+real(kind=WP)                 :: gamma0_tra    = 0.0005
+real(kind=WP)                 :: gamma1_tra    = 0.0125
+real(kind=WP)                 :: gamma2_tra    = 0.
 !_______________________________________________________________________________
 ! use non-constant reference density if .false. density_ref=density_0
 logical                       :: use_density_ref   = .false.
@@ -176,7 +181,8 @@ character(20)                  :: which_pgf='shchepetkin'
             tra_adv_lim, tra_adv_ph, tra_adv_pv, num_tracers, tracer_ID, &
             use_momix, momix_lat, momix_kv, &
             use_instabmix, instabmix_kv, &
-            use_windmix, windmix_kv, windmix_nl
+            use_windmix, windmix_kv, windmix_nl, &
+            smooth_bh_tra, gamma0_tra, gamma1_tra, gamma2_tra
             
 END MODULE o_PARAM  
 !==========================================================


### PR DESCRIPTION
…ffusion (adopted from Sergey's notes) which is implemented as filter (an analogous to that of the biharmonic viscosities). It is controlled via gammaX_tra (similar as for viscosities).

We recommend to use this option in very high resolution runs where the Redi diffusivity is generally scaled to zero and the simulated tracers may contain noise.