### PR TITLE
Fix circular module dependency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,13 +126,14 @@ if(USE_ICEPACK)
                               ${src_home}/icepack_drivers/Icepack/columnphysics/*.F90)
    list(APPEND sources_Fortran ${sources_ice_pack})
 elseif(ENABLE_IFS_INTERFACE) # ICEPACK + IFS_INTERFACE NOT SUPPORTED (YET)
+   if(ENABLE_MULTIO)
+      list(APPEND sources_Fortran ${src_home}/ifs_interface/iom.F90)
+   endif()
+
    list(APPEND sources_Fortran ${src_home}/ifs_interface/ifs_interface.F90
                                ${src_home}/ifs_interface/ifs_modules.F90
                                ${src_home}/ifs_interface/ifs_notused.F90
                                ${src_home}/ifs_interface/mpp_io.F90)
-endif()
-if(ENABLE_MULTIO)
-   list(APPEND sources_Fortran ${src_home}/ifs_interface/iom.F90)
 endif()
 
 file(GLOB sources_C ${src_home}/*.c)

--- a/src/ifs_interface/iom.F90
+++ b/src/ifs_interface/iom.F90
@@ -16,10 +16,13 @@ MODULE iom
     TYPE(multio_handle) :: mio_handle
     INTEGER(8), PRIVATE :: mio_parent_comm
 
+    PUBLIC iom_enable_multio
     PUBLIC iom_initialize, iom_init_server, iom_finalize
     PUBLIC iom_send_fesom_domains
     PUBLIC iom_field_request, iom_send_fesom_data
     PUBLIC iom_flush
+
+    LOGICAL :: lnomultio = .TRUE._1
 
     PRIVATE ctl_stop
     !!----------------------------------------------------------------------
@@ -45,6 +48,11 @@ MODULE iom
 
 CONTAINS
 
+    SUBROUTINE iom_enable_multio()
+        IMPLICIT NONE
+        lnomultio = .FALSE._1
+    END SUBROUTINE
+
     SUBROUTINE multio_custom_error_handler(context, err, info)
         USE mpi
 
@@ -65,7 +73,6 @@ CONTAINS
 
     SUBROUTINE iom_initialize(client_id, local_comm, return_comm, global_comm )
         USE mpi
-        USE mpp_io, ONLY: lnomultio
 
         IMPLICIT NONE
         CHARACTER(LEN=*), INTENT(IN)      :: client_id
@@ -152,8 +159,6 @@ CONTAINS
     END SUBROUTINE iom_initialize
 
     SUBROUTINE iom_finalize()
-        USE mpp_io, ONLY: lnomultio
-
         IMPLICIT NONE
         INTEGER :: err
 
@@ -171,8 +176,6 @@ CONTAINS
     END SUBROUTINE iom_finalize
 
     SUBROUTINE iom_init_server(server_comm)
-        USE mpp_io, ONLY: lnomultio
-
         IMPLICIT NONE
         INTEGER, INTENT(IN) :: server_comm
         type(multio_configuration)        :: conf_ctx
@@ -242,7 +245,6 @@ CONTAINS
     END SUBROUTINE iom_init_server
 
     SUBROUTINE iom_send_fesom_domains(partit, mesh)
-        USE mpp_io, ONLY: lnomultio
         USE MOD_MESH
         USE MOD_PARTIT
 
@@ -346,7 +348,6 @@ CONTAINS
     END SUBROUTINE iom_send_fesom_domains
 
     SUBROUTINE iom_send_fesom_data(data)
-        USE mpp_io, ONLY: lnomultio
         USE g_clock
         USE g_config, only: MeshId
         IMPLICIT NONE
@@ -441,8 +442,6 @@ CONTAINS
     END SUBROUTINE
 
     SUBROUTINE iom_flush(domain, step)
-        USE mpp_io, ONLY: lnomultio
-
         IMPLICIT NONE
 
         CHARACTER(6), INTENT(IN)                :: domain

--- a/src/ifs_interface/mpp_io.F90
+++ b/src/ifs_interface/mpp_io.F90
@@ -78,9 +78,11 @@ MODULE mpp_io
         WRITE(*,namio)
         CLOSE(10)
 
+#if defined(__MULTIO)
         IF (ntask_multio /= 0) THEN
             CALL iom_enable_multio()
         ENDIF
+#endif
 
         IF ( ntask_xios + ntask_multio == 0 ) THEN
             iicomm = mpi_comm_world

--- a/src/ifs_interface/mpp_io.F90
+++ b/src/ifs_interface/mpp_io.F90
@@ -7,7 +7,7 @@
 
 MODULE mpp_io
 #if defined(__MULTIO)        
-    USE iom, only : iom_initialize, iom_init_server, iom_finalize
+    USE iom, only : iom_enable_multio, iom_initialize, iom_init_server, iom_finalize
 #endif
     IMPLICIT NONE
     PRIVATE
@@ -20,7 +20,6 @@ MODULE mpp_io
     INTEGER :: ntask_multio  = 0
     INTEGER :: ntask_xios    = 0
     LOGICAL, PUBLIC :: lioserver, lmultioserver, lmultiproc
-    LOGICAL, PUBLIC :: lnomultio = .TRUE._1
     INTEGER :: ntask_notio
     INTEGER, SAVE :: mppallrank, mppallsize, mppiorank, mppiosize
     INTEGER, SAVE :: mppmultiorank, mppmultiosize
@@ -80,7 +79,7 @@ MODULE mpp_io
         CLOSE(10)
 
         IF (ntask_multio /= 0) THEN
-            lnomultio = .FALSE._1
+            CALL iom_enable_multio()
         ENDIF
 
         IF ( ntask_xios + ntask_multio == 0 ) THEN


### PR DESCRIPTION
Previous commit introduced a circular dependency between the iom.F90 and the mpp_io.F90 modules. 
This fixes the issue and restores encapsulation of multio state variables.