### PR TITLE
Update ifs_interface.F90

### DIFF
--- a/src/ifs_interface/ifs_interface.F90
+++ b/src/ifs_interface/ifs_interface.F90
@@ -9,7 +9,7 @@ MODULE nemogcmcoup_steps
    INTEGER :: substeps !per IFS timestep
 END MODULE nemogcmcoup_steps
 
-SUBROUTINE nemogcmcoup_init( icomm, inidate, initime, itini, itend, zstp, &
+SUBROUTINE nemogcmcoup_init( mype, icomm, inidate, initime, itini, itend, zstp, &
    & lwaveonly, iatmunit, lwrite )
 
    ! Initialize the FESOM model for single executable coupling 
@@ -26,6 +26,7 @@ SUBROUTINE nemogcmcoup_init( icomm, inidate, initime, itini, itend, zstp, &
    ! Input arguments
 
    ! Message passing information
+   INTEGER, INTENT(IN) :: mype ! was added to ifs/nemo/ininemo.F90 to allow diagnostics based on the first tasks only
    INTEGER, INTENT(IN) :: icomm
    ! Initial date (e.g. 20170906), time, initial timestep and final time step
    INTEGER, INTENT(OUT) ::  inidate, initime, itini, itend


### PR DESCRIPTION
The coupling interface has changed to allow more diagnostics based on the first tasks only (when running with NEMO). An integer MYPROC is introduced so that the Communicator is only the second argument. This change is also needed for FESOM to run with the same main RAPS, where the ectrans-gpu will be made available. So a dummy integer had to be introduced that is not used by FESOM, and the communicator is picked up from the second argument. Note that this will break the interface in older RAPSes.

diff --git a/ifs/nemo/ininemo.F90 b/ifs/nemo/ininemo.F90
index 0424029558..b16d5b25be 100644
--- a/ifs/nemo/ininemo.F90
+++ b/ifs/nemo/ininemo.F90
@@ -103,10 +103,10 @@ IF (LNEMOIFSLOG) THEN
   WRITE(NULOUT,*)
   WRITE(NULOUT,*)'INITIALIZING NEMO.'
   WRITE(NULOUT,*)
-CALL NEMOGCMCOUP_INIT( MPL_COMM, IDATE, ITIME, ITINI, ITEND,&
**+CALL NEMOGCMCOUP_INIT( MYPROC-1, MPL_COMM, IDATE, ITIME, ITINI, ITEND,&
     & ZTSTEP_O, .FALSE., NULOUT, LOUTPUT )**
 ELSE
-CALL NEMOGCMCOUP_INIT( MPL_COMM, IDATE, ITIME, ITINI, ITEND,&
**+CALL NEMOGCMCOUP_INIT( MYPROC-1, MPL_COMM, IDATE, ITIME, ITINI, ITEND,&
     & ZTSTEP_O, .FALSE., -1, LOUTPUT )**
 ENDIF
 #else