### PR TITLE
use consistent target attribute

### DIFF
--- a/src/gen_modules_partitioning.F90
+++ b/src/gen_modules_partitioning.F90
@@ -25,7 +25,7 @@ module par_support_interfaces
      USE MOD_PARTIT
      USE MOD_PARSUP
      implicit none
-     type(t_partit), intent(in), target :: partit
+     type(t_partit), intent(inout), target :: partit
      type(t_mesh),   intent(in), target :: mesh
   end subroutine
 


### PR DESCRIPTION
Otherwise compilation fails with cray compiler. The attribute in the module was not consistent with the subroutine above. I chose "inout" for both attributes, choosing both "in" failed.