### PR TITLE
implementing warning when opt_visc=5 is used

### DIFF
--- a/config/namelist.dyn
+++ b/config/namelist.dyn
@@ -4,7 +4,8 @@ visc_gamma1  = 0.1   ! [nodim], for computation of the flow aware viscosity
 visc_gamma2  = 0.285 ! [s/m],   is only used in easy backscatter option
 visc_easybsreturn= 1.5
 
-opt_visc     = 5          
+opt_visc     = 5     
+check_opt_visc=.true.  ! check if optvisc=5 is valid based on ratio resol/rossbyR
 ! 5=Kinematic (easy) Backscatter
 ! 6=Biharmonic flow aware (viscosity depends on velocity Laplacian)
 ! 7=Biharmonic flow aware (viscosity depends on velocity differences)

--- a/src/MOD_DYN.F90
+++ b/src/MOD_DYN.F90
@@ -76,6 +76,7 @@ TYPE T_DYN
     ! 6=Biharmonic flow aware (viscosity depends on velocity Laplacian)
     ! 7=Biharmonic flow aware (viscosity depends on velocity differences)
     ! 8=Dynamic Backscatter
+    integer                                     :: check_opt_visc= .true.
     integer                                     :: opt_visc      = 5
 
     ! gamma0 [m/s],   backgroung viscosity= gamma0*len, it should be as small

--- a/src/MOD_DYN.F90
+++ b/src/MOD_DYN.F90
@@ -76,7 +76,7 @@ TYPE T_DYN
     ! 6=Biharmonic flow aware (viscosity depends on velocity Laplacian)
     ! 7=Biharmonic flow aware (viscosity depends on velocity differences)
     ! 8=Dynamic Backscatter
-    integer                                     :: check_opt_visc= .true.
+    logical                                     :: check_opt_visc= .true.
     integer                                     :: opt_visc      = 5
 
     ! gamma0 [m/s],   backgroung viscosity= gamma0*len, it should be as small

--- a/src/oce_ale.F90
+++ b/src/oce_ale.F90
@@ -2919,7 +2919,7 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
     use write_step_info_interface
     use check_blowup_interface
     use fer_solve_interface
-    use check_validviscopt_interface
+!PS     use check_validviscopt_interface
     IMPLICIT NONE
     integer       , intent(in)            :: n
     type(t_dyn)   , intent(inout), target :: dynamics

--- a/src/oce_ale.F90
+++ b/src/oce_ale.F90
@@ -2919,6 +2919,7 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
     use write_step_info_interface
     use check_blowup_interface
     use fer_solve_interface
+    use check_validviscopt_interface
     IMPLICIT NONE
     integer       , intent(in)            :: n
     type(t_dyn)   , intent(inout), target :: dynamics
@@ -2959,7 +2960,13 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
     else  
         call pressure_force_4_zxxxx(tracers, partit, mesh)
     end if
-
+    
+    !___________________________________________________________________________
+    ! check validity of visc_opt=5 selection
+    ! --> need to know buoyancy frequency to do so.
+    ! --> only check on the first timestep 
+    if (n==1) call check_viscopt(dynamics, partit, mesh)
+    
     !___________________________________________________________________________
     ! calculate alpha and beta
     ! it will be used for KPP, Redi, GM etc. Shall we keep it on in general case?

--- a/src/oce_ale.F90
+++ b/src/oce_ale.F90
@@ -2919,7 +2919,6 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
     use write_step_info_interface
     use check_blowup_interface
     use fer_solve_interface
-!PS     use check_validviscopt_interface
     IMPLICIT NONE
     integer       , intent(in)            :: n
     type(t_dyn)   , intent(inout), target :: dynamics

--- a/src/oce_dyn.F90
+++ b/src/oce_dyn.F90
@@ -56,16 +56,6 @@ end module
 
 module check_validviscopt_interface
     interface
-!PS          subroutine check_viscopt(dynamics, partit, mesh)
-!PS             USE MOD_DYN
-!PS             USE MOD_PARTIT
-!PS             USE MOD_PARSUP
-!PS             USE MOD_MESH
-!PS             type(t_dyn)   , intent(inout), target :: dynamics
-!PS             type(t_partit), intent(inout), target :: partit
-!PS             type(t_mesh)  , intent(in)   , target :: mesh
-!PS         end subroutine 
-        
         subroutine check_validviscopt_5(partit, mesh)
             USE MOD_MESH
             USE MOD_PARTIT

--- a/src/oce_dyn.F90
+++ b/src/oce_dyn.F90
@@ -54,6 +54,28 @@ module visc_filt_bidiff_interface
   end interface
 end module
 
+module check_validviscopt_interface
+    interface
+         subroutine check_viscopt(dynamics, partit, mesh)
+            USE MOD_DYN
+            USE MOD_PARTIT
+            USE MOD_PARSUP
+            USE MOD_MESH
+            type(t_dyn)   , intent(inout), target :: dynamics
+            type(t_partit), intent(inout), target :: partit
+            type(t_mesh)  , intent(in)   , target :: mesh
+        end subroutine 
+        
+        subroutine check_validviscopt_5(partit, mesh)
+            USE MOD_MESH
+            USE MOD_PARTIT
+            USE MOD_PARSUP
+            type(t_partit), intent(inout), target :: partit
+            type(t_mesh)  , intent(in)   , target :: mesh
+        end subroutine    
+    end interface
+end module 
+
 ! 
 ! Contains routines needed for computations of dynamics.
 ! includes: update_vel, compute_vel_nodes
@@ -746,3 +768,143 @@ salt   => tracers%data(2)%values(:,:)
   call exchange_nod(dynamics%ke_swA, partit)
   call exchange_nod(dynamics%ke_swB, partit)
 END SUBROUTINE compute_apegen
+
+
+!
+!
+!_______________________________________________________________________________
+! check validity of visc_opt=5 selection on basis of ratio betweem resolution and 
+! 1st baroclinic rossby radius. visc_opt=5 ("easy backscatter") in eddy 
+! resolving/partly eddy permitting setups can lead to problems in form of 
+! exedingly strong near boundary currents that can lead e.g to very weak 
+! Drake Passage throughflow (<80Sv). In this case better use visc_opt=7, 
+! which is the flow aware viscosity option 
+subroutine check_viscopt(dynamics, partit, mesh)
+    USE MOD_DYN
+    USE MOD_PARTIT
+    USE MOD_PARSUP
+    USE MOD_MESH
+    IMPLICIT NONE
+    type(t_dyn)   , intent(inout), target :: dynamics
+    type(t_partit), intent(inout), target :: partit
+    type(t_mesh)  , intent(in)   , target :: mesh
+    
+    if (dynamics%check_opt_visc) then
+        select case (dynamics%opt_visc)
+            case(5) 
+                ! check validity of visc_opt=5 especially in higher resolved setups
+                ! --> there it can lead to problems
+                call check_validviscopt_5(partit, mesh)
+        end select   
+    end if 
+end subroutine check_viscopt
+
+!
+!
+!_______________________________________________________________________________
+! check if viscopt=5 is a valid and recommended option for the used configuration
+subroutine check_validviscopt_5(partit, mesh)
+    USE MOD_MESH
+    USE MOD_PARTIT
+    USE MOD_PARSUP
+    USE o_PARAM , ONLY: rad
+    USE o_ARRAYS, ONLY: bvfreq
+    USE g_CONFIG
+    USE g_comm_auto
+    IMPLICIT NONE
+    type(t_mesh),   intent(in),    target :: mesh
+    type(t_partit), intent(inout), target :: partit
+    integer                               :: node, nz, nzmax, nzmin
+    real(kind=WP)                         :: f_min=1.e-6_WP, z_min=100.0_WP, r_max=200000._WP, r_min=2000.0_WP
+    real(kind=WP)                         :: c_min=0.5_WP, c1
+    real(kind=WP)                         :: excl_EQ=30.0, thresh_ratio=1.5
+    real(kind=WP)                         :: loc_R, loc_A
+    real(kind=WP)                         :: glb_R, glb_A
+    real(kind=WP)                         :: fac_ResR1barocl, rossbyr_1barocl
+#include "associate_part_def.h"
+#include "associate_mesh_def.h"
+#include "associate_part_ass.h"
+#include "associate_mesh_ass.h"
+    
+    !___________________________________________________________________________
+    loc_R = 0.0_WP
+    loc_A = 0.0_WP
+    do node=1, myDim_nod2D
+        !_______________________________________________________________________
+        ! Exlude the equator |lat|<30° from checking the ration between resolution
+        ! and first baroclinic rossby radius  
+        if (abs(mesh%geo_coord_nod2D(2,node)/rad)<excl_EQ) cycle
+        
+        !_______________________________________________________________________
+        !ca. first baroclinic gravity wave speed limited from below by c_min
+        nzmax=mesh%nlevels_nod2D_min(node)
+        nzmin=mesh%ulevels_nod2D_max(node)
+        c1=0.0_WP
+        do nz=nzmin, nzmax-1
+            c1=c1+hnode_new(nz,node)*(                                         &
+                                    sqrt(abs(max(bvfreq(nz  ,node), 0._WP)))+  &
+                                    sqrt(abs(max(bvfreq(nz+1,node), 0._WP)))   &
+                                  )/2._WP ! add abs() for -0 case, cray
+        end do
+        c1=max(c_min, c1/pi)
+        
+        !_______________________________________________________________________
+        ! compute 1st. baroclinic rossby radius
+        rossbyr_1barocl = max( min( c1/max( abs(mesh%coriolis_node(node)), f_min), r_max), r_min)
+        
+        !_______________________________________________________________________
+        ! compute ratio between rossby and resolution, if ratio >=1 setup is not eddy 
+        ! resolving in best case eddy permitting --> GM/Redi will still be neccessary
+        fac_ResR1barocl =min(mesh_resolution(node)/rossbyr_1barocl, 5._WP)
+        
+        !_______________________________________________________________________
+        ! compute local mean ratio but exclude equator |lat|<30°, since Rossby radius 
+        ! at equator becomes very large
+        loc_R   = loc_R + fac_ResR1barocl
+        loc_A   = loc_A + 1.0_WP
+    end do
+    
+    !___________________________________________________________________________
+    ! compute global mean ratio --> core2 Ratio=4.26 (eddy parameterizted), 
+    ! dart Ratio=0.97 (eddy resolving/permitting)
+    call MPI_AllREDUCE(loc_R, glb_R, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_FESOM, MPIerr)
+    call MPI_AllREDUCE(loc_A, glb_A, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_FESOM, MPIerr)
+    glb_R  = glb_R/glb_A
+    
+    !___________________________________________________________________________
+    ! create warning message when ratio<thresh_ratio
+    if (glb_R<thresh_ratio) then 
+        if (mype==0) then 
+        print *, achar(27)//'[33m'
+        write(*,*) '____________________________________________________________________'
+        write(*,*) ' --check opt_visc--> Mean Ratio Resol/Rrossby = ',  glb_R 
+        write(*,*) '____________________________________________________________________'
+        write(*,*) ' WARNING: You want to use opt_visc=5 (easy backscatter viscosity) in'
+        write(*,*) '          an eddy resolving to eddy permitting (Resol/Rrossby<1.5)  '
+        write(*,*) '          configuration. It revealed to us that this can lead to    '
+        write(*,*) '          problems in form of unrealistically strong near boundary  '
+        write(*,*) '          currents that can ultimatively lead to an e.g very weak   '
+        write(*,*) '          Drake Passage throughflow (<80Sv in spinup up dart        '
+        write(*,*) '          configuration). For these kind of setups we recommend to  '
+        write(*,*) '          use opt_visc=7, which is the flow aware viscosity         '
+        write(*,*) '          parameterisation.                                         '
+        write(*,*) '          The easy backscatter viscosity was designed to energetise '
+        write(*,*) '          coarse resolved configurations!!!                         '
+        write(*,*) '          --> So please change the viscosity option in namelist.dyn '
+        write(*,*) '              to opt_visc=7 .                                       '
+        write(*,*) '          --> If you insist in using opt_visc=5 in your simulation, '
+        write(*,*) '              you can switch off this check in namelist.dyn by      '
+        write(*,*) '              setting check_opt_visc=.false.                        '
+        write(*,*) '                                                                    '
+        write(*,*) '____________________________________________________________________'
+        print *, achar(27)//'[0m'
+        write(*,*)
+        call par_ex(partit%MPI_COMM_FESOM, partit%mype, 0)
+        end if
+    else
+        if (mype==0) then 
+        write(*,*) ' --check opt_visc--> Mean Ratio Resol/Rrossby = ',  glb_R 
+        end if
+    end if     
+    
+end subroutine check_validviscopt_5

--- a/src/oce_dyn.F90
+++ b/src/oce_dyn.F90
@@ -784,6 +784,7 @@ subroutine check_viscopt(dynamics, partit, mesh)
     USE MOD_PARTIT
     USE MOD_PARSUP
     USE MOD_MESH
+    USE check_validviscopt_interface
     IMPLICIT NONE
     type(t_dyn)   , intent(inout), target :: dynamics
     type(t_partit), intent(inout), target :: partit

--- a/src/oce_dyn.F90
+++ b/src/oce_dyn.F90
@@ -823,7 +823,6 @@ subroutine check_validviscopt_5(partit, mesh)
     
 !$OMP PARALLEL DEFAULT(SHARED) PRIVATE(node, nz, nzmax, nzmin, c1, rossbyr_1barocl, &
 !$OMP                                  fac_ResR1barocl, loc_R, loc_A)
-
 !$OMP DO
     do node=1, myDim_nod2D
         !_______________________________________________________________________
@@ -860,6 +859,8 @@ subroutine check_validviscopt_5(partit, mesh)
         loc_A   = loc_A + 1.0_WP
     end do
 !$OMP END DO
+!$OMP END PARALLEL
+!$OMP BARRIER
 
     !___________________________________________________________________________
     ! compute global mean ratio --> core2 Ratio=4.26 (eddy parameterizted), 

--- a/src/oce_dyn.F90
+++ b/src/oce_dyn.F90
@@ -820,6 +820,10 @@ subroutine check_validviscopt_5(partit, mesh)
     !___________________________________________________________________________
     loc_R = 0.0_WP
     loc_A = 0.0_WP
+    
+!$OMP PARALLEL DEFAULT(SHARED) PRIVATE(node nz, nzmax, nzmin, c1, rossbyr_1barocl, &
+!$OMP                                  fac_ResR1barocl, loc_R, loc_A)
+!$OMP DO
     do node=1, myDim_nod2D
         !_______________________________________________________________________
         ! Exlude the equator |lat|<30° from checking the ration between resolution
@@ -854,7 +858,8 @@ subroutine check_validviscopt_5(partit, mesh)
         loc_R   = loc_R + fac_ResR1barocl
         loc_A   = loc_A + 1.0_WP
     end do
-    
+!$OMP END DO
+
     !___________________________________________________________________________
     ! compute global mean ratio --> core2 Ratio=4.26 (eddy parameterizted), 
     ! dart Ratio=0.97 (eddy resolving/permitting)

--- a/src/oce_dyn.F90
+++ b/src/oce_dyn.F90
@@ -56,15 +56,15 @@ end module
 
 module check_validviscopt_interface
     interface
-         subroutine check_viscopt(dynamics, partit, mesh)
-            USE MOD_DYN
-            USE MOD_PARTIT
-            USE MOD_PARSUP
-            USE MOD_MESH
-            type(t_dyn)   , intent(inout), target :: dynamics
-            type(t_partit), intent(inout), target :: partit
-            type(t_mesh)  , intent(in)   , target :: mesh
-        end subroutine 
+!PS          subroutine check_viscopt(dynamics, partit, mesh)
+!PS             USE MOD_DYN
+!PS             USE MOD_PARTIT
+!PS             USE MOD_PARSUP
+!PS             USE MOD_MESH
+!PS             type(t_dyn)   , intent(inout), target :: dynamics
+!PS             type(t_partit), intent(inout), target :: partit
+!PS             type(t_mesh)  , intent(in)   , target :: mesh
+!PS         end subroutine 
         
         subroutine check_validviscopt_5(partit, mesh)
             USE MOD_MESH

--- a/src/oce_dyn.F90
+++ b/src/oce_dyn.F90
@@ -821,8 +821,9 @@ subroutine check_validviscopt_5(partit, mesh)
     loc_R = 0.0_WP
     loc_A = 0.0_WP
     
-!$OMP PARALLEL DEFAULT(SHARED) PRIVATE(node nz, nzmax, nzmin, c1, rossbyr_1barocl, &
+!$OMP PARALLEL DEFAULT(SHARED) PRIVATE(node, nz, nzmax, nzmin, c1, rossbyr_1barocl, &
 !$OMP                                  fac_ResR1barocl, loc_R, loc_A)
+
 !$OMP DO
     do node=1, myDim_nod2D
         !_______________________________________________________________________

--- a/src/oce_setup_step.F90
+++ b/src/oce_setup_step.F90
@@ -261,6 +261,7 @@ subroutine ocean_setup(dynamics, tracers, partit, mesh)
         write(*,*) 'maximum allowed CDF on explicit W is set to: ', dynamics%wsplit_maxcfl
         write(*,*) '******************************************************************************'
     end if
+
 end subroutine ocean_setup
 !
 !
@@ -390,8 +391,9 @@ SUBROUTINE dynamics_init(dynamics, partit, mesh)
     logical        :: use_freeslip =.false.
     logical        :: use_wsplit   =.false.
     logical        :: ldiag_KE     =.false.
+    logical        :: check_opt_visc=.true.
     real(kind=WP)  :: wsplit_maxcfl
-    namelist /dynamics_visc   / opt_visc, visc_gamma0, visc_gamma1, visc_gamma2,  &
+    namelist /dynamics_visc   / opt_visc, check_opt_visc, visc_gamma0, visc_gamma1, visc_gamma2,  &
                                 use_ivertvisc, visc_easybsreturn
     namelist /dynamics_general/ momadv_opt, use_freeslip, use_wsplit, wsplit_maxcfl, ldiag_KE
     !___________________________________________________________________________
@@ -418,6 +420,7 @@ SUBROUTINE dynamics_init(dynamics, partit, mesh)
     !___________________________________________________________________________
     ! set parameters in derived type
     dynamics%opt_visc          = opt_visc
+    dynamics%check_opt_visc    = check_opt_visc
     dynamics%visc_gamma0       = visc_gamma0
     dynamics%visc_gamma1       = visc_gamma1
     dynamics%visc_gamma2       = visc_gamma2
@@ -753,6 +756,7 @@ SUBROUTINE arrays_init(num_tracers, partit, mesh)
 !!PS     dum_3d_n = 0.0_WP
 !!PS     dum_2d_e = 0.0_WP
 !!PS     dum_3d_e = 0.0_WP
+
 END SUBROUTINE arrays_init
 !
 !


### PR DESCRIPTION
- create warning message when opt_visc=5 is used in an eddy resolving to eddy permitting configuration. Warning message is triggered when mean ratio Resolution/R_rossby <1.5. We still might need to play on this parameter. It can maybe be larger.