### PR TITLE
Draft: fixing the finalize for the fesom2-openifs coupling, as well as verbose coupled

### DIFF
--- a/src/cpl_driver.F90
+++ b/src/cpl_driver.F90
@@ -66,7 +66,6 @@ module cpl_driver
   REAL(kind=WP), POINTER                          :: exfld(:)          ! buffer for receiving global exchange fields
   real(kind=WP), allocatable, dimension(:,:)      :: cplsnd
 
-  real(kind=WP)              :: time_send(2), time_recv(2)
 
   integer, dimension(1,3)    :: iextent    
   integer, dimension(1,3)    :: ioffset   
@@ -571,13 +570,6 @@ contains
     end if
     t3=MPI_Wtime()
     
-    if (ind==1) then
-       time_send(1)=t3-t1       
-       time_send(2)=t2-t1
-    else
-       time_send(1)=time_send(1)+t3-t1
-       time_send(2)=time_send(2)+t2-t1
-    endif	         
   end subroutine cpl_oasis3mct_send
 
   ! ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -618,7 +610,7 @@ contains
     ! receive data from OASIS3-MCT on local root
     !
 #ifdef VERBOSE
-    if (mype==0) then
+    if (partit%mype==0) then
         print *, 'oasis_get: ', cpl_recv(ind)
     endif    
 #endif
@@ -635,13 +627,6 @@ contains
       call exchange_nod(data_array, partit)
    end if   
    t3=MPI_Wtime()
-   if (ind==1) then
-      time_recv(1)=t3-t1
-      time_recv(2)=t3-t2
-   else      
-      time_recv(1)=time_recv(1)+t3-t1
-      time_recv(2)=time_recv(2)+t3-t2
-   endif
   end subroutine cpl_oasis3mct_recv
   
 !

--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -432,7 +432,8 @@ contains
     call MPI_AllREDUCE(MPI_IN_PLACE, max_rtime,  14, MPI_REAL, MPI_MAX, f%MPI_COMM_FESOM, f%MPIerr)
     call MPI_AllREDUCE(MPI_IN_PLACE, min_rtime,  14, MPI_REAL, MPI_MIN, f%MPI_COMM_FESOM, f%MPIerr)
     
-#if defined (__oifs) ! OpenIFS has call oasis_terminate through par_ex
+#if defined (__oifs) 
+    ! OpenIFS coupled version has to call oasis_terminate through par_ex
     call par_ex(f%partit%MPI_COMM_FESOM, f%partit%mype)
 #endif
     if(f%fesom_did_mpi_init) call par_ex(f%partit%MPI_COMM_FESOM, f%partit%mype) ! finalize MPI before FESOM prints its stats block, otherwise there is sometimes output from other processes from an earlier time in the programm AFTER the starts block (with parastationMPI)

--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -431,7 +431,10 @@ contains
     mean_rtime(1:14) = mean_rtime(1:14) / real(f%npes,real32)
     call MPI_AllREDUCE(MPI_IN_PLACE, max_rtime,  14, MPI_REAL, MPI_MAX, f%MPI_COMM_FESOM, f%MPIerr)
     call MPI_AllREDUCE(MPI_IN_PLACE, min_rtime,  14, MPI_REAL, MPI_MIN, f%MPI_COMM_FESOM, f%MPIerr)
-
+    
+#if defined (__oifs) ! OpenIFS has call oasis_terminate through par_ex
+    call par_ex(f%partit%MPI_COMM_FESOM, f%partit%mype)
+#endif
     if(f%fesom_did_mpi_init) call par_ex(f%partit%MPI_COMM_FESOM, f%partit%mype) ! finalize MPI before FESOM prints its stats block, otherwise there is sometimes output from other processes from an earlier time in the programm AFTER the starts block (with parastationMPI)
     if (f%mype==0) then
         41 format (a35,a10,2a15) !Format for table heading

--- a/src/gen_forcing_couple.F90
+++ b/src/gen_forcing_couple.F90
@@ -442,10 +442,6 @@ subroutine update_atm_forcing(istep, ice, tracers, dynamics, partit, mesh)
 #ifdef VERBOSE
   if (mod(istep,logfile_outfreq)==0 .and. mype==0) then
      write(*,*) 'update forcing data took', t2-t1
-#ifdef __oasis     
-     write(*,*) 'oasis part + exchange mesh:', time_recv(1)+time_send(1)
-     write(*,*) 'exchange mesh             :', time_recv(2)+time_send(2)
-#endif /* (__oasis) */     
   end if
 #endif
 

--- a/src/gen_modules_partitioning.F90
+++ b/src/gen_modules_partitioning.F90
@@ -79,24 +79,29 @@ subroutine par_init(partit)    ! initializes MPI
   end if
 end subroutine par_init
 !=================================================================
-
-
-
 subroutine par_ex(COMM, mype, abort)       ! finalizes MPI
-USE MOD_PARTIT
+  use MOD_PARTIT
 
-
-#ifndef __oifs
-! MPI finalization for standalone and coupled ECHAM runs
+! In case we are letting oasis orchestrate MPI, we need to shut down through
+! oasis as well, thus we are including it here.
 #if defined (__oasis)
+#if defined (__oifs)
+  !For OpenIFS coupled runs we use the new OASIS nameing scheme (oasis)
+  use mod_oasis
+#else
+  !For ECHAM coupled runs we use the old OASIS nameing scheme (prism / prism_proto)
   use mod_prism 
-#endif
+#endif ! oifs/echam
+#endif ! oasis
+
   implicit none
   integer,           intent(in)   :: COMM
   integer,           intent(in)   :: mype
   integer, optional, intent(in)   :: abort
   integer                         :: error
 
+! For standalone runs we directly call the MPI_barrier and MPI_finalize
+!---------------------------------------------------------------
 #ifndef __oasis
   if (present(abort)) then
      if (mype==0) write(*,*) 'Run finished unexpectedly!'
@@ -105,7 +110,20 @@ USE MOD_PARTIT
      call  MPI_Barrier(COMM, error)
      call  MPI_Finalize(error)
   endif
+#else ! standalone
+
+! From here on the two coupled options
+!-------------------------------------
+#if defined (__oifs)
+  !For OpenIFS coupled runs we use the new OASIS nameing scheme (oasis)
+  if (present(abort)) then
+    if (mype==0) write(*,*) 'Run finished unexpectedly!'
+    call MPI_ABORT(COMM, 1 )
+  else
+    call oasis_terminate
+  endif
 #else
+  !For ECHAM coupled runs we use the old OASIS nameing scheme (prism / prism_proto)
   if (.not. present(abort)) then
      if (mype==0) print *, 'FESOM calls MPI_Barrier before calling prism_terminate'
      call  MPI_Barrier(MPI_COMM_WORLD, error)
@@ -116,28 +134,12 @@ USE MOD_PARTIT
   
   if (mype==0) print *, 'FESOM calls MPI_Finalize'
   call MPI_Finalize(error)
-#endif
-  if (mype==0) print *, 'fesom should stop with exit status = 0'
-#endif
+#endif ! oifs/echam
+#endif ! oasis
 
-
-#if defined (__oifs)
-!OIFS coupling doesnt call prism_terminate_proto but cpl_oasis3mct_finalize through which it calls oasis_terminate
-  use cpl_driver 
-  implicit none
-  integer,           intent(in)   :: COMM
-  integer,           intent(in)   :: mype
-  integer, optional, intent(in)   :: abort
-  integer                         :: error
-  if (present(abort)) then
-    if (mype==0) write(*,*) 'Run finished unexpectedly!'
-    call MPI_ABORT(COMM, 1 )
-  else
-    if (mype==0) write(*,*) 'Finalizing MPI communication through oasis'
-    call cpl_oasis3mct_finalize
-    if (mype==0) write(*,*) 'MPI communication closed down'
-  endif
-#endif
+! Regardless of standalone, OpenIFS oder ECHAM coupling, if we reach to this point
+! we should be fine shutting the whole model down
+if (mype==0) print *, 'fesom should stop with exit status = 0'
 
 end subroutine par_ex
 !=======================================================================

--- a/src/gen_modules_partitioning.F90
+++ b/src/gen_modules_partitioning.F90
@@ -79,10 +79,15 @@ subroutine par_init(partit)    ! initializes MPI
   end if
 end subroutine par_init
 !=================================================================
+
+
+
 subroutine par_ex(COMM, mype, abort)       ! finalizes MPI
 USE MOD_PARTIT
+
+
 #ifndef __oifs
-!For standalone and coupled ECHAM runs
+! MPI finalization for standalone and coupled ECHAM runs
 #if defined (__oasis)
   use mod_prism 
 #endif
@@ -114,8 +119,11 @@ USE MOD_PARTIT
 #endif
   if (mype==0) print *, 'fesom should stop with exit status = 0'
 #endif
+
+
 #if defined (__oifs)
-!OIFS coupling doesnt call prism_terminate_proto and uses COMM instead of MPI_COMM_WORLD
+!OIFS coupling doesnt call prism_terminate_proto but cpl_oasis3mct_finalize through which it calls oasis_terminate
+  use cpl_driver 
   implicit none
   integer,           intent(in)   :: COMM
   integer,           intent(in)   :: mype
@@ -125,8 +133,9 @@ USE MOD_PARTIT
     if (mype==0) write(*,*) 'Run finished unexpectedly!'
     call MPI_ABORT(COMM, 1 )
   else
-    call  MPI_Barrier(COMM, error)
-    call  MPI_Finalize(error)
+    if (mype==0) write(*,*) 'Finalizing MPI communication through oasis'
+    call cpl_oasis3mct_finalize
+    if (mype==0) write(*,*) 'MPI communication closed down'
   endif
 #endif
 


### PR DESCRIPTION
I tried running a coupled AWI-CM3 simulation with the refactoring branch and verbose output today. Here is a quick fix for the errors I encountered.