### PR TITLE
Add same information from GH readme to RTD docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,15 @@
 FESOM2 documentation
 ====================
 
+The Finite volumE Sea Ice-Ocean Model (FESOM2).
+
+Multi-resolution ocean general circulation model that solves
+the equations of motion describing the ocean and sea ice using
+finite-volume methods on unstructured computational grids. The
+model is developed and supported by researchers at the Alfred
+Wegener Institute, Helmholtz Centre for Polar and Marine
+Research (AWI), in Bremerhaven, Germany.
+
 Authors
    -------
 


### PR DESCRIPTION
Hello,

I was working on some review feedback in an eFlows4HPC, where we were asked to add the acronym of FESOM in the document.

I accessed the RTD site but I couldn't find it. I found it later on fesom.de. The GitHub README has this information, so I copied that over here, along with the introductory paragraph from GH's README.

Local preview:

![image](https://github.com/FESOM/fesom2/assets/304786/1ecf0285-2dd4-423f-aced-3a8f9ea38eff)
