### PR TITLE
multio: set unstructuredGridType from namelist

### DIFF
--- a/src/gen_modules_config.F90
+++ b/src/gen_modules_config.F90
@@ -27,8 +27,9 @@ module g_config
   character(MAX_PATH)        :: ClimateDataPath='./hydrography/'
   character(MAX_PATH)        :: TideForcingPath='./tide_forcing/'
   character(MAX_PATH)        :: ResultPath='./result/'
+  character(20)              :: MeshId='NONE'
   namelist /paths/  MeshPath, ClimateDataPath, &
-       TideForcingPath, ResultPath
+       TideForcingPath, ResultPath, MeshId
        
   !_____________________________________________________________________________
   ! *** restart_log ***

--- a/src/ifs_interface/iom.F90
+++ b/src/ifs_interface/iom.F90
@@ -332,6 +332,7 @@ CONTAINS
 
     SUBROUTINE iom_send_fesom_data(data)
         USE g_clock
+        USE g_config, only: MeshId
         IMPLICIT NONE
 
         TYPE(iom_field_request), INTENT(INOUT)  :: data
@@ -373,7 +374,7 @@ CONTAINS
             CALL ctl_stop('send_fesom_data: md%set_string(gridType) failed: ', multio_error_string(cerr))
         END IF
 
-        cerr = md%set_string("unstructuredGridType", "CORE2")
+        cerr = md%set_string("unstructuredGridType", MeshId)
         IF (cerr /= MULTIO_SUCCESS) THEN
             CALL ctl_stop('send_fesom_data: md%set_string(unstructuredGridType) failed: ', multio_error_string(cerr))
         END IF


### PR DESCRIPTION
multio: set unstructuredGridType from namelist

This requires setting MeshId in namelist.config (under mesh) to either CORE2 or NG5. Default is NONE and NONE will crash multio.