### PR TITLE
hotfix to run awicm3 with mpi that is not intelmpi

### DIFF
--- a/src/fvom_main.F90
+++ b/src/fvom_main.F90
@@ -50,12 +50,12 @@ type(t_mesh),             target, save :: mesh
     !OIFS-FESOM2 coupling: does not require MPI_INIT here as this is done by OASIS
     call MPI_INIT_THREAD(MPI_THREAD_MULTIPLE, provided, i)
 #endif
-    
-    t1 = MPI_Wtime()
 
 #if defined (__oasis)
     call cpl_oasis3mct_init(MPI_COMM_FESOM)
 #endif
+
+    t1 = MPI_Wtime()
 
     call par_init 
     if(mype==0) then


### PR DESCRIPTION
This solves #99 and should be part of the release still.