### PR TITLE
change levante environment to explicitly increase stack size and use …

### DIFF
--- a/env/levante.dkrz.de/shell
+++ b/env/levante.dkrz.de/shell
@@ -11,3 +11,23 @@ export LD_LIBRARY_PATH=/sw/spack-levante/intel-oneapi-mkl-2022.0.1-ttdktf/mkl/20
 module load netcdf-c/4.8.1-openmpi-4.1.2-intel-2021.5.0
 module load netcdf-fortran/4.5.3-openmpi-4.1.2-intel-2021.5.0
 module load git # to be able to determine the fesom git SHA when compiling
+
+ulimit -s unlimited # without setting the stack size we get a segfault from the levante netcdf library at runtime
+ulimit -c 0 # do not create a coredump after a crash
+
+# environment for Open MPI 4.0.0 and later from https://docs.dkrz.de/doc/levante/running-jobs/runtime-settings.html
+export OMPI_MCA_pml="ucx"
+export OMPI_MCA_btl=self
+export OMPI_MCA_osc="pt2pt"
+export UCX_IB_ADDR_TYPE=ib_global
+# for most runs one may or may not want to disable HCOLL
+export OMPI_MCA_coll="^ml,hcoll"
+export OMPI_MCA_coll_hcoll_enable="0"
+export HCOLL_ENABLE_MCAST_ALL="0"
+export HCOLL_MAIN_IB=mlx5_0:1
+export UCX_NET_DEVICES=mlx5_0:1
+export UCX_TLS=mm,knem,cma,dc_mlx5,dc_x,self
+export UCX_UNIFIED_MODE=y
+export HDF5_USE_FILE_LOCKING=FALSE
+export OMPI_MCA_io="romio321"
+export UCX_HANDLE_ERRORS=bt


### PR DESCRIPTION
…MPI and networking settings recommended by DKRZ

tested with "jane" mesh (33M nodes) on 25600 processes