### PR TITLE
fix severe error with uninitialized copies of variables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,7 +75,7 @@ elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL  GNU )
 		target_compile_options(${PROJECT_NAME} PRIVATE -fallow-argument-mismatch) # gfortran v10 is strict about erroneous API calls: "Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)"
 	endif()
 elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL Cray )
-       target_compile_options(${PROJECT_NAME} PRIVATE -c -emf -hbyteswapio -hflex_mp=conservative -hfp1 -hadd_paren -Ounroll0 -hipa0 -r am -s real64)
+       target_compile_options(${PROJECT_NAME} PRIVATE -c -emf -hbyteswapio -hflex_mp=conservative -hfp1 -hadd_paren -Ounroll0 -hipa0 -r am -s real64 -hnoomp)
 endif()
 target_include_directories(${PROJECT_NAME} PRIVATE ${NETCDF_Fortran_INCLUDE_DIRECTORIES} ${OASIS_Fortran_INCLUDE_DIRECTORIES})
 target_include_directories(${PROJECT_NAME} PRIVATE ${MCT_Fortran_INCLUDE_DIRECTORIES} ${MPEU_Fortran_INCLUDE_DIRECTORIES})

--- a/src/gen_modules_partitioning.F90
+++ b/src/gen_modules_partitioning.F90
@@ -72,12 +72,6 @@ save
   integer, allocatable ::  remPtr_elem2D(:), remList_elem2D(:)
 
   logical :: elem_full_flag  
-!$OMP threadprivate(com_nod2D,com_elem2D,com_elem2D_full)
-!$OMP threadprivate(mype)
-!$OMP threadprivate(myDim_nod2D, eDim_nod2D, myList_nod2D)
-!$OMP threadprivate(myDim_elem2D, eDim_elem2D, eXDim_elem2D, myList_elem2D)
-!$OMP threadprivate(myDim_edge2D, eDim_edge2D, myList_edge2D)
-  
 
 contains
 subroutine par_init    ! initializes MPI


### PR DESCRIPTION
These variables are copied and uninitialized if we use threads and OpenMP has been activated (OpenMP is secretly active for some compilers e.g. Cray ftn)