### PR TITLE
setting default for tracers/AB_order = 2 in oce_setup_step.F90

### DIFF
--- a/src/oce_setup_step.F90
+++ b/src/oce_setup_step.F90
@@ -293,7 +293,7 @@ SUBROUTINE tracer_init(tracers, partit, mesh)
     integer        :: num_tracers
     logical        :: i_vert_diff, smooth_bh_tra
     real(kind=WP)  :: gamma0_tra, gamma1_tra, gamma2_tra
-    integer        :: AB_order
+    integer        :: AB_order = 2
     namelist /tracer_listsize/ num_tracers
     namelist /tracer_list    / nml_tracer_list
     namelist /tracer_general / smooth_bh_tra, gamma0_tra, gamma1_tra, gamma2_tra, i_vert_diff, AB_order


### PR DESCRIPTION
Hey folks! We've reworked AB_tracer. Now it initializes by default, so even if you forget to set it in the namelist, it won't run wild with random values. We've identified the chaos monster!