### PR TITLE
use_recom is moved from RECOM to FESOM. And some other module correct…

### DIFF
--- a/config/namelist.config
+++ b/config/namelist.config
@@ -54,6 +54,7 @@ use_cavity=.false.              !
 use_cavity_partial_cell=.false. 
 use_floatice = .false.
 use_sw_pene=.true.
+use_recom = .false.             ! couple FESOM + RECOM
 /
 
 &machine

--- a/src/gen_ic3d.F90
+++ b/src/gen_ic3d.F90
@@ -17,7 +17,7 @@ MODULE g_ic3d
    USE g_PARSUP
    USE g_comm_auto
    USE g_support
-   USE g_config, only: dummy, ClimateDataPath, use_cavity
+   USE g_config, only: dummy, ClimateDataPath, use_cavity, use_recom
 #if defined (__recom)
    USE recom_config
 #endif

--- a/src/gen_modules_config.F90
+++ b/src/gen_modules_config.F90
@@ -103,13 +103,15 @@ module g_config
   logical                       :: use_floatice = .false.
   logical                       :: use_cavity = .false. ! switch on/off cavity usage
   logical                       :: use_cavity_partial_cell = .false. ! switch on/off cavity usage
+  logical                       :: use_recom = .false.   ! coupled FESOM + RECOM
   real(kind=WP)                 :: cavity_partial_cell_thresh=0.0_WP ! same as partial_cell_tresh but for surface
   logical                       :: toy_ocean=.false. ! Ersatz forcing has to be supplied
   character(100)                :: which_toy="soufflet" 
   logical                       :: flag_debug=.false.    ! prints name of actual subroutine he is in 
   logical                       :: flag_warn_cflz=.true. ! switches off cflz warning
   namelist /run_config/ use_ice,use_floatice, use_sw_pene, use_cavity, & 
-                        use_cavity_partial_cell, cavity_partial_cell_thresh, toy_ocean, which_toy, flag_debug, flag_warn_cflz
+                        use_cavity_partial_cell, cavity_partial_cell_thresh, toy_ocean, which_toy, flag_debug, flag_warn_cflz, &
+                        use_recom
   
   !_____________________________________________________________________________
   ! *** others ***

--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -99,8 +99,9 @@ subroutine ini_mean_io(mesh)
   use g_PARSUP
   use diagnostics
 #if defined(__recom)
-  use REcoM_GloVar
-  use recom_config, only: PAR3D
+  use REcoM_GloVar, only: PAR3D, glodpco2surf, glopco2surf, gloco2flux, glohplus, atmfeinput, &
+      atmninput, denitben, benthos, diags2d
+  use recom_config
 !  use REcoM_ciso
 #endif
   use i_PARAM, only: whichEVP

--- a/src/oce_ale_tracer.F90
+++ b/src/oce_ale_tracer.F90
@@ -893,8 +893,9 @@ end subroutine diff_ver_part_impl_ale
     use ver_sinking_recom_benthos_interface
     ! deniz: commented out and added conditional compilation on top of the subroutine
     !#if defined(__recom)
-        USE REcoM_GloVar
-        use recom_config, only : allow_var_sinking, GlowFluxPhy, GlowFluxDet, GlowFluxDia     !, recom_debug
+        USE REcoM_GloVar, only: GlowFluxPhy, GlowFluxDet, GlowFluxDia     !, recom_debug
+        use recom_config, only: allow_var_sinking, vdet, vdet_a, vphy, vdia, vdet_zoo2, secondsperday, use_fe2n, &
+            fe2n_benthos, fe2c_benthos, redo2c, ciso
     !#endif
         IMPLICIT NONE
         type(t_mesh), intent(in) , target  :: mesh
@@ -906,7 +907,7 @@ end subroutine diff_ver_part_impl_ale
         real(kind=WP)             :: ver_flux(mesh%nl,myDim_nod2D+eDim_nod2D)
     !   real(kind=WP)             :: Vbenthic_det,Vbenthic_phy,Vbenthic_dia
     !    real(kind=WP), intent(inout), target :: ttf(mesh%nl-1, myDim_nod2D+eDim_nod2D)
-    #include "associate_mesh.h"
+#include "associate_mesh.h"
 
        do n=1, myDim_nod2D
             nl1=nlevels_nod2D(n)-1
@@ -1043,8 +1044,8 @@ end subroutine diff_ver_part_impl_ale
     use diff_ver_recom_expl_interface
     ! deniz: commented out this one moved it to top
     !#if defined(__recom)
-        USE REcoM_GloVar
-        use recom_config, only: GlodecayBenthos, GlowFluxPhy, GlowFluxDet, GlowFluxDia  !, recom_debug
+        USE REcoM_GloVar, only: GlodecayBenthos, GlowFluxPhy, GlowFluxDet, GlowFluxDia  !, recom_debug
+        use recom_config
     !#endif
         IMPLICIT NONE
         type(t_mesh), intent(in) , target :: mesh
@@ -1054,7 +1055,7 @@ end subroutine diff_ver_part_impl_ale
         integer                  :: nlevels_nod2D_minimum
         real(kind=WP)            :: bottom_flux(myDim_nod2D+eDim_nod2D)
 
-    #include "associate_mesh.h"
+#include "associate_mesh.h"
 
     bottom_flux = 0._WP
     id = tracer_id(tr_num)


### PR DESCRIPTION
**TLDR:** RECOM is now coupled to FESOM similar to how ICEPACK is coupled.

This pull request will allow independent coupling of FESOM and RECOM together with the RECOM pull request at
https://gitlab.dkrz.de/modular_esm/REcoM/-/merge_requests/48

Now, FESOM and RECOM are coupled to each other via `namelist.config` option `use_recom = .true.`. By default it is `.false.`

The coupled compilation is turned on in the main CMake file by turning it on:
`set(RECOM_COUPLED ON CACHE BOOL "compile fesom coupled to RECOM")`