### PR TITLE
IFS-interface: read precomputed weights matching mpi ranks

### DIFF
--- a/src/ifs_interface/ifs_modules.F90
+++ b/src/ifs_interface/ifs_modules.F90
@@ -1803,10 +1803,11 @@ CONTAINS
       INTEGER :: dims1(1), dims2(2)
       INTEGER :: idda, idsa, idrm, idns, idsaa, idnr, idnrp, idnsp
 
-      WRITE(cdfile,'(A,2(I8.8,A),2(I4.4,A),A)') &
-         & TRIM(cdpath)//'/'//TRIM(cdprefix)//'_', &
-         & nsrcglopoints,'_',ndstglopoints,'_',mype,'_',nproc,'.nc'
+      WRITE(cdfile, '(A,I0,A,2(I8.8,A),2(I4.4,A),A)') &
+         & TRIM(cdpath) // '/dist_', nproc, '/'// TRIM(cdprefix)//'_', &
+         & nsrcglopoints, '_', ndstglopoints, '_', mype, '_', nproc, '.nc'
 
+      call execute_command_line('mkdir -p ' // cdpath)
       CALL nchdlerr(nf90_create(TRIM(cdfile),nf90_clobber,ncid), &
          &          __LINE__, __MYFILE__ )
 
@@ -1957,14 +1958,17 @@ CONTAINS
       CHARACTER(len=1024) :: cdfile
       INTEGER :: ncid, dimid, varid, num_wgts
 
-      WRITE(cdfile,'(A,2(I8.8,A),2(I4.4,A),A)') &
-         & TRIM(cdpath)//'/'//TRIM(cdprefix)//'_', &
-         & nsrcglopoints,'_',ndstglopoints,'_',mype,'_',nproc,'.nc'
+      WRITE(cdfile, '(A,I0,A,2(I8.8,A),2(I4.4,A),A)') &
+         & TRIM(cdpath) // '/dist_', nproc, '/'// TRIM(cdprefix)//'_', &
+         & nsrcglopoints, '_', ndstglopoints, '_', mype, '_', nproc, '.nc'
 
 
       lexists=nf90_open(TRIM(cdfile),nf90_nowrite,ncid)==nf90_noerr
 
       IF (lexists) THEN
+        IF (mype==0) THEN
+          WRITE(*,*) "FESOM ifs-interface: precomputed weight file exists, reading it in."
+        ENDIF
 
          ! If num_links is not present we assume it to be zero.
          


### PR DESCRIPTION
This makes fesom look for the precomputed interpolation weights in a subdir with name 'dist_<mpi-ranks>' in the path given in the namfesomcoup.in namelist as cdpathdist. (same as for mesh dist) It is no longer required to change the namelist every time the number of mpi ranks is changed.

It requires the namelist in the INPROOT to be changed though, e.g.:
`cdpathdist='/scratch/project_465000454/sbeyer/ifs_inputs/remapping_weights/'`
instead of 
`cdpathdist='/scratch/project_465000454/sbeyer/ifs_inputs/remapping_weights/dist_2048'`
