### PR TITLE
Refactoring improve4ogurses calendar

### DIFF
--- a/src/gen_modules_clock.F90
+++ b/src/gen_modules_clock.F90
@@ -196,11 +196,20 @@ contains
     flag=0
 
     if(.not.include_fleapyear) return
-
+    call is_fleapyr(year, flag)
+    
+  end subroutine check_fleapyr
+  
+  subroutine is_fleapyr(year, flag)
+    implicit none
+    integer, intent(in) :: year      
+    integer, intent(out):: flag
+    flag=0
     if ((mod(year,4)==0.and.mod(year,100)/=0) .or. mod(year,400)==0) then
        flag=1
     endif
-  end subroutine check_fleapyr
+  end subroutine is_fleapyr
+  
   !
   !----------------------------------------------------------------------------
   !

--- a/src/gen_surface_forcing.F90
+++ b/src/gen_surface_forcing.F90
@@ -747,7 +747,7 @@ CONTAINS
         ! if include_fleapyear==.False. and forcing file of year contains a fleap
         ! year, try to step over the 29.Feb so it is not used for temporal 
         ! interpolation
-        if ((include_fleapyear==.False.) .and.  &
+        if ((include_fleapyear .eqv. .False.) .and.  &
             ((trim(sbc_flfi(fld_idx)%calendar).eq.'julian'             ) .or. &
              (trim(sbc_flfi(fld_idx)%calendar).eq.'gregorian'          ) .or. &
              (trim(sbc_flfi(fld_idx)%calendar).eq.'proleptic_gregorian') .or. &
@@ -1242,7 +1242,7 @@ CONTAINS
         !_______________________________________________________________________
         ! special case if include_fleapyear==False but the calendar of the forcing 
         ! is julian or gregorian, so has the potential to contain a fleapyear value 
-        if ((include_fleapyear==.False.) .and.  &
+        if ((include_fleapyear .eqv. .False.) .and.  &
             ((trim(sbc_flfi(fld_idx)%calendar).eq.'julian'             ) .or. &
              (trim(sbc_flfi(fld_idx)%calendar).eq.'gregorian'          ) .or. &
              (trim(sbc_flfi(fld_idx)%calendar).eq.'proleptic_gregorian') .or. &

--- a/src/gen_surface_forcing.F90
+++ b/src/gen_surface_forcing.F90
@@ -216,7 +216,6 @@ CONTAINS
       !open file
       if (partit%mype==0) then
          iost = nf_open(trim(flf%file_name),NF_NOWRITE,ncid)
-         write(*,*) 'before: flf%file_name=', trim(flf%file_name)
       end if
 
       call MPI_BCast(iost, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
@@ -375,7 +374,6 @@ CONTAINS
         aux_calendar = aux_calendar(1:aux_len)
         if (iost .ne. NF_NOERR) then
             flf%calendar='none'
-            aux_len = 4
             write(*,*) ' --> could not find/read calendar attribute in the time axis'
             write(*,*) '     of the forcing file (Is this right?). I assume there is'
             write(*,*) '     none and proceed in CORE2 style without leap years!'


### PR DESCRIPTION
Solve special problem here: Ozgurs wants to repeat only a part of the JRA55 forcing periodically (e.g repeat the period 1958-1967) through re-linking of the original forcing files. 
 
- 1st problem: This will mess up the leap year cycle of the entire forcing, so the model has to run best without leapyear although the calendar  system of the forcing remains gregorian (so with leapyear)  This can be solved by makeing the treatment of the time-axes depending on the calendar of the forcing files, not alone from the include_fleapyear flag

- 2nd problem: In the case of a periodically repeated forcing period through re-linking of the original files it happens that e.g. the year 1968 is linked to the file 1958. In that case the time axis of the 1968 forcing file remains that of the original 1958 file. So the time axis needs to be resetted properly to the right year they are supposed to represent 