### PR TITLE
give default values to uninitialized variables

### DIFF
--- a/src/oce_ale_tracer.F90
+++ b/src/oce_ale_tracer.F90
@@ -342,6 +342,9 @@ subroutine diff_ver_part_expl_ale(tr_num, mesh)
     real(kind=WP)            :: zinv1,Ty
 
 #include "associate_mesh.h"
+
+    Ty = 0.0_WP
+    
     !___________________________________________________________________________    
     do n=1, myDim_nod2D
         nl1=nlevels_nod2D(n)-1

--- a/src/oce_ice_init_state.F90
+++ b/src/oce_ice_init_state.F90
@@ -372,6 +372,8 @@ subroutine init_fields_na_test(mesh)
 
 #include "associate_mesh.h"
 
+  c_status = .false.
+
   ! ===================
   ! Fill the model fields with dummy values
   ! ===================
@@ -477,6 +479,8 @@ subroutine init_fields_global_test(mesh)
   type(t_mesh), intent(in)           , target :: mesh
 
 #include "associate_mesh.h"
+
+  c_status = .false.
 
   ! ===================
   ! Fill the model fields with dummy values

--- a/src/oce_vel_rhs_vinv.F90
+++ b/src/oce_vel_rhs_vinv.F90
@@ -120,6 +120,7 @@ subroutine compute_vel_rhs_vinv(mesh) !vector invariant
     real(kind=WP)     :: density0_inv = 1./density_0
 
 #include "associate_mesh.h"
+    w = 0.0_WP
 
     uvert=0.0_WP 
 


### PR DESCRIPTION
Using this would otherwise lead to undefined state at runtime and compiling these files lets the cray ftn compiler choke.