### PR TITLE
Chunking commented out again

### DIFF
--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -618,9 +618,9 @@ subroutine create_new_file(entry, mesh)
   
   call assert_nf( nf_def_var(entry%ncid, trim(entry%name), entry%data_strategy%netcdf_type(), entry%ndim+1, &
                                     (/entry%dimid(1:entry%ndim), entry%recID/), entry%varID), __LINE__)
-  if (entry%ndim==2) then
-     call assert_nf( nf_def_var_chunking(entry%ncid, entry%varID, NF_CHUNKED, (/1, entry%glsize(1)/)), __LINE__);
-  end if
+!  if (entry%ndim==2) then
+!     call assert_nf( nf_def_var_chunking(entry%ncid, entry%varID, NF_CHUNKED, (/1, entry%glsize(1)/)), __LINE__);
+!  end if
   call assert_nf( nf_put_att_text(entry%ncid, entry%varID, 'description', len_trim(entry%description), entry%description), __LINE__)
   call assert_nf( nf_put_att_text(entry%ncid, entry%varID, 'long_name', len_trim(entry%description), entry%description), __LINE__)
   call assert_nf( nf_put_att_text(entry%ncid, entry%varID, 'units',       len_trim(entry%units),       entry%units), __LINE__)


### PR DESCRIPTION
Commenting out lines 621-623 in the routine `src/io_meandata.F90`.

This change is **needed on Mistral** (only).