### PR TITLE
Workbench bugfix cavity

### DIFF
--- a/src/cvmix_tke.F90
+++ b/src/cvmix_tke.F90
@@ -452,7 +452,8 @@ subroutine integrate_tke( &
     dzw                                                             !
    
   ! IDEMIX variables, if run coupled iw_diss is added as forcing to TKE
-  real(cvmix_r8), dimension(max_nlev), intent(in), optional  :: &
+!!PS   real(cvmix_r8), dimension(max_nlev), intent(in), optional  :: &
+  real(cvmix_r8), dimension(nlev+1), intent(in), optional  :: &
     E_iw                                                         ,& !  
     alpha_c                                                      ,& !
     iw_diss                                                         !

--- a/src/gen_modules_cvmix_idemix.F90
+++ b/src/gen_modules_cvmix_idemix.F90
@@ -291,16 +291,16 @@ module g_cvmix_idemix
             !___________________________________________________________________
             ! calculate for TKE square of Brünt-Väisälä frequency, be aware that
             ! bvfreq contains already the squared brünt Väisälä frequency ...
-            bvfreq2        = 0.0_WP
+            bvfreq2          = 0.0_WP
             bvfreq2(uln:nln) = bvfreq(uln:nln,node)
             
             !___________________________________________________________________
             ! dz_trr distance between tracer points, surface and bottom dz_trr is half 
             ! the layerthickness ...
-            dz_trr         = 0.0_WP
-            dz_trr(uln+1:nln)  = abs(Z_3d_n(uln:nln-1,node)-Z_3d_n(uln+1:nln,node))
+            dz_trr           = 0.0_WP
+            dz_trr(uln+1:nln)= abs(Z_3d_n(uln:nln-1,node)-Z_3d_n(uln+1:nln,node))
             dz_trr(uln)      = hnode(uln,node)/2.0_WP
-            dz_trr(nln+1)  = hnode(nln,node)/2.0_WP
+            dz_trr(nln+1)    = hnode(nln,node)/2.0_WP
             
             !___________________________________________________________________
             ! main call to calculate idemix
@@ -308,41 +308,42 @@ module g_cvmix_idemix
             
             call cvmix_coeffs_idemix(&
                 ! parameter
-                dzw             = hnode(:,node),                &
-                dzt             = dz_trr(:),                    &
-                nlev            = nln,                          &
-                max_nlev        = nl-1,                         &  
-                dtime           = dt,                           &
-                coriolis        = coriolis_node(node),          &
+                dzw             = hnode(uln:nln,node),                &
+                dzt             = dz_trr(uln:nln+1),                  &
+!                 nlev            = nln,                                &
+                nlev            = nln-uln+1,                          &
+                max_nlev        = nl-1,                               &  
+                dtime           = dt,                                 &
+                coriolis        = coriolis_node(node),                &
                 ! essentials 
-                iwe_new         = iwe(:,node),                  & ! out
-                iwe_old         = iwe_old(:),                   & ! in
-                forc_iw_surface = forc_iw_surface_2D(node),     & ! in
-                forc_iw_bottom  = forc_iw_bottom_2D(node),      & ! in
+                iwe_new         = iwe(uln:nln+1,node),                & ! out
+                iwe_old         = iwe_old(uln:nln+1),                 & ! in
+                forc_iw_surface = forc_iw_surface_2D(node),           & ! in
+                forc_iw_bottom  = forc_iw_bottom_2D(node),            & ! in
                 ! FIXME: nils: better output IDEMIX Ri directly
-                alpha_c         = iwe_alpha_c(:,node),          & ! out (for Ri IMIX)
+                alpha_c         = iwe_alpha_c(uln:nln+1,node),        & ! out (for Ri IMIX)
                 ! only for Osborn shortcut 
                 ! FIXME: nils: put this to cvmix_tke
-                KappaM_out      = iwe_Av(:,node),               & ! out
-                KappaH_out      = iwe_Kv(:,node),               & ! out
-                Nsqr            = bvfreq2(:),                   & ! in
+                KappaM_out      = iwe_Av(  uln:nln+1,node),           & ! out
+                KappaH_out      = iwe_Kv(  uln:nln+1,node),           & ! out
+                Nsqr            = bvfreq2( uln:nln+1),                & ! in
                 ! diagnostics
-                iwe_Ttot        = iwe_Ttot(:,node),             &
-                iwe_Tdif        = iwe_Tdif(:,node),             &
-                iwe_Thdi        = iwe_Thdi(:,node),             &
-                iwe_Tdis        = iwe_Tdis(:,node),             &
-                iwe_Tsur        = iwe_Tsur(:,node),             &
-                iwe_Tbot        = iwe_Tbot(:,node),             &
-                c0              = iwe_c0(:,node),               &
-                v0              = iwe_v0(:,node),               &
+                iwe_Ttot        = iwe_Ttot(uln:nln+1,node),           &
+                iwe_Tdif        = iwe_Tdif(uln:nln+1,node),           &
+                iwe_Thdi        = iwe_Thdi(uln:nln+1,node),           &
+                iwe_Tdis        = iwe_Tdis(uln:nln+1,node),           &
+                iwe_Tsur        = iwe_Tsur(uln:nln+1,node),           &
+                iwe_Tbot        = iwe_Tbot(uln:nln+1,node),           &
+                c0              = iwe_c0(  uln:nln+1,node),           &
+                v0              = iwe_v0(  uln:nln+1,node),           &
                 ! debugging
-                debug           = debug,                        &
+                debug           = debug,                              &
                 !i = i,                                        &
                 !j = j,                                        &
                 !tstep_count = tstep_count,                    &
-                cvmix_int_1     = cvmix_dummy_1(:,node),        &
-                cvmix_int_2     = cvmix_dummy_2(:,node),        &
-                cvmix_int_3     = cvmix_dummy_3(:,node)         &
+                cvmix_int_1     = cvmix_dummy_1(uln:nln+1,node),      &
+                cvmix_int_2     = cvmix_dummy_2(uln:nln+1,node),      &
+                cvmix_int_3     = cvmix_dummy_3(uln:nln+1,node)       &
                 )
             
         end do !-->do node = 1,node_size
@@ -393,10 +394,10 @@ module g_cvmix_idemix
                 uln = ulevels_nod2D(node)
                 
                 ! thickness of mid-level to mid-level interface at node
-                dz_trr         = 0.0_WP
+                dz_trr             = 0.0_WP
                 dz_trr(uln+1:nln)  = Z_3d_n(uln:nln-1,node)-Z_3d_n(uln+1:nln,node)
-                dz_trr(uln)      = hnode(uln,node)/2.0_WP
-                dz_trr(nln+1)  = hnode(nln,node)/2.0_WP
+                dz_trr(uln)        = hnode(uln,node)/2.0_WP
+                dz_trr(nln+1)      = hnode(nln,node)/2.0_WP
                 
                 ! surface cell 
                 vol_wcelli(uln,node) = 1/(areasvol(uln,node)*dz_trr(uln))
@@ -459,7 +460,7 @@ module g_cvmix_idemix
                 
                 ! thickness of mid-level to mid-level interface of element el(1)
                 dz_trr         = 0.0_WP
-                dz_trr(1)      = helem(1,el(1))/2.0_WP
+                dz_trr(nu1)    = helem(nu1,el(1))/2.0_WP
                 !!PS do nz=2,nl1-1
                 do nz=nu1+1,nl1-1
                     dz_trr(nz) = helem(nz-1,el(1))/2.0_WP + helem(nz,el(1))/2.0_WP
@@ -480,7 +481,7 @@ module g_cvmix_idemix
                     
                     ! thickness of mid-level to mid-level interface of element el(2)
                     dz_trr2         = 0.0_WP
-                    dz_trr2(1)      = helem(1,el(2))/2.0_WP
+                    dz_trr2(nu2)    = helem(nu2,el(2))/2.0_WP
                     !!PS do nz=2,nl2-1
                     do nz=nu2+1,nl2-1
                         dz_trr2(nz) = helem(nz-1,el(2))/2.0_WP + helem(nz,el(2))/2.0_WP

--- a/src/gen_modules_cvmix_tke.F90
+++ b/src/gen_modules_cvmix_tke.F90
@@ -277,19 +277,14 @@ module g_cvmix_tke
             ! calcualte for TKE surface momentum forcing --> norm of nodal 
             ! surface wind stress --> tke_forc2d_normstress --> interpolate from elements
             ! to nodes
-            tvol = 0.0_WP
-            do nelem=1,nod_in_elem2D_num(node)
-                elem = nod_in_elem2D(nelem,node)
-                tvol = tvol + elem_area(elem)
-                tke_forc2d_normstress(node) = tke_forc2d_normstress(node) &
-                                         + sqrt(stress_surf(1,elem)**2 + stress_surf(2,elem)**2)*elem_area(elem)/density_0
-            end do !--> do nelem=1,nod_in_elem2D_num(node)
-            tke_forc2d_normstress(node) = tke_forc2d_normstress(node)/tvol
-                
+            tke_forc2d_normstress(node) =   sqrt( &
+                                                stress_node_surf(1,node)**2 + &
+                                                stress_node_surf(2,node)**2 &
+                                                )/density_0
+            
             !___________________________________________________________________
             ! calculate for TKE 3D vertical velocity shear
             vshear2=0.0_WP
-            !!PS do nz=2,nln
             do nz=nun+1,nln
                 vshear2(nz)=(( Unode(1, nz-1, node) - Unode(1, nz, node))**2 + &
                              ( Unode(2, nz-1, node) - Unode(2, nz, node))**2)/ &
@@ -313,14 +308,10 @@ module g_cvmix_tke
             !___________________________________________________________________
             ! dz_trr distance between tracer points, surface and bottom dz_trr is half 
             ! the layerthickness ...
-            !!PS dz_trr         = 0.0_WP
-            !!PS dz_trr(2:nln)  = abs(Z_3d_n(1:nln-1,node)-Z_3d_n(2:nln,node))
-            !!PS dz_trr(1)      = hnode(1,node)/2.0_WP
-            !!PS dz_trr(nln+1)  = hnode(nln,node)/2.0_WP
-            dz_trr         = 0.0_WP
-            dz_trr(nun+1:nln)  = abs(Z_3d_n(nun:nln-1,node)-Z_3d_n(nun+1:nln,node))
-            dz_trr(nun)      = hnode(nun,node)/2.0_WP
-            dz_trr(nln+1)  = hnode(nln,node)/2.0_WP
+            dz_trr            = 0.0_WP
+            dz_trr(nun+1:nln) = abs(Z_3d_n(nun:nln-1,node)-Z_3d_n(nun+1:nln,node))
+            dz_trr(nun)       = hnode(nun,node)/2.0_WP
+            dz_trr(nln+1)     = hnode(nln,node)/2.0_WP
             
             !___________________________________________________________________
             ! main cvmix call to calculate tke
@@ -330,44 +321,45 @@ module g_cvmix_tke
             
             call cvmix_coeffs_tke(&
                 ! parameter
-                dzw          = hnode(:,node),               & ! distance between layer interface --> hnode
-                dzt          = dz_trr(:),                   & ! distnace between tracer points
-                nlev         = nln,                         &
+                dzw          = hnode(nun:nln,node),               & ! distance between layer interface --> hnode
+                dzt          = dz_trr(nun:nln+1),                   & ! distnace between tracer points
+!                 nlev         = nln,                         &
+                nlev         = nln-nun+1,                         &
                 max_nlev     = nl-1,                        &
                 dtime        = dt,                          &
                 rho_ref      = density_0,                   &
                 grav         = g,                           &
                 ! essentials
-                tke_new      = tke(:,node),                 & ! out--> turbulent kinetic energy
-                KappaM_out   = tke_Av(:,node),              & ! out
-                KappaH_out   = tke_Kv(:,node),              & ! out
-                tke_old      = tke_old(:),                  & ! in --> turbulent kinetic energy previous time step
-                old_KappaM   = tke_Av_old(:),               & ! in
-                old_KappaH   = tke_Kv_old(:),               & ! in
-                Ssqr         = vshear2(:),                  & ! in --> square vert. vel. shear
-                Nsqr         = bvfreq2(:),                  & ! in --> square brunt Väisälä freq
-                alpha_c      = tke_in3d_iwealphac(:,node),  & ! in for IDEMIX Ri
-                E_iw         = tke_in3d_iwe(:,node),        & ! in for IDEMIX Ri
+                tke_new      = tke(       nun:nln+1,node),                 & ! out--> turbulent kinetic energy
+                KappaM_out   = tke_Av(    nun:nln+1,node),              & ! out
+                KappaH_out   = tke_Kv(    nun:nln+1,node),              & ! out
+                tke_old      = tke_old(   nun:nln+1),                  & ! in --> turbulent kinetic energy previous time step
+                old_KappaM   = tke_Av_old(nun:nln+1),               & ! in
+                old_KappaH   = tke_Kv_old(nun:nln+1),               & ! in
+                Ssqr         = vshear2(   nun:nln+1),                  & ! in --> square vert. vel. shear
+                Nsqr         = bvfreq2(   nun:nln+1),                  & ! in --> square brunt Väisälä freq
+                alpha_c      = tke_in3d_iwealphac(nun:nln+1,node),  & ! in for IDEMIX Ri
+                E_iw         = tke_in3d_iwe(nun:nln+1,node),        & ! in for IDEMIX Ri
                 ! forcing
-                forc_tke_surf= tke_forc2d_normstress(node), & ! in --> wind stress  
-                forc_rho_surf= tke_forc2d_rhosurf(node),    & ! in
-                bottom_fric  = tke_forc2d_botfrict(node),   & ! in
-                iw_diss      = tke_in3d_iwdis(:,node),      & ! in
+                forc_tke_surf= tke_forc2d_normstress(   node), & ! in --> wind stress  
+                forc_rho_surf= tke_forc2d_rhosurf(      node), & ! in
+                bottom_fric  = tke_forc2d_botfrict(     node), & ! in
+                iw_diss      = tke_in3d_iwdis(nun:nln+1,node), & ! in
                 ! diagnostics
-                tke_Tbpr     = tke_Tbpr(:,node),            & ! buoyancy production
-                tke_Tspr     = tke_Tspr(:,node),            & ! shear production 
-                tke_Tdif     = tke_Tdif(:,node),            & ! vertical diffusion d/dz(k d/dz)TKE
-                tke_Tdis     = tke_Tdis(:,node),            & ! dissipation
-                tke_Twin     = tke_Twin(:,node),            & ! wind forcing
-                tke_Tiwf     = tke_Tiwf(:,node),            & ! internal wave forcing when idemix is used
-                tke_Tbck     = tke_Tbck(:,node),            & ! background forcing only active if IDEMIX is not active, forcing that results from resetting TKE to minimum background TKE value
-                tke_Ttot     = tke_Ttot(:,node),            & ! sum of all terms
-                tke_Lmix     = tke_Lmix(:,node),            & ! mixing length scale of the TKE scheme
-                tke_Pr       = tke_Pr(:,node),              & ! Prantl number
+                tke_Tbpr     = tke_Tbpr(nun:nln+1,node),            & ! buoyancy production
+                tke_Tspr     = tke_Tspr(nun:nln+1,node),            & ! shear production 
+                tke_Tdif     = tke_Tdif(nun:nln+1,node),            & ! vertical diffusion d/dz(k d/dz)TKE
+                tke_Tdis     = tke_Tdis(nun:nln+1,node),            & ! dissipation
+                tke_Twin     = tke_Twin(nun:nln+1,node),            & ! wind forcing
+                tke_Tiwf     = tke_Tiwf(nun:nln+1,node),            & ! internal wave forcing when idemix is used
+                tke_Tbck     = tke_Tbck(nun:nln+1,node),            & ! background forcing only active if IDEMIX is not active, forcing that results from resetting TKE to minimum background TKE value
+                tke_Ttot     = tke_Ttot(nun:nln+1,node),            & ! sum of all terms
+                tke_Lmix     = tke_Lmix(nun:nln+1,node),            & ! mixing length scale of the TKE scheme
+                tke_Pr       = tke_Pr(  nun:nln+1,node),              & ! Prantl number
                 ! debugging
-                cvmix_int_1  = cvmix_dummy_1(:,node),        & !
-                cvmix_int_2  = cvmix_dummy_2(:,node),        & !
-                cvmix_int_3  = cvmix_dummy_3(:,node),        & !
+                cvmix_int_1  = cvmix_dummy_1(nun:nln+1,node),        & !
+                cvmix_int_2  = cvmix_dummy_2(nun:nln+1,node),        & !
+                cvmix_int_3  = cvmix_dummy_3(nun:nln+1,node),        & !
                 i = 1,                                       &
                 j = 1,                                       &
                 tstep_count = tstep_count                    &
@@ -375,10 +367,8 @@ module g_cvmix_tke
             
             tke_Av(nln+1,node)=0.0_WP
             tke_Kv(nln+1,node)=0.0_WP
-            !!PS tke_Av(1,node)=0.0_WP
-            !!PS tke_Kv(1,node)=0.0_WP
-            tke_Av(nun,node)=0.0_WP
-            tke_Kv(nun,node)=0.0_WP
+            tke_Av(nun  ,node)=0.0_WP
+            tke_Kv(nun  ,node)=0.0_WP
             
         end do !--> do node = 1,node_size
         
@@ -393,7 +383,6 @@ module g_cvmix_tke
         Av = 0.0_WP
         do elem=1, myDim_elem2D
             elnodes=elem2D_nodes(:,elem)
-            !!PS do nz=2,nlevels(elem)-1
             do nz=ulevels(elem)+1,nlevels(elem)-1
                 Av(nz,elem) = sum(tke_Av(nz,elnodes))/3.0_WP    ! (elementwise)                
             end do

--- a/src/oce_fer_gm.F90
+++ b/src/oce_fer_gm.F90
@@ -311,7 +311,7 @@ subroutine init_Redi_GM(mesh) !fer_compute_C_K_Redi
             ! the surface template for the scaling 
             !!PS do nz=2, nzmax
             do nz=nzmin+1, nzmax
-                fer_k(nz,n)=fer_k(1,n)*zscaling(nz)
+                fer_k(nz,n)=fer_k(nzmin,n)*zscaling(nz)
             end do 
             ! after vertical Ferreira scaling is done also scale surface template
             !!PS fer_k(1,n)=fer_k(1,n)*zscaling(1)


### PR DESCRIPTION
- fix bug when using TKE + IDEMIX in combination with cavity
- also fix bug in cvmix_TKE.F90 where two variables of different size are multiplied
- also fix bug in GM scaling when using cavity