### PR TITLE
setting Intel bach as default compiler for Levante. Replacing env/lev…

### DIFF
--- a/env/levante.dkrz.de/shell.nvhpc
+++ b/env/levante.dkrz.de/shell.nvhpc
@@ -2,22 +2,14 @@
 export LC_ALL=en_US.UTF-8
 export CPU_MODEL=AMD_EPYC_ZEN3
 
-module load intel-oneapi-compilers/2022.0.1-gcc-11.2.0
-module load intel-oneapi-mkl/2022.0.1-gcc-11.2.0
-module load openmpi/4.1.2-intel-2021.5.0
-export FC=mpif90 CC=mpicc CXX=mpicxx ;
-export LD_LIBRARY_PATH=/sw/spack-levante/intel-oneapi-mkl-2022.0.1-ttdktf/mkl/2022.0.1/lib/intel64:$LD_LIBRARY_PATH
-
-export lib_multio=/home/a/a270029/fesom2.0/lib/multio/lib/lib64/
-export inc_multio=/home/a/a270029/fesom2.0/lib/multio/build/module/
-export lib_eccodes=/sw/spack-levante/eccodes-2.21.0-3ehkbb/lib64/
+# module load intel-oneapi-compilers/2022.0.1-gcc-11.2.0
+# module load openmpi/4.1.2-intel-2021.5.0
+spack load openmpi@4.1.2%nvhpc@22.5
+export FC=mpif90 CC=mpicc CXX=mpicxx;
 
 module load netcdf-c/4.8.1-openmpi-4.1.2-intel-2021.5.0
 module load netcdf-fortran/4.5.3-openmpi-4.1.2-intel-2021.5.0
 module load git # to be able to determine the fesom git SHA when compiling
-
-ulimit -s unlimited # without setting the stack size we get a segfault from the levante netcdf library at runtime
-ulimit -c 0 # do not create a coredump after a crash
 
 # environment for Open MPI 4.0.0 and later from https://docs.dkrz.de/doc/levante/running-jobs/runtime-settings.html
 export OMPI_MCA_pml="ucx"


### PR DESCRIPTION
…ante.dkrz.de/shell.nvhpc->shell will allow to compile with NV & OpenACC support