### PR TITLE
skip wind stress computations when coupled to IFS

### DIFF
--- a/src/gen_forcing_couple.F90
+++ b/src/gen_forcing_couple.F90
@@ -298,7 +298,7 @@ subroutine update_atm_forcing(istep, ice, tracers, partit, mesh)
                 mask=1.
                 call force_flux_consv(runoff, mask, i, 0,action, partit, mesh)
             end if
-#if defined (__oifs) || defined (__ifsinterface)
+#if defined (__oifs)
 
          elseif (i.eq.13) then
              if (action) then
@@ -342,7 +342,7 @@ subroutine update_atm_forcing(istep, ice, tracers, partit, mesh)
      end if
   END DO
 !$OMP END PARALLEL DO
-#endif
+
   if (use_cavity) then 
 !$OMP PARALLEL DO
     do i=1,myDim_nod2d+eDim_nod2d
@@ -404,6 +404,7 @@ subroutine update_atm_forcing(istep, ice, tracers, partit, mesh)
   end do
 !$OMP END PARALLEL DO
   ! heat and fresh water fluxes are treated in i_therm and ice2ocean
+#endif /* skip all in case of __ifsinterface */
 #endif /* (__oasis) */
 
   t2=MPI_Wtime()


### PR DESCRIPTION
moved #endif for (#ifndef __ifsfesom) case after the wind stress computation, skipping the whole part that is usually done when not using (__oasis)