### PR TITLE
Next gems c3 fesom2.5 climate dt raw restarts at the end

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -54,9 +54,13 @@ elif [[ $LOGINHOST =~ ^cc[a-b]+-login[0-9]+\.ecmwf\.int$ ]]; then
 elif [[ $LOGINHOST =~ ^stco-esl[0-9]+$ ]]; then
    STRATEGY="aleph"
 elif [[ $LOGINHOST =~ ^[A-Za-z0-9]+\.ecmwf\.int$ ]]; then
-STRATEGY="wsecmwf"
+   STRATEGY="wsecmwf"
 elif [[ $LOGINHOST =~ \.bullx$ ]]; then
-STRATEGY="atosecmwf"
+   STRATEGY="atosecmwf"
+elif [[ $LOGINHOST =~ uan[0-9][0-9] ]]; then
+   STRATEGY="lumi"
+elif [[ -d $DIR/env/$LOGINHOST ]]; then # check if directory with LOGINHOST exists in env
+STRATEGY=$LOGINHOST
 else
    echo "can not determine environment for host: "$LOGINHOST
    [ $BEING_EXECUTED = true ] && exit 1

--- a/env/lumi/shell
+++ b/env/lumi/shell
@@ -1,0 +1,20 @@
+module purge
+module load PrgEnv-cray/8.3.3
+module load craype-x86-milan
+
+vers=14.0.2
+module swap cce cce/$vers
+module load cray-fftw/3.3.10.1
+module load cray-hdf5/1.12.1.5
+module load cray-netcdf/4.8.1.5
+
+export FC=ftn
+export CC=cc
+export CXX=cc
+export NETCDF_Fortran_INCLUDE_DIRECTORIES=$CRAY_NETCDF_DIR/include
+export NETCDF_C_INCLUDE_DIRECTORIES=$CRAY_NETCDF_DIR/include
+export NETCDF_C_LIBRARIES=$CRAY_NETCDF_DIR/lib
+export NETCDF_Fortran_LIBRARIES=$CRAY_NETCDF_DIR/lib
+$CC -v
+$FC -V
+$CXX -v

--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -400,10 +400,6 @@ contains
     ! EO parameters
     real(kind=real32) :: mean_rtime(15), max_rtime(15), min_rtime(15)
 
-#if defined (__ifsinterface)
-    ! write raw restart at the end of run
-    call write_all_raw_restarts(f%last_nstep, f%MPI_COMM_FESOM, f%mype)
-#endif
     call finalize_output()
     call finalize_restart()
 

--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -389,7 +389,6 @@ contains
     end do
 
     f%last_nstep = f%from_nstep-1+current_nsteps
-    write(*,*) "THIS IS THE LAST TIME STEP! -> ", f%last_nstep
     f%from_nstep = f%from_nstep+current_nsteps
   end subroutine
 

--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -209,7 +209,7 @@ contains
         call clock_newyear                        ! check if it is a new year
         if (f%mype==0) f%t6=MPI_Wtime()
         !___CREATE NEW RESTART FILE IF APPLICABLE___________________________________
-        call restart(0, r_restart, f%which_readr, f%ice, f%dynamics, f%tracers, f%partit, f%mesh)
+        call restart(0, 0, 0, r_restart, f%which_readr, f%ice, f%dynamics, f%tracers, f%partit, f%mesh)
         if (f%mype==0) f%t7=MPI_Wtime()
         ! store grid information into netcdf file
         if (.not. r_restart) call write_mesh_info(f%partit, f%mesh)
@@ -292,7 +292,7 @@ contains
     use fesom_main_storage_module
     integer, intent(in) :: current_nsteps 
     ! EO parameters
-    integer n
+    integer n, nstart, ntotal
 
     !=====================
     ! Time stepping
@@ -314,7 +314,10 @@ contains
     if (use_global_tides) then
        call foreph_ini(yearnew, month, f%partit)
     end if
-    do n=f%from_nstep, f%from_nstep-1+current_nsteps        
+    nstart=f%from_nstep
+    ntotal=f%from_nstep-1+current_nsteps
+    !do n=f%from_nstep, f%from_nstep-1+current_nsteps
+    do n=nstart, ntotal
         if (use_global_tides) then
            call foreph(f%partit, f%mesh)
         end if
@@ -378,7 +381,7 @@ contains
         call output (n, f%ice, f%dynamics, f%tracers, f%partit, f%mesh)
 
         f%t5 = MPI_Wtime()
-        call restart(n, .false., f%which_readr, f%ice, f%dynamics, f%tracers, f%partit, f%mesh)
+        call restart(n, nstart, ntotal, .false., f%which_readr, f%ice, f%dynamics, f%tracers, f%partit, f%mesh)
         f%t6 = MPI_Wtime()
         
         f%rtime_fullice       = f%rtime_fullice       + f%t2 - f%t1

--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -42,7 +42,7 @@ module fesom_main_storage_module
     
   type :: fesom_main_storage_type
 
-    integer           :: n, from_nstep, offset, row, i, provided, last_nstep
+    integer           :: n, from_nstep, offset, row, i, provided
     integer           :: which_readr ! read which restart files (0=netcdf, 1=core dump,2=dtype)
     integer, pointer  :: mype, npes, MPIerr, MPI_COMM_FESOM
     real(kind=WP)     :: t0, t1, t2, t3, t4, t5, t6, t7, t8, t0_ice, t1_ice, t0_frc, t1_frc
@@ -391,7 +391,6 @@ contains
         f%rtime_read_forcing  = f%rtime_read_forcing  + f%t1_frc - f%t0_frc
     end do
 
-    f%last_nstep = f%from_nstep-1+current_nsteps
     f%from_nstep = f%from_nstep+current_nsteps
   end subroutine
 

--- a/src/io_restart.F90
+++ b/src/io_restart.F90
@@ -152,7 +152,7 @@ end subroutine ini_ice_io
 !
 !--------------------------------------------------------------------------------------------
 !
-subroutine restart(istep, l_read, which_readr, ice, dynamics, tracers, partit, mesh)
+subroutine restart(istep, nstart, ntotal, l_read, which_readr, ice, dynamics, tracers, partit, mesh)
 
 #if defined(__icepack)
   icepack restart not merged here ! produce a compiler error if USE_ICEPACK=ON; todo: merge icepack restart from 68d8b8b
@@ -163,7 +163,7 @@ subroutine restart(istep, l_read, which_readr, ice, dynamics, tracers, partit, m
   ! this is the main restart subroutine
   ! if l_read   is TRUE the restart file will be read
 
-  integer :: istep
+  integer :: istep, nstart, ntotal
   logical :: l_read
   logical :: is_portable_restart_write, is_raw_restart_write, is_bin_restart_write
   type(t_mesh)  , intent(inout), target :: mesh
@@ -313,7 +313,11 @@ subroutine restart(istep, l_read, which_readr, ice, dynamics, tracers, partit, m
   if(is_portable_restart_write .and. (raw_restart_length_unit /= "off")) then
     is_raw_restart_write = .true. ! always write a raw restart together with the portable restart (unless raw restarts are off)
   else
+#if !defined __ifsinterface
     is_raw_restart_write = is_due(trim(raw_restart_length_unit), raw_restart_length, istep)
+#else
+    is_raw_restart_write = is_due(trim(raw_restart_length_unit), raw_restart_length, istep) .OR. (istep==ntotal)
+#endif
   end if
   
   ! --> should write derived type binary restart: True/False

--- a/src/io_restart.F90
+++ b/src/io_restart.F90
@@ -14,7 +14,7 @@ MODULE io_RESTART
   use fortran_utils
   
   implicit none
-  public :: restart, finalize_restart, write_all_raw_restarts
+  public :: restart, finalize_restart
   private
 
   integer,       save       :: globalstep=0 ! todo: remove this from module scope as it will mess things up if we use async read/write from the same process

--- a/work/job_ini_lumi
+++ b/work/job_ini_lumi
@@ -1,0 +1,31 @@
+#!/bin/bash
+#SBATCH --account=project_462000048 # edit your account
+#SBATCH --job-name=ini
+#SBATCH --partition=debug
+#SBATCH --time=00:30:00
+#SBATCH --ntasks=128            # Number of tasks (MPI) tasks to be launched
+#SBATCH -o fesom2_%x_%j.out
+#SBATCH -e fesom2_%x_%j.out
+
+set -x
+
+ulimit -s unlimited
+
+source ../env/lumi/shell
+
+ln -s ../bin/fesom_ini.x         .           # cp -n ../bin/fvom_ini.x
+cp -n ../config/namelist.config  .
+#cp -n ../config/namelist.forcing .
+#cp -n ../config/namelist.oce     .
+#cp -n ../config/namelist.ice     .
+
+
+#___DETERMINE SLURM JOBID+OUTPUTFILE____________________________________________
+jobid=$(echo $SLURM_JOB_ID | cut -d"." -f1)
+fname="fesom2_${SLURM_JOB_NAME}_${jobid}.out"
+
+#___PUT JOB IN QUEUE____________________________________________________________
+date
+srun --mpi=pmi2 --ntasks=1 ./fesom_ini.x >> ${fname}
+date
+


### PR DESCRIPTION
@dsidoren made some further changes to the refactoring branch: now the raw restarts are written at the end of the simulation (when `__ifsinterface`) but that is activated via `io_restart.F90` instead of from `fesom_module.F90`. By doing it this way the problems experienced by @sebastianbeyer with the updating of the `fesom.clock` are gone as now it uses the standard way of writing raw restarts which automatically updates the `fesom.clock`.

I cherry-picked this changes and also I cleaned the changes @sebastianbeyer and myself did on our first approach, that are not needed any more.

All this is working on standalone FESOM (tested manually in Levante)

@trackow, if you approve this PR we will be one step closer to the dreamed more sensible restarting strategy in IFS-FESOM :) (I should be opening a PR soon also in RAPS repo)