### PR TITLE
when mpi_abort is called it should abort MPI_COMM_WORLD and not COMM,…

### DIFF
--- a/src/gen_modules_partitioning.F90
+++ b/src/gen_modules_partitioning.F90
@@ -109,7 +109,7 @@ subroutine par_ex(COMM, mype, abort)       ! finalizes MPI
 #ifndef __oasis
   if (present(abort)) then
      if (mype==0) write(*,*) 'Run finished unexpectedly!'
-     call MPI_ABORT(COMM, 1 )
+     call MPI_ABORT(MPI_COMM_WORLD, 1 )
   else
      call  MPI_Barrier(COMM, error)
      call  MPI_Finalize(error)


### PR DESCRIPTION
… without which coupled model hangs indefinitely waiting for FESOM, for instance if partition not found then IFS/FESOM will wait until Job is timed out.