### PR TITLE
Fix/2.1 awiesm 2.1 async icebergs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 project(FESOM2.0)
 set(TOPLEVEL_DIR ${CMAKE_CURRENT_LIST_DIR})
-set(FESOM_COUPLED OFF CACHE BOOL "compile fesom standalone or with oasis support (i.e. coupled)")
+set(FESOM_COUPLED ON CACHE BOOL "compile fesom standalone or with oasis support (i.e. coupled)")
 set(OIFS_COUPLED OFF CACHE BOOL "compile fesom coupled to OpenIFS. (Also needs FESOM_COUPLED to work)")
 set(CRAY OFF CACHE BOOL "compile with cray ftn")
 set(USE_ICEPACK OFF CACHE BOOL "compile fesom with the Iceapck modules for sea ice column physics.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 project(FESOM2.0)
 set(TOPLEVEL_DIR ${CMAKE_CURRENT_LIST_DIR})
-set(FESOM_COUPLED ON CACHE BOOL "compile fesom standalone or with oasis support (i.e. coupled)")
+set(FESOM_COUPLED OFF CACHE BOOL "compile fesom standalone or with oasis support (i.e. coupled)")
 set(OIFS_COUPLED OFF CACHE BOOL "compile fesom coupled to OpenIFS. (Also needs FESOM_COUPLED to work)")
 set(CRAY OFF CACHE BOOL "compile with cray ftn")
 set(USE_ICEPACK OFF CACHE BOOL "compile fesom with the Iceapck modules for sea ice column physics.")

--- a/config/namelist.config
+++ b/config/namelist.config
@@ -60,3 +60,11 @@ use_sw_pene=.true.
 n_levels=2
 n_part= 12, 36          ! 432 number of partitions on each hierarchy level
 /
+
+&icebergs
+use_icesheet_coupling=.false.
+ib_num=1
+use_icebergs=.false.
+steps_per_ib_step=8
+ib_async_mode=0
+/

--- a/src/fvom_main.F90
+++ b/src/fvom_main.F90
@@ -106,10 +106,10 @@ logical             :: bIcbCalcCycleCompleted
 
 type(t_mesh),             target, save :: mesh
 
-#if defined (__async_icebergs)
+!#if defined (__async_icebergs)
 ! kh 26.03.21 get current values for ib_async_mode and thread_support_level_required
     call read_namelist_icebergs
-#endif
+!#endif
 
 #ifndef __oifs
     !ECHAM6-FESOM2 coupling: cpl_oasis3mct_init is called here in order to avoid circular dependencies between modules (cpl_driver and g_PARSUP)

--- a/src/icb_allocate.F90
+++ b/src/icb_allocate.F90
@@ -89,7 +89,7 @@ subroutine allocate_icb()
   allocate(arr_block(15*ib_num))
   allocate(elem_block(ib_num))
   allocate(vl_block(4*ib_num))
-  allocate(buoy_props(ib_num,12))
+  allocate(buoy_props(ib_num,13))
   buoy_props = 0.0
   allocate(melted(ib_num))
   melted = .false.


### PR DESCRIPTION
I removed the if clause for reading in the iceberg related namelist section in namelist.config. This enables to run icebergs also when compiled with ASYNC_ICEBERS=OFF. I also adapted the default nemlist.config.