### PR TITLE
 synchronize the salinity cutoff and blowup criteria for salinity…

### DIFF
--- a/src/write_step_info.F90
+++ b/src/write_step_info.F90
@@ -469,11 +469,11 @@ subroutine check_blowup(istep, ice, dynamics, tracers, partit, mesh)
           !_______________________________________________________________
           ! check salt
           if ( (tracers%data(2)%values(nz, n) /= tracers%data(2)%values(nz, n)) .or.  &
-             tracers%data(2)%values(nz, n) < 0 .or. tracers%data(2)%values(nz, n)>50 ) then
+             tracers%data(2)%values(nz, n) <=3.0_WP .or. tracers%data(2)%values(nz, n)>=45.0_WP ) then
 !$OMP CRITICAL
              found_blowup_loc=1
              write(*,*) '___CHECK FOR BLOW UP___________ --> mstep=',istep
-             write(*,*) ' --STOP--> found salinity becomes NaN or <0, >50'
+             write(*,*) ' --STOP--> found salinity becomes NaN or <=3.0, >=45.0'
              write(*,*) 'mype     = ',mype
              write(*,*) 'mstep    = ',istep
              write(*,*) 'node     = ',n


### PR DESCRIPTION
synchronize the salinity cutoff criteria in oce_ale_tracer.F90 with the salinity blowup criteria in write_step_info.F90 to allow the model to blowup from salinity. Otherwise it can happen that we create a salinity zombie run that is kept artificially alive although it wants to blowup via salinity.