### PR TITLE
Force to write raw restart files at end of run

### DIFF
--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -42,7 +42,7 @@ module fesom_main_storage_module
     
   type :: fesom_main_storage_type
 
-    integer           :: n, from_nstep, offset, row, i, provided
+    integer           :: n, from_nstep, offset, row, i, provided, last_nstep
     integer           :: which_readr ! read which restart files (0=netcdf, 1=core dump,2=dtype)
     integer, pointer  :: mype, npes, MPIerr, MPI_COMM_FESOM
     real(kind=WP)     :: t0, t1, t2, t3, t4, t5, t6, t7, t8, t0_ice, t1_ice, t0_frc, t1_frc
@@ -388,6 +388,8 @@ contains
         f%rtime_read_forcing  = f%rtime_read_forcing  + f%t1_frc - f%t0_frc
     end do
 
+    f%last_nstep = f%from_nstep-1+current_nsteps
+    write(*,*) "THIS IS THE LAST TIME STEP! -> ", f%last_nstep
     f%from_nstep = f%from_nstep+current_nsteps
   end subroutine
 
@@ -396,6 +398,9 @@ contains
     use fesom_main_storage_module
     ! EO parameters
     real(kind=real32) :: mean_rtime(15), max_rtime(15), min_rtime(15)
+
+    ! write raw restart at the end of run
+    call write_all_raw_restarts(f%last_nstep, f%MPI_COMM_FESOM, f%mype)
 
     call finalize_output()
     call finalize_restart()

--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -399,9 +399,10 @@ contains
     ! EO parameters
     real(kind=real32) :: mean_rtime(15), max_rtime(15), min_rtime(15)
 
+#if defined (__ifsinterface)
     ! write raw restart at the end of run
     call write_all_raw_restarts(f%last_nstep, f%MPI_COMM_FESOM, f%mype)
-
+#endif
     call finalize_output()
     call finalize_restart()
 

--- a/src/io_restart.F90
+++ b/src/io_restart.F90
@@ -14,7 +14,7 @@ MODULE io_RESTART
   use fortran_utils
   
   implicit none
-  public :: restart, finalize_restart
+  public :: restart, finalize_restart, write_all_raw_restarts
   private
 
   integer,       save       :: globalstep=0 ! todo: remove this from module scope as it will mess things up if we use async read/write from the same process


### PR DESCRIPTION
This is what @mandresm and I came up with today, after talking with @trackow and @dsidoren 

1. Writes always raw_restarts at the end of the file independently of the namelist configurations
2. Restarts successfully even if only the raw_restarts are used (no standard restarts available)
3. Writes correctly the info file so that the first number corresponds to the last time step run for the whole simulation

In the line in fesom_module.F90 that defines f%last_nstep I tried f%last_nstep = n but for some FORTRAN reason that gives 49 for the first chunk instead of 48. To solve that I defined f%last_nstep = f%from_nstep-1+current_nsteps in agreement with the last iteration defined in the time stepping do (line 317 in my fesom_module.F90)


@mandresm did compare the result of this with AWICM3 and it seems to do what it is supposed to do:
> I have checked the first number of .info of a standard AWICM3 3-days with daily restart simulation and it is in agreement with the file above (108 instead of 144, because for AWICM3 the default number of steps per day is 36)


If I understood @dsidoren correctly, we could also somehow use 
`use o_PARAM,           only : mstep, WP` 
instead of our addition of `f%last_nstep`, but I don't yet know exactly how.

We also should add a namelist option to enable/disable this feature, because we don't want it for all runs.