### PR TITLE
fix that ensures we dont check for salinity <= 3 inside ice shelf

### DIFF
--- a/src/write_step_info.F90
+++ b/src/write_step_info.F90
@@ -417,7 +417,7 @@ subroutine check_blowup(istep, ice, dynamics, tracers, partit, mesh)
        end if ! --> if ( .not. trim(which_ALE)=='linfs' .and. ...
           
        
-       do nz=1,nlevels_nod2D(n)-1
+       do nz=ulevels_nod2D(n),nlevels_nod2D(n)-1
           !_______________________________________________________________
           ! check temp
           if ( (tracers%data(1)%values(nz, n) /= tracers%data(1)%values(nz, n)) .or. &


### PR DESCRIPTION
Since we made sure that the salinity threshold is consistently at 3 PSU everywhere, we can no longer check for salt blowup in the layers above the cavity, where salinity is = 0