### PR TITLE
Fix restart: when tke or iwe files do not exist, make existence of iwe and tke optional

### DIFF
--- a/src/io_restart.F90
+++ b/src/io_restart.F90
@@ -82,15 +82,15 @@ subroutine ini_ocean_io(year, dynamics, tracers, partit, mesh)
   !___Save restart variables for TKE and IDEMIX_________________________________
 !   if (trim(mix_scheme)=='cvmix_TKE' .or. trim(mix_scheme)=='cvmix_TKE+IDEMIX') then
   if (mix_scheme_nmb==5 .or. mix_scheme_nmb==56) then
-        call oce_files%def_node_var('tke', 'Turbulent Kinetic Energy', 'm2/s2', tke(:,:), mesh, partit)
+        call oce_files%def_node_var_optional('tke', 'Turbulent Kinetic Energy', 'm2/s2', tke(:,:), mesh, partit)
   endif
 !   if (trim(mix_scheme)=='cvmix_IDEMIX' .or. trim(mix_scheme)=='cvmix_TKE+IDEMIX') then
   if (mix_scheme_nmb==6 .or. mix_scheme_nmb==56) then
-        call oce_files%def_elem_var('iwe', 'Internal Wave Energy'    , 'm2/s2', iwe(:,:), mesh, partit)
+        call oce_files%def_elem_var_optional('iwe', 'Internal Wave Energy'    , 'm2/s2', iwe(:,:), mesh, partit)
   endif 
   if (dynamics%opt_visc==8) then
-        call oce_files%def_elem_var('uke', 'unresolved kinetic energy', 'm2/s2', uke(:,:), mesh, partit)
-        call oce_files%def_elem_var('uke_rhs', 'unresolved kinetic energy rhs', 'm2/s2', uke_rhs(:,:), mesh, partit)
+        call oce_files%def_elem_var_optional('uke', 'unresolved kinetic energy', 'm2/s2', uke(:,:), mesh, partit)
+        call oce_files%def_elem_var_optional('uke_rhs', 'unresolved kinetic energy rhs', 'm2/s2', uke_rhs(:,:), mesh, partit)
   endif
   
   do j=1,tracers%num_tracers


### PR DESCRIPTION
make existence of tke and iwe files optional for restart so that the restart also works when the files dont exist like in a restart from TKE to TKE+IDEMIX. If the files would be needed but they do not exist they are simply initialised with zeros for the first time step

allow for restart from:
- tke  --> tke+idemix
- kpp --> tke 
- kpp --> tke+idemix  

should also allow restart for:
- viscop5 --> viscopt8
- viscop6 --> viscopt8
- viscop7 --> viscopt8
