### PR TITLE
consistent blowup check for salinty as clipped in oce_ale_tracer.F90

### DIFF
--- a/src/oce_ale_tracer.F90
+++ b/src/oce_ale_tracer.F90
@@ -274,7 +274,8 @@ subroutine solve_tracers_ale(ice, dynamics, tracers, partit, mesh)
         end do
 !$OMP END PARALLEL DO
     end if
-
+    
+    ! TODO: do it only when it is coupled to atmosphere 
     !___________________________________________________________________________
     ! to avoid crash with high salinities when coupled to atmosphere
     ! --> if we do only where (tr_arr(:,:,2) < 3._WP ) we also fill up the bottom

--- a/src/write_step_info.F90
+++ b/src/write_step_info.F90
@@ -469,7 +469,7 @@ subroutine check_blowup(istep, ice, dynamics, tracers, partit, mesh)
           !_______________________________________________________________
           ! check salt
           if ( (tracers%data(2)%values(nz, n) /= tracers%data(2)%values(nz, n)) .or.  &
-             tracers%data(2)%values(nz, n) <=3.0_WP .or. tracers%data(2)%values(nz, n)>=45.0_WP ) then
+             tracers%data(2)%values(nz, n) <3.0_WP .or. tracers%data(2)%values(nz, n) >45.0_WP ) then
 !$OMP CRITICAL
              found_blowup_loc=1
              write(*,*) '___CHECK FOR BLOW UP___________ --> mstep=',istep


### PR DESCRIPTION
make salinity blow up consistent with clipping in
https://github.com/FESOM/fesom2/blob/c5e2f09cf28b0a25eea3b605a221b339abe9f2dc/src/oce_ale_tracer.F90#L284-L294

otherwise will blowup at the boundaries 45.0 and 3.0


