### PR TITLE
be able to call the FESOM executable with options

### DIFF
--- a/src/command_line_options.F90
+++ b/src/command_line_options.F90
@@ -1,0 +1,37 @@
+module command_line_options_module
+! synopsis: read options passed to the main executable and trigger corresponding actions
+
+  implicit none  
+  public command_line_options
+  private
+
+  type :: command_line_options_type
+  contains
+    procedure, nopass :: parse
+  end type
+  type(command_line_options_type) command_line_options
+
+contains
+
+  subroutine parse()
+    integer i
+    character(len=:), allocatable :: arg
+    integer arglength
+
+    do i = 1, command_argument_count()    
+      call get_command_argument(i, length=arglength)
+      allocate(character(arglength) :: arg)
+      call get_command_argument(i, value=arg)
+      select case (arg)
+      case('--smoketest')
+        print '(g0)', 'smoketest'
+      case default
+        print *, 'unknown option: ', arg
+        error stop
+      end select
+      deallocate(arg)
+    end do
+
+  end subroutine
+
+end module

--- a/src/command_line_options.F90
+++ b/src/command_line_options.F90
@@ -14,6 +14,7 @@ module command_line_options_module
 contains
 
   subroutine parse()
+    use info_module
     integer i
     character(len=:), allocatable :: arg
     integer arglength
@@ -25,6 +26,9 @@ contains
       select case (arg)
       case('--smoketest')
         print '(g0)', 'smoketest'
+      case('--info')
+        print '(g0)', '# Definitions'
+        call info%print_definitions()
       case default
         print *, 'unknown option: ', arg
         error stop

--- a/src/fvom_main.F90
+++ b/src/fvom_main.F90
@@ -23,6 +23,7 @@ use io_mesh_info
 use diagnostics
 use mo_tidal
 use fesom_version_info_module
+use command_line_options_module
 
 ! Define icepack module
 #if defined (__icepack)
@@ -44,6 +45,11 @@ real(kind=real32) :: mean_rtime(15), max_rtime(15), min_rtime(15)
 real(kind=real32) :: runtime_alltimesteps
 
 type(t_mesh),             target, save :: mesh
+
+  if(command_argument_count() > 0) then
+    call command_line_options%parse()
+    stop
+  end if
 
 #ifndef __oifs
     !ECHAM6-FESOM2 coupling: cpl_oasis3mct_init is called here in order to avoid circular dependencies between modules (cpl_driver and g_PARSUP)

--- a/src/info_module.F90
+++ b/src/info_module.F90
@@ -1,0 +1,92 @@
+module info_module
+! synopsis: query information from FESOM
+
+  implicit none  
+  public info
+  private
+
+  type :: info_type
+  contains
+    procedure, nopass :: print_definitions
+  end type
+  type(info_type) info
+
+contains
+
+  ! this is a list of preprocessor definitions from the FESOM Fortran source files
+  ! it will probably become outdated at some point and should be reviewed
+  ! the result will reflect the status of definitions as they are set when *this file* had been compiled
+  subroutine print_definitions()
+#ifdef __icepack
+      print '(g0)', '__icepack is ON'
+#else
+      print '(g0)', '__icepack is OFF'
+#endif  
+#ifdef __oasis
+      print '(g0)', '__oasis is ON'
+#else
+      print '(g0)', '__oasis is OFF'
+#endif  
+#ifdef __oifs
+      print '(g0)', '__oifs is ON'
+#else
+      print '(g0)', '__oifs is OFF'
+#endif  
+#ifdef DEBUG
+      print '(g0)', 'DEBUG is ON'
+#else
+      print '(g0)', 'DEBUG is OFF'
+#endif  
+#ifdef DISABLE_MULTITHREADING
+      print '(g0)', 'DISABLE_MULTITHREADING is ON'
+#else
+      print '(g0)', 'DISABLE_MULTITHREADING is OFF'
+#endif  
+#ifdef false
+      print '(g0)', 'false is ON'
+#else
+      print '(g0)', 'false is OFF'
+#endif  
+#ifdef FVOM_INIT
+      print '(g0)', 'FVOM_INIT is ON'
+#else
+      print '(g0)', 'FVOM_INIT is OFF'
+#endif  
+#ifdef oifs
+      print '(g0)', 'oifs is ON'
+#else
+      print '(g0)', 'oifs is OFF'
+#endif  
+#ifdef OMP_MAX_THREADS
+      print '(g0)', 'OMP_MAX_THREADS is ON'
+#else
+      print '(g0)', 'OMP_MAX_THREADS is OFF'
+#endif  
+#ifdef PARMS
+      print '(g0)', 'PARMS is ON'
+#else
+      print '(g0)', 'PARMS is OFF'
+#endif  
+#ifdef PETSC
+      print '(g0)', 'PETSC is ON'
+#else
+      print '(g0)', 'PETSC is OFF'
+#endif  
+#ifdef use_cavity
+      print '(g0)', 'use_cavity is ON'
+#else
+      print '(g0)', 'use_cavity is OFF'
+#endif  
+#ifdef use_fullfreesurf
+      print '(g0)', 'use_fullfreesurf is ON'
+#else
+      print '(g0)', 'use_fullfreesurf is OFF'
+#endif  
+#ifdef VERBOSE
+      print '(g0)', 'VERBOSE is ON'
+#else
+      print '(g0)', 'VERBOSE is OFF'
+#endif  
+  end subroutine
+
+end module


### PR DESCRIPTION
Be able to call the FESOM executable with options for testing it without running a simulation (i.e. a minimal dry-run)