### PR TITLE
Some bug fixes relating to the introduction of dynamics derived type

### DIFF
--- a/src/cavity_param.F90
+++ b/src/cavity_param.F90
@@ -1,13 +1,15 @@
 module cavity_heat_water_fluxes_3eq_interface
   interface
-    subroutine cavity_heat_water_fluxes_3eq(tracers, partit, mesh)
+    subroutine cavity_heat_water_fluxes_3eq(dynamics, tracers, partit, mesh)
       use mod_mesh
       USE MOD_PARTIT
       USE MOD_PARSUP
+      use MOD_DYN
       use mod_tracer
       type(t_partit), intent(inout), target :: partit
       type(t_mesh),   intent(in),    target :: mesh
       type(t_tracer), intent(in),    target :: tracers
+      type(t_dyn),    intent(in),    target :: dynamics
     end subroutine
   end interface
 end module

--- a/src/fvom.F90
+++ b/src/fvom.F90
@@ -342,7 +342,7 @@ contains
             !___compute fluxes to the ocean: heat, freshwater, momentum_________
             if (flag_debug .and. f%mype==0)  print *, achar(27)//'[34m'//' --> call oce_fluxes_mom...'//achar(27)//'[0m'
             call oce_fluxes_mom(f%dynamics, f%partit, f%mesh) ! momentum only
-            call oce_fluxes(f%tracers, f%partit, f%mesh)
+            call oce_fluxes(f%dynamics, f%tracers, f%partit, f%mesh)
         end if
         call before_oce_step(f%dynamics, f%tracers, f%partit, f%mesh) ! prepare the things if required
         f%t2 = MPI_Wtime()

--- a/src/ice_oce_coupling.F90
+++ b/src/ice_oce_coupling.F90
@@ -7,7 +7,7 @@ module ocean2ice_interface
       use mod_tracer
       use MOD_DYN
       type(t_dyn)   , intent(in)   , target :: dynamics
-      type(t_tracer), intent(in)   , target :: tracers
+      type(t_tracer), intent(inout), target :: tracers
       type(t_partit), intent(inout), target :: partit
       type(t_mesh)  , intent(in)   , target :: mesh
       
@@ -17,14 +17,16 @@ end module
 
 module oce_fluxes_interface
   interface
-    subroutine oce_fluxes(tracers, partit, mesh)
+    subroutine oce_fluxes(dynamics, tracers, partit, mesh)
       use mod_mesh
       USE MOD_PARTIT
+      use MOD_DYN
       USE MOD_PARSUP
       use mod_tracer
       type(t_partit), intent(inout), target :: partit
       type(t_mesh)  , intent(in)   , target :: mesh
-      type(t_tracer), intent(in)   , target :: tracers
+      type(t_tracer), intent(inout), target :: tracers
+      type(t_dyn)   , intent(in)   , target :: dynamics
     end subroutine
   end interface
 end module
@@ -201,9 +203,10 @@ end subroutine ocean2ice
 !
 !
 !_______________________________________________________________________________
-subroutine oce_fluxes(tracers, partit, mesh)
+subroutine oce_fluxes(dynamics, tracers, partit, mesh)
 
   use MOD_MESH
+  use MOD_DYN
   use MOD_TRACER
   USE MOD_PARTIT
   USE MOD_PARSUP
@@ -225,6 +228,7 @@ subroutine oce_fluxes(tracers, partit, mesh)
   type(t_partit), intent(inout), target :: partit
   type(t_mesh),   intent(in),    target :: mesh
   type(t_tracer), intent(inout), target :: tracers
+  type(t_dyn),    intent(in),    target :: dynamics
   integer                    :: n, elem, elnodes(3),n1
   real(kind=WP)              :: rsss, net
   real(kind=WP), allocatable :: flux(:)
@@ -276,7 +280,7 @@ subroutine oce_fluxes(tracers, partit, mesh)
     water_flux  = -fresh_wa_flux
 #endif 
     heat_flux_in=heat_flux ! sw_pene will change the heat_flux
-    if (use_cavity) call cavity_heat_water_fluxes_3eq(tracers, partit, mesh)
+    if (use_cavity) call cavity_heat_water_fluxes_3eq(dynamics, tracers, partit, mesh)
     !!PS if (use_cavity) call cavity_heat_water_fluxes_2eq(mesh)
     
 !!PS     where(ulevels_nod2D>1) heat_flux=0.0_WP

--- a/src/ifs_interface/ifs_interface.F90
+++ b/src/ifs_interface/ifs_interface.F90
@@ -348,7 +348,7 @@ SUBROUTINE nemogcmcoup_lim2_get( mype, npes, icomm, &
 
    USE par_kind ! in ifs_modules.F90
    USE fesom_main_storage_module, only: fesom => f
-   USE o_ARRAYS, ONLY : UV ! tr_arr is now tracers
+   !USE o_ARRAYS, ONLY : UV ! tr_arr is now tracers, UV in dynamics derived type
    USE i_arrays, ONLY : m_ice, a_ice, m_snow
    USE i_therm_param, ONLY : tmelt
    USE g_rotate_grid, only: vector_r2g
@@ -463,8 +463,8 @@ SUBROUTINE nemogcmcoup_lim2_get( mype, npes, icomm, &
    ! Surface currents need to be rotated to geographical grid
 
    ! Pack u(v) surface currents
-   zsendU(:)=UV(1,1,1:myDim_elem2D)
-   zsendV(:)=UV(2,1,1:myDim_elem2D) !UV includes eDim, leave those away here
+   zsendU(:)=fesom%dynamics%UV(1,1,1:myDim_elem2D)
+   zsendV(:)=fesom%dynamics%UV(2,1,1:myDim_elem2D) !UV includes eDim, leave those away here
 
    do elem=1, myDim_elem2D
 

--- a/src/oce_setup_step.F90
+++ b/src/oce_setup_step.F90
@@ -51,7 +51,7 @@ module ocean_setup_interface
         type(t_dyn)   , intent(inout), target :: dynamics
         type(t_tracer), intent(inout), target :: tracers
         type(t_partit), intent(inout), target :: partit
-        type(t_mesh)  , intent(in)   , target :: mesh
+        type(t_mesh)  , intent(inout)   , target :: mesh
         end subroutine
     end interface
 end module


### PR DESCRIPTION
For example, the oce_fluxes under cavities are U-dependent (added dynamics to the subroutine arguments), UV is now in dynamics (ifs interface), and the interface definition was not consistent with the subroutine definitions in several places.