### PR TITLE
production_DE fix in ice_fem_fct for occurring Overflows

### DIFF
--- a/src/ice_fct.F90
+++ b/src/ice_fct.F90
@@ -817,14 +817,14 @@ subroutine ice_fem_fct(tr_array_id, ice, partit, mesh)
 
         flux=icepplus(n)
         if (abs(flux)>0) then
-            icepplus(n)=min(1.0_WP,tmax(n)/flux)
+            icepplus(n)=min(1.0_WP,tmax(n)/max(flux,1.e-12))
         else
             icepplus(n)=0._WP
         end if
 
         flux=icepminus(n)
         if (abs(flux)>0) then
-            icepminus(n)=min(1.0_WP,tmin(n)/flux)
+            icepminus(n)=min(1.0_WP,tmin(n)/min(flux,-1.e-12))
         else
             icepminus(n)=0._WP
         end if


### PR DESCRIPTION
Worked now for 12 days on Levante without Overflows in ice_fem_fct:

/work/bm1235/a270046/production-tests/tco1279l137/hz9o/hres/intel.levante.openmpi/lvt.intel.sp/h288.N240+20.T3840xt8xh1+ioT320xt8xh0.nextgems_6h.i32r0w32.1279NG5-8617297