### PR TITLE
Update ice_thermo_cpl.F90 to fix the ice/snow surface temperature (273.15K)

### DIFF
--- a/src/ice_thermo_cpl.F90
+++ b/src/ice_thermo_cpl.F90
@@ -488,7 +488,7 @@ contains
   zcprosn=rhosno*cpsno/dt               ! Specific Energy required to change temperature of 1m snow on ice [J/(sm³K)]
   zcpdte=zcpdt+zcprosn*hsn              ! Combined Energy required to change temperature of snow + 0.05m of upper ice
   t=(zcpdte*t+a2ihf+zicefl)/(zcpdte+con/zsniced) ! New sea ice surf temp [K]
-  t=min(TFrezs,t)                       ! Not warmer than freezing please!
+  t=min(273.15_WP,t)                       ! Not warmer than freezing please!
  end subroutine ice_surftemp
 
  subroutine ice_albedo(h,hsn,t,alb)

--- a/src/ice_thermo_cpl.F90
+++ b/src/ice_thermo_cpl.F90
@@ -474,6 +474,11 @@ contains
   real(kind=WP)  zcprosn
   !---- local parameters
   real(kind=WP), parameter :: dice  = 0.05_WP                       ! ECHAM6's thickness for top ice "layer"
+    !---- freezing temperature of sea-water [K]
+  real(kind=WP)  :: TFrezs
+
+  !---- compute freezing temperature of sea-water from salinity
+  TFrezs = -0.0575_WP*S_oc + 1.7105e-3_WP*sqrt(S_oc**3) - 2.155e-4_WP*(S_oc**2)+273.15
 
   snicecond = con/consn                 ! equivalence fraction thickness of ice/snow
   zsniced=h+snicecond*hsn               ! Ice + Snow-Ice-equivalent thickness [m]

--- a/src/ice_thermo_cpl.F90
+++ b/src/ice_thermo_cpl.F90
@@ -474,11 +474,6 @@ contains
   real(kind=WP)  zcprosn
   !---- local parameters
   real(kind=WP), parameter :: dice  = 0.05_WP                       ! ECHAM6's thickness for top ice "layer"
-  !---- freezing temperature of sea-water [K]
-  real(kind=WP)  :: TFrezs
-
-  !---- compute freezing temperature of sea-water from salinity
-  TFrezs = -0.0575_WP*S_oc + 1.7105e-3_WP*sqrt(S_oc**3) - 2.155e-4_WP*(S_oc**2)+273.15
 
   snicecond = con/consn                 ! equivalence fraction thickness of ice/snow
   zsniced=h+snicecond*hsn               ! Ice + Snow-Ice-equivalent thickness [m]


### PR DESCRIPTION
By checking the subroutine "ice_surftemp" I found that t, the ice surface temperature, is limited to the freezing temperature of sea water (TFrezs, l.491).
If I understand the code correctly, this can be artificially wrong by up to 2 Kelvin, because ice is in principle allowed to reach 0°C at the surface (admittedly there is a small salinity content in the ice, but none in the snow). 

While this should help with getting reduced ice thickness due to the smaller atm-ice/snow heat flux (smaller temp gradient), it could also help with fixing the snow (which melts first). 