### PR TITLE
Fix compilation issues using Hecuba (2.1_intel) on MN4

### DIFF
--- a/env/bsc/shell
+++ b/env/bsc/shell
@@ -1,7 +1,4 @@
-
-module load intel/2020.1 impi/2018.4 mkl/2020.1 bsc/1.0 netcdf/4.2
-
+module use /apps/HECUBA/modulefiles
+module load intel/2020.1 impi/2018.4 mkl/2020.1 bsc/1.0 netcdf/4.2 Hecuba/2.1_intel
 export FC=mpiifort CC=mpiicc CXX=mpiicpc
-
-
 

--- a/src/io_hecuba/CMakeLists.txt
+++ b/src/io_hecuba/CMakeLists.txt
@@ -30,5 +30,5 @@ target_link_libraries(${PROJECT_NAME} PRIVATE -L${HECUBA_ROOT}/lib -lhfetch)
 #target_link_libraries(${PROJECT_NAME}_C -L${LIBDILL_LIB} -ldill -pthread -lssl -lcrypto)
 
 
-#target_compile_options(${PROJECT_NAME} PRIVATE -std=c++11 -fpic -shared)
+target_compile_options(${PROJECT_NAME} PRIVATE -std=c++11 -fpic -shared)
 

--- a/src/io_hecuba/hecuba_c_connector.cpp
+++ b/src/io_hecuba/hecuba_c_connector.cpp
@@ -38,7 +38,7 @@ void setExpMetaData(std::string expname, std::string key, std::string value) {
     std::cout<< "+ end here in set metadata"<<std::endl;
    }	
 
-void sendMetricsToHecuba(const char * expname, const char * varname, int32_t timestep_i, int32_t chunk_id, void *data, int32_t metadata) {
+void sendMetricsToHecuba(const char * expname, const char * varname, int32_t timestep_i, int32_t chunk_id, void *data, uint32_t metadata) {
     StorageNumpy metrics_data(data,{metadata,1}); // instantiates a StorageNumpy with the specified info
 
     std::string generatedName = "";


### PR DESCRIPTION
Hi @suvarchal ,

Yolanda noticed the compilation issues with this branch, and suggest a fix (`uint32_t` instead of `int32_t`). I've updated the modules I used to compile on MN4, and we also enabled `c++11` as that's what Hecuba 2.11_intel uses.

With this we were able to successfully compile this branch.

Could you, please,

i) confirm this branch can be used with Alien4Cloud
ii) check if these changes look OK

Thanks!!
Bruno