### PR TITLE
fix shaped pointer assignment for nvfortran

### DIFF
--- a/src/associate_part_ass.h
+++ b/src/associate_part_ass.h
@@ -20,7 +20,7 @@ part            => partit%part
 lb=lbound(partit%s_mpitype_elem3D, 2)
 ub=ubound(partit%s_mpitype_elem3D, 2)
 
-#ifdef __PGI
+#ifdef __PGIxx
 myList_nod2D            => partit%myList_nod2D(1:myDim_nod2D +eDim_nod2D)
 myList_elem2D           => partit%myList_elem2D(1:myDim_elem2D+eDim_elem2D+eXDim_elem2D)
 myList_edge2D           => partit%myList_edge2D(1:myDim_edge2D+eDim_edge2D)
@@ -62,44 +62,44 @@ r_mpitype_nod2D_i       => partit%r_mpitype_nod2D_i(1:com_nod2D%rPEnum)
 s_mpitype_nod3D         => partit%s_mpitype_nod3D(1:com_nod2D%sPEnum, lb:ub, 1:3)
 r_mpitype_nod3D         => partit%r_mpitype_nod3D(1:com_nod2D%rPEnum, lb:ub, 1:3)
 #else
-myList_nod2D (1:myDim_nod2D +eDim_nod2D)                => partit%myList_nod2D
-myList_elem2D(1:myDim_elem2D+eDim_elem2D+eXDim_elem2D)  => partit%myList_elem2D
-myList_edge2D(1:myDim_edge2D+eDim_edge2D)               => partit%myList_edge2D
+myList_nod2D (1:myDim_nod2D +eDim_nod2D)                => partit%myList_nod2D(:)
+myList_elem2D(1:myDim_elem2D+eDim_elem2D+eXDim_elem2D)  => partit%myList_elem2D(:)
+myList_edge2D(1:myDim_edge2D+eDim_edge2D)               => partit%myList_edge2D(:)
 
 if (allocated(partit%remPtr_nod2D)) then
-   remPtr_nod2D  (1:npes)                => partit%remPtr_nod2D
-   remList_nod2D (1:remPtr_nod2D(npes))  => partit%remList_nod2D
+   remPtr_nod2D  (1:npes)                => partit%remPtr_nod2D(:)
+   remList_nod2D (1:remPtr_nod2D(npes))  => partit%remList_nod2D(:)
 end if
 
 if (allocated(partit%remPtr_elem2D)) then
-remPtr_elem2D (1:npes)                => partit%remPtr_elem2D
-remList_elem2D(1:remPtr_elem2D(npes)) => partit%remList_elem2D
+remPtr_elem2D (1:npes)                => partit%remPtr_elem2D(:)
+remList_elem2D(1:remPtr_elem2D(npes)) => partit%remList_elem2D(:)
 end if
 
-s_mpitype_elem2D(1:com_elem2D%sPEnum, 1:4) => partit%s_mpitype_elem2D
-r_mpitype_elem2D(1:com_elem2D%rPEnum, 1:4) => partit%r_mpitype_elem2D
+s_mpitype_elem2D(1:com_elem2D%sPEnum, 1:4) => partit%s_mpitype_elem2D(:,:)
+r_mpitype_elem2D(1:com_elem2D%rPEnum, 1:4) => partit%r_mpitype_elem2D(:,:)
 
-s_mpitype_elem2D_full_i(1:com_elem2D_full%sPEnum) => partit%s_mpitype_elem2D_full_i
-r_mpitype_elem2D_full_i(1:com_elem2D_full%rPEnum) => partit%r_mpitype_elem2D_full_i
+s_mpitype_elem2D_full_i(1:com_elem2D_full%sPEnum) => partit%s_mpitype_elem2D_full_i(:)
+r_mpitype_elem2D_full_i(1:com_elem2D_full%rPEnum) => partit%r_mpitype_elem2D_full_i(:)
 
-s_mpitype_elem2D_full(1:com_elem2D_full%sPEnum, 1:4) => partit%s_mpitype_elem2D_full
-r_mpitype_elem2D_full(1:com_elem2D_full%rPEnum, 1:4) => partit%r_mpitype_elem2D_full
+s_mpitype_elem2D_full(1:com_elem2D_full%sPEnum, 1:4) => partit%s_mpitype_elem2D_full(:,:)
+r_mpitype_elem2D_full(1:com_elem2D_full%rPEnum, 1:4) => partit%r_mpitype_elem2D_full(:,:)
 
-s_mpitype_elem3D(1:com_elem2D%sPEnum, lb:ub, 1:4) => partit%s_mpitype_elem3D
-r_mpitype_elem3D(1:com_elem2D%rPEnum, lb:ub, 1:4) => partit%r_mpitype_elem3D 
+s_mpitype_elem3D(1:com_elem2D%sPEnum, lb:ub, 1:4) => partit%s_mpitype_elem3D(:,:,:)
+r_mpitype_elem3D(1:com_elem2D%rPEnum, lb:ub, 1:4) => partit%r_mpitype_elem3D(:,:,:)
 
-s_mpitype_elem3D_full(1:com_elem2D_full%sPEnum, lb:ub, 1:4) => partit%s_mpitype_elem3D_full
-r_mpitype_elem3D_full(1:com_elem2D_full%rPEnum, lb:ub, 1:4) => partit%r_mpitype_elem3D_full
+s_mpitype_elem3D_full(1:com_elem2D_full%sPEnum, lb:ub, 1:4) => partit%s_mpitype_elem3D_full(:,:,:)
+r_mpitype_elem3D_full(1:com_elem2D_full%rPEnum, lb:ub, 1:4) => partit%r_mpitype_elem3D_full(:,:,:)
 
-r_mpitype_elem3D(1:com_elem2D%rPEnum, lb:ub, 1:4)           => partit%r_mpitype_elem3D
-r_mpitype_elem3D_full(1:com_elem2D_full%rPEnum, lb:ub, 1:4) => partit%r_mpitype_elem3D_full
+r_mpitype_elem3D(1:com_elem2D%rPEnum, lb:ub, 1:4)           => partit%r_mpitype_elem3D(:,:,:)
+r_mpitype_elem3D_full(1:com_elem2D_full%rPEnum, lb:ub, 1:4) => partit%r_mpitype_elem3D_full(:,:,:)
 
-s_mpitype_nod2D(1:com_nod2D%sPEnum) => partit%s_mpitype_nod2D
-r_mpitype_nod2D(1:com_nod2D%rPEnum) => partit%r_mpitype_nod2D
+s_mpitype_nod2D(1:com_nod2D%sPEnum) => partit%s_mpitype_nod2D(:)
+r_mpitype_nod2D(1:com_nod2D%rPEnum) => partit%r_mpitype_nod2D(:)
 
-s_mpitype_nod2D_i(1:com_nod2D%sPEnum) => partit%s_mpitype_nod2D_i
-r_mpitype_nod2D_i(1:com_nod2D%rPEnum) => partit%r_mpitype_nod2D_i
+s_mpitype_nod2D_i(1:com_nod2D%sPEnum) => partit%s_mpitype_nod2D_i(:)
+r_mpitype_nod2D_i(1:com_nod2D%rPEnum) => partit%r_mpitype_nod2D_i(:)
 
-s_mpitype_nod3D(1:com_nod2D%sPEnum, lb:ub, 1:3) => partit%s_mpitype_nod3D
-r_mpitype_nod3D(1:com_nod2D%rPEnum, lb:ub, 1:3) => partit%r_mpitype_nod3D
+s_mpitype_nod3D(1:com_nod2D%sPEnum, lb:ub, 1:3) => partit%s_mpitype_nod3D(:,:,:)
+r_mpitype_nod3D(1:com_nod2D%rPEnum, lb:ub, 1:3) => partit%r_mpitype_nod3D(:,:,:)
 #endif


### PR DESCRIPTION
It compiles this way with nvfortran 22.1-0
If this works, we should remove the old ifdef __PGI block