### PR TITLE
Formating of benchmark results

### DIFF
--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -285,7 +285,6 @@ contains
     use fesom_main_storage_module
     integer, intent(in) :: current_nsteps 
     ! EO parameters
-
     integer n
 
     !=====================
@@ -426,30 +425,38 @@ contains
     call MPI_AllREDUCE(MPI_IN_PLACE, min_rtime,  14, MPI_REAL, MPI_MIN, f%MPI_COMM_FESOM, f%MPIerr)
 
     if (f%mype==0) then
-        write(*,*) '___MODEL RUNTIME mean, min, max per task [seconds]________________________'
-        write(*,*) '  runtime ocean:',mean_rtime(1), min_rtime(1), max_rtime(1)
-        write(*,*) '    > runtime oce. mix,pres. :',mean_rtime(2), min_rtime(2), max_rtime(2)
-        write(*,*) '    > runtime oce. dyn. u,v,w:',mean_rtime(3), min_rtime(3), max_rtime(3)
-        write(*,*) '    > runtime oce. dyn. ssh  :',mean_rtime(4), min_rtime(4), max_rtime(4)
-        write(*,*) '        > runtime oce. solve ssh:',mean_rtime(5), min_rtime(5), max_rtime(5)
-        write(*,*) '    > runtime oce. GM/Redi   :',mean_rtime(6), min_rtime(6), max_rtime(6)
-        write(*,*) '    > runtime oce. tracer    :',mean_rtime(7), min_rtime(7), max_rtime(7)
-        write(*,*) '  runtime ice  :',mean_rtime(10), min_rtime(10), max_rtime(10)
-        write(*,*) '    > runtime ice step :',mean_rtime(8), min_rtime(8), max_rtime(8)
-        write(*,*) '  runtime diag:   ', mean_rtime(11), min_rtime(11), max_rtime(11)
-        write(*,*) '  runtime output: ', mean_rtime(12), min_rtime(12), max_rtime(12)
-        write(*,*) '  runtime restart:', mean_rtime(13), min_rtime(13), max_rtime(13)
-        write(*,*) '  runtime forcing:', mean_rtime(14), min_rtime(14), max_rtime(14)
-        write(*,*) '  runtime total (ice+oce):',mean_rtime(9), min_rtime(9), max_rtime(9)
+        41 format (a35,a10,2a15) !Format for table heading
+        42 format (a30,3f15.4)   !Format for table content
+
+        print 41, '___MODEL RUNTIME per task [seconds]','_____mean_','___________min_', '___________max_'
+        print 42, '  runtime ocean:              ',    mean_rtime(1),     min_rtime(1),      max_rtime(1)
+        print 42, '    > runtime oce. mix,pres. :',    mean_rtime(2),     min_rtime(2),      max_rtime(2)
+        print 42, '    > runtime oce. dyn. u,v,w:',    mean_rtime(3),     min_rtime(3),      max_rtime(3)
+        print 42, '    > runtime oce. dyn. ssh  :',    mean_rtime(4),     min_rtime(4),      max_rtime(4)
+        print 42, '    > runtime oce. solve ssh :',    mean_rtime(5),     min_rtime(5),      max_rtime(5)
+        print 42, '    > runtime oce. GM/Redi   :',    mean_rtime(6),     min_rtime(6),      max_rtime(6)
+        print 42, '    > runtime oce. tracer    :',    mean_rtime(7),     min_rtime(7),      max_rtime(7)
+        print 42, '  runtime ice  :              ',    mean_rtime(10),    min_rtime(10),     max_rtime(10)
+        print 42, '    > runtime ice step :      ',    mean_rtime(8),     min_rtime(8),      max_rtime(8)
+        print 42, '  runtime diag:               ',    mean_rtime(11),    min_rtime(11),     max_rtime(11)
+        print 42, '  runtime output:             ',    mean_rtime(12),    min_rtime(12),     max_rtime(12)
+        print 42, '  runtime restart:            ',    mean_rtime(13),    min_rtime(13),     max_rtime(13)
+        print 42, '  runtime forcing:            ',    mean_rtime(14),    min_rtime(14),     max_rtime(14)
+        print 42, '  runtime total (ice+oce):    ',    mean_rtime(9),     min_rtime(9),      max_rtime(9)
+
+        43 format (a33,i15)        !Format Ncores
+        44 format (a33,i15)        !Format OMP threads
+        45 format (a33,f15.4,a4)   !Format runtime
+
         write(*,*)
-        write(*,*) '============================================'
-        write(*,*) '=========== BENCHMARK RUNTIME =============='
-        write(*,*) '    Number of cores :    ',f%npes
+        write(*,*) '======================================================'
+        write(*,*) '================ BENCHMARK RUNTIME ==================='
+        print 43, '    Number of cores :            ',f%npes
 #if defined(_OPENMP)
-        write(*,*) '    Max OpenMP threads : ',OMP_GET_MAX_THREADS()
+        print 44, '    Max OpenMP threads :         ',OMP_GET_MAX_THREADS()
 #endif
-        write(*,*) '    Runtime for all timesteps :  ',f%runtime_alltimesteps,' sec'
-        write(*,*) '============================================'
+        print 45, '    Runtime for all timesteps :  ',f%runtime_alltimesteps,' sec'
+        write(*,*) '======================================================'
         write(*,*)
     end if    
 !   call clock_finish  


### PR DESCRIPTION
I applied some formatting to the output of benchmarking results.
I think that it improves readability:

```
___MODEL RUNTIME per task [seconds]_____mean____________min____________max_
  runtime ocean:                      43.5929        43.0615        43.8523
    > runtime oce. mix,pres. :         3.3932         3.3294         3.4519
    > runtime oce. dyn. u,v,w:        13.1379        12.8427        13.2614
    > runtime oce. dyn. ssh  :        14.0319        13.9048        14.1876
    > runtime oce. solve ssh :        13.2368        13.1427        13.4317
    > runtime oce. GM/Redi   :         0.6927         0.6421         0.7238
    > runtime oce. tracer    :        12.1759        11.5902        12.3848
  runtime ice  :                      50.9768        50.8949        51.0513
    > runtime ice step :              46.8131        45.0400        50.8056
  runtime diag:                        0.0002         0.0002         0.0003
  runtime output:                      0.8267         0.7544         0.8999
  runtime restart:                     0.0101         0.0070         0.0167
  runtime forcing:                     3.6190         3.5716         3.6885
  runtime total (ice+oce):            90.4060        88.5496        94.2351
  
 ======================================================
 ================ BENCHMARK RUNTIME ===================
    Number of cores :                         16
    Max OpenMP threads :                      18
    Runtime for all timesteps :          99.7411 sec
 ======================================================
 ```
 vs.
 
 ```
 ___MODEL RUNTIME mean, min, max per task [seconds]________________________
   runtime ocean:   43.59292       43.06152       43.85226    
     > runtime oce. mix,pres. :   3.393186       3.329443       3.451879    
     > runtime oce. dyn. u,v,w:   13.13791       12.84274       13.26140    
     > runtime oce. dyn. ssh  :   14.03186       13.90479       14.18762    
         > runtime oce. solve ssh:   13.23683       13.14265       13.43169    
     > runtime oce. GM/Redi   :  0.6926519      0.6420640      0.7237537    
     > runtime oce. tracer    :   12.17593       11.59023       12.38481    
   runtime ice  :   50.97684       50.89487       51.05132    
     > runtime ice step :   46.81309       45.04001       50.80558    
   runtime diag:     2.1210872E-04  1.8339604E-04  2.5294349E-04
   runtime output:   0.8267341      0.7544109      0.8999163    
   runtime restart:  1.0121147E-02  6.9599897E-03  1.6742770E-02
   runtime forcing:   3.618972       3.571629       3.688519    
   runtime total (ice+oce):   90.40601       88.54964       94.23515    
 
 ============================================
 =========== BENCHMARK RUNTIME ==============
     Number of cores :              16
     Max OpenMP threads :           18
     Runtime for all timesteps :     99.74113      sec
 ============================================

```