### PR TITLE
Add lumi CI/CD workflow

### DIFF
--- a/.github/workflows/lumi-sync.yaml
+++ b/.github/workflows/lumi-sync.yaml
@@ -1,0 +1,26 @@
+name: Run CICD on Lumi (using .gitlab-ci.yml)
+
+on: push
+  branches:
+    - refactoring
+
+jobs:
+  gitlabsync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check out code"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: "Gitlab mirror and CI"
+        uses: "tiggi/gitlab-mirror-and-ci-action@tiggi/fixes"
+        with:
+          args: "https://gitlab.com/lumi-cicd/fesom2.git"
+        env:
+          FOLLOW_TAGS: "true"
+          FORCE_PUSH: "true"
+          GITLAB_HOSTNAME: "gitlab.com"
+          GITLAB_USERNAME: "tiggi"
+          GITLAB_PASSWORD: ${{ secrets.GITLAB_PASSWORD }}
+          GITLAB_PROJECT_ID: "51374059"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lumi-sync.yaml
+++ b/.github/workflows/lumi-sync.yaml
@@ -3,6 +3,7 @@ name: Run CICD on Lumi (using .gitlab-ci.yml)
 on: push
   branches:
     - refactoring
+    - lumi_gpu_evatali
 
 jobs:
   gitlabsync:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,13 @@
+fesom-job:
+  stage: build
+  variables:
+    SCHEDULER_PARAMETERS: "-N 1 -n 56  --mem=16G   -t 00:30:00 -A project_462000376"
+  tags:
+    - lumi
+  artifacts:
+    paths:
+      - fesom_build.log
+  script:
+    - echo "building fesom branch"
+    - bash -l configure.sh lumi
+    - touch fesom_build.log


### PR DESCRIPTION
First commit of github actions workflow that mirrors the repo to gitlab, runs the CI there and waits for it to complete.
Also added a rudimentary .gitlab-ci.yml to compile FESOM.
