### PR TITLE
dkrz_new_nvhpc_openmpi_sesh

### DIFF
--- a/env/levante.dkrz.de/shell.nvhpc
+++ b/env/levante.dkrz.de/shell.nvhpc
@@ -5,8 +5,8 @@ export CPU_MODEL=AMD_EPYC_ZEN3
 module --force purge 
 # module load intel-oneapi-compilers/2022.0.1-gcc-11.2.0
 # module load openmpi/4.1.2-intel-2021.5.0
-module load nvhpc/22.5-gcc-11.2.0
-module load openmpi/.4.1.4-nvhpc-22.5
+module load nvhpc/23.9-gcc-11.2.0
+module load openmpi/4.1.6-nvhpc-23.9
 export FC=mpif90 CC=mpicc CXX=mpicxx;
 
 module load netcdf-c/4.8.1-openmpi-4.1.2-intel-2021.5.0


### PR DESCRIPTION
add the new openmpi compiled with the new recommended UCX-1.14.1 version, and the newest nvhpc

(cherry picked from commit 8ad2746365caad80d1e7b8773296af2389d44ff0)