### PR TITLE
Refactoring improve4ogurses calendar new

### DIFF
--- a/src/gen_modules_clock.F90
+++ b/src/gen_modules_clock.F90
@@ -196,11 +196,18 @@ contains
     flag=0
 
     if(.not.include_fleapyear) return
+    call is_fleapyr(year, flag)
+  end subroutine check_fleapyr
 
+  subroutine is_fleapyr(year, flag)
+    implicit none
+    integer, intent(in) :: year      
+    integer, intent(out):: flag
+    flag=0
     if ((mod(year,4)==0.and.mod(year,100)/=0) .or. mod(year,400)==0) then
        flag=1
     endif
-  end subroutine check_fleapyr
+  end subroutine is_fleapyr
   !
   !----------------------------------------------------------------------------
   !

--- a/src/gen_surface_forcing.F90
+++ b/src/gen_surface_forcing.F90
@@ -171,6 +171,8 @@ MODULE g_sbf
       character(len = MAX_PATH)                 :: file_name ! file name
       character(len = 34)                  :: var_name  ! variable name in the NetCDF file
       character(len = 34)                  :: calendar  ! variable name in the NetCDF file
+      integer                              :: year_orig ! year according to original time axis 
+      integer                              :: year      ! year according to filename year!=year_orig in case of linked forcing 
       integer                              :: nc_Nlon
       integer                              :: nc_Nlat
       integer                              :: nc_Ntime
@@ -215,6 +217,7 @@ CONTAINS
       integer                               :: ierror              ! return error code
       character(len=20)                     :: aux_calendar
       integer                               :: aux_len
+      integer                               :: yyyy, mm, dd
 
       !open file
       if (partit%mype==0) then
@@ -371,7 +374,8 @@ CONTAINS
       call check_nferr(iost,flf%file_name,partit)
       
       ! digg for calendar attribute in time axis variable
-      if (partit%mype==0 .and. use_flpyrcheck) then
+!PS       if (partit%mype==0 .and. use_flpyrcheck) then
+      if (partit%mype==0) then
          iost = nf_inq_attlen(ncid, id_time,'calendar',aux_len)
          iost = nf_get_att(ncid, id_time,'calendar',aux_calendar)
          aux_calendar = aux_calendar(1:aux_len)
@@ -385,7 +389,10 @@ CONTAINS
             flf%calendar=lowercase(aux_calendar)
             write(*,*) ' --> found calendar attr. in time axis: |',trim(flf%calendar),'|' 
          end if 
-         
+      end if   
+      call MPI_BCast(flf%calendar, len(flf%calendar), MPI_CHARACTER, 0, partit%MPI_COMM_FESOM, ierror)
+      
+      if (partit%mype==0 .and. use_flpyrcheck) then
          ! check for calendar and include_fleapyear consistency
          if ((trim(flf%calendar).eq.'none')   .or. &
              (trim(flf%calendar).eq.'noleap') .or. &
@@ -446,8 +453,41 @@ CONTAINS
          end if 
       end if
       
-    ! transform time axis accorcing to calendar and include_fleapyear=.true./.false. flag  
-      flf%nc_time = flf%nc_time / nm_nc_freq + julday(nm_nc_iyear,nm_nc_imm,nm_nc_idd)
+!PS     ! transform time axis accorcing to calendar and include_fleapyear=.true./.false. flag  
+!PS       flf%nc_time = flf%nc_time / nm_nc_freq + julday(nm_nc_iyear,nm_nc_imm,nm_nc_idd)
+      ! transfer time-axis of the forcing files in units of days 
+      flf%nc_time = flf%nc_time / nm_nc_freq
+
+      ! add the original reference period (1900-01-01(JRA55) to 0000-01-01)  of the 
+      ! forcing file in units of days --> new reference period 0001-01-01
+      flf%nc_time = flf%nc_time + julday(nm_nc_iyear, nm_nc_imm, nm_nc_idd, trim(flf%calendar))
+
+      ! Solve special problem here: Ozgurs wants to repeat only part of the JRA55
+      ! forcing periodically (e.g repeat the period 1958-1967) through re-linking 
+      ! of the original forcing files. 
+      ! 
+      ! 1st problem: This will mess up the leap year cycle of the entire forcing, so 
+      !              the model has to run best without leapyear although the calendar 
+      !              system of the forcing remains gregorian (so with leapyear)
+      !              This can be solved by makeing the treatment of the time-axes
+      !              depending on the calendar of the forcing files, not alone from
+      !              the include_fleapyear flag
+      !               
+      ! 2nd problem: In the case of a periodically repeated forcing period through
+      !              re-linking of the original files it happens that e.g. the year
+      !              1968 is linked to the file 1958 in that case time axis of the 
+      !              1968 forcing file remains that of the original 1958 file. So
+      !              axis needs to be resetted properly            
+      call calendar_date(int(flf%nc_time(1)), yyyy, mm, dd, trim(flf%calendar))
+
+      ! remove the reference period of the original file
+      flf%year_orig = yyyy
+      flf%nc_time   = flf%nc_time - julday(yyyy   , 1, 1, trim(flf%calendar))
+
+      ! reset the reference period to the proper year it should represent
+      flf%year      = yearnew
+      flf%nc_time   = flf%nc_time + julday(yearnew, 1, 1, trim(flf%calendar))
+      
       if (nm_nc_tmid/=1) then
          if (flf%nc_Ntime > 1) then
             do i = 1, flf%nc_Ntime-1
@@ -533,14 +573,16 @@ CONTAINS
       if (l_cloud) sbc_flfi(i_cloud)%var_name=ADJUSTL(trim(nm_cloud_var))
    END SUBROUTINE nc_sbc_ini_fillnames
 
-   SUBROUTINE nc_sbc_ini(rdate, partit, mesh)
+!PS    SUBROUTINE nc_sbc_ini(rdate, partit, mesh)
+   SUBROUTINE nc_sbc_ini(partit, mesh)
       !!---------------------------------------------------------------------
       !! ** Purpose : initialization of ocean forcing from NETCDF file
       !!----------------------------------------------------------------------
 
       IMPLICIT NONE
-      real(wp),intent(in) :: rdate ! initialization date
-      integer             :: idate
+!PS       real(wp),intent(in) :: rdate ! initialization date
+      real(wp)            :: rdate ! initialization date
+!PS       integer             :: idate
       integer             :: yyyy,mm,dd
 
       integer                  :: i
@@ -566,13 +608,20 @@ CONTAINS
       warn     = 0
 
       ! get ini year; Fill names of sbc_flfi
-      idate=int(rdate)
-      call calendar_date(idate,yyyy,mm,dd)
-      call nc_sbc_ini_fillnames(yyyy)
+!PS       idate=int(rdate)
+!PS       call calendar_date(idate,yyyy,mm,dd)
+!PS       call nc_sbc_ini_fillnames(yyyy)
+      call nc_sbc_ini_fillnames(yearnew)
+      
       ! we assume that all NetCDF files have identical grid and time variable
       do fld_idx = 1, i_totfl
          call nc_readTimeGrid(sbc_flfi(fld_idx), partit)
       end do
+      
+      ! compute model rdate at initial moment
+      rdate = real(julday(yearnew, 1, 1, sbc_flfi(1)%calendar ))
+      rdate = rdate+real(daynew-1,WP)+timenew/86400._WP 
+      
       if (lfirst) then
       do fld_idx = 1, i_totfl
          flf=>sbc_flfi(fld_idx)
@@ -621,12 +670,17 @@ CONTAINS
          call getcoeffld(fld_idx, rdate, partit, mesh)
       end do
          ! interpolate in time
+         
+      if (partit%mype==0) then 
+        write(*,*) 'sbc_do --> mstep:',mstep, ' rdate=', rdate
+      end if 
       call data_timeinterp(rdate, partit)
    END SUBROUTINE nc_sbc_ini
 
    SUBROUTINE getcoeffld(fld_idx, rdate, partit, mesh)
       use forcing_provider_async_module
       use io_netcdf_workaround_module
+      use g_clock
       !!---------------------------------------------------------------------
       !!                    ***  ROUTINE getcoeffld ***
       !!
@@ -656,10 +710,12 @@ CONTAINS
 !     real(wp), allocatable, dimension(:,:)  :: sbcdata1,sbcdata2
       real(wp)             :: data1,data2
       real(wp)             :: delta_t   ! time(t_indx) - time(t_indx+1)
-
+      real(wp)             :: rdatep1 ! time(t_indx) - time(t_indx+1)
+      
       integer              :: elnodes(4) !4 nodes from one element
       integer              :: numnodes   ! nu,ber of nodes in elem (3 for triangle, 4 for ... )
-      integer              :: yyyy,mm,dd
+!PS       integer              :: yyyy,mm,dd
+      integer              :: yyyy, mm, dd, flag_flpyr=0
       integer              :: ierror              ! return error code
       integer,   pointer   :: nc_Ntime, nc_Nlon, nc_Nlat, t_indx, t_indx_p1
       character(len=MAX_PATH), pointer   :: file_name
@@ -701,8 +757,51 @@ CONTAINS
       now_date = rdate
       call binarysearch(nc_Ntime,nc_time,now_date,t_indx)
       if ( (t_indx < nc_Ntime) .and. (t_indx > 0) ) then
-         t_indx_p1 = t_indx + 1
-         delta_t   = nc_time(t_indx_p1) - nc_time(t_indx)
+!PS          t_indx_p1 = t_indx + 1
+!PS          delta_t   = nc_time(t_indx_p1) - nc_time(t_indx)
+      
+        t_indx_p1 = t_indx + 1   
+        delta_t   = nc_time(t_indx_p1) - nc_time(t_indx)
+
+        !_______________________________________________________________________
+        ! if include_fleapyear==.False. and forcing file of year contains a fleap
+        ! year, try to step over the 29.Feb so it is not used for temporal 
+        ! interpolation
+        if ((include_fleapyear .eqv. .False.) .and.  &
+            ((trim(sbc_flfi(fld_idx)%calendar).eq.'julian'             ) .or. &
+             (trim(sbc_flfi(fld_idx)%calendar).eq.'gregorian'          ) .or. &
+             (trim(sbc_flfi(fld_idx)%calendar).eq.'proleptic_gregorian') .or. &
+             (trim(sbc_flfi(fld_idx)%calendar).eq.'standard'           ))) then
+
+            ! Need to know what is the original year of the forcing file. In case of 
+            ! ozgures problem where forcing files get re-linked it can happen that 
+            ! non-leapyears are represented by a leapyear file thus the indexing 
+            ! and counting needs to be adapted
+            ! --> sbc_flfi(fld_idx)%year_orig ... year according to original time axis 
+            ! --> sbc_flfi(fld_idx)%year      ... year according to filename 
+            call is_fleapyr(sbc_flfi(fld_idx)%year_orig, flag_flpyr)
+
+            ! here skip the 29.Feb in the counting 
+            ! go from 28.Feb directly to 1.Mar for the case the forcing file contains 
+            ! a leapyear.
+            if (flag_flpyr==1) then 
+                ! skip the 29. Feb if the model finds one in the forcing data
+                call calendar_date(int(nc_time(t_indx_p1)), yyyy, mm, dd, sbc_flfi(fld_idx)%calendar )
+                if (mm==2 .and. dd==29) then 
+                    ! --> go directly to the first time slice what represents the
+                    !     1. March
+                    rdatep1 = real(julday(yearnew,1,1, sbc_flfi(fld_idx)%calendar ),WP)
+                    rdatep1 = rdatep1+real(60,WP) + delta_t*0.5_WP
+                    call binarysearch(nc_Ntime, nc_time, rdatep1, t_indx_p1)
+                    delta_t   = nc_time(t_indx_p1) - nc_time(t_indx)
+                    if (partit%mype==0 .and. fld_idx==1) then 
+                        call calendar_date(int(nc_time(t_indx_p1)), yyyy, mm, dd, sbc_flfi(fld_idx)%calendar )
+                        write(*,*) ' --> jump over 29. Feb, now : yy, mm, dd  = ', yyyy, mm, dd            
+                    end if 
+                end if 
+            end if 
+        end if
+
       elseif (t_indx > 0) then ! NO extrapolation to future
          t_indx    = nc_Ntime
          t_indx_p1 = t_indx
@@ -914,8 +1013,8 @@ CONTAINS
       !!----------------------------------------------------------------------
       IMPLICIT NONE
 
-      integer            :: idate ! initialization date
-      real(wp)           :: rdate ! initialization date
+!PS       integer            :: idate ! initialization date
+!PS       real(wp)           :: rdate ! initialization date
       integer            :: iost  ! I/O status
       integer            :: sbc_alloc                   !: allocation status
 
@@ -949,10 +1048,10 @@ CONTAINS
       READ( nm_sbc_unit, nml=nam_sbc, iostat=iost )
       close( nm_sbc_unit )
       
-      if (mype==0) write(*,*) "Start: Ocean forcing initialization."
-      rdate = real(julday(yearnew,1,1))
-      rdate = rdate+real(daynew-1,WP)+timenew/86400._WP
-      idate = int(rdate)
+!PS       if (mype==0) write(*,*) "Start: Ocean forcing initialization."
+!PS       rdate = real(julday(yearnew,1,1))
+!PS       rdate = rdate+real(daynew-1,WP)+timenew/86400._WP
+!PS       idate = int(rdate)
 
       if (mype==0) then
          write(*,*) "Start: Ocean forcing initialization."
@@ -1081,7 +1180,11 @@ CONTAINS
       emp          = 0.0_WP
       qsr          = 0.0_WP
       ALLOCATE(sbc_flfi(i_totfl))
-      call nc_sbc_ini(rdate, partit, mesh)
+      
+      !_________________________________________________________________________
+      ! initialise interpolations coefficients
+!PS       call nc_sbc_ini(rdate, partit, mesh)
+      call nc_sbc_ini(partit, mesh)
       !==========================================================================
 #endif
       ! runoff
@@ -1121,7 +1224,8 @@ CONTAINS
       real(wp)     :: rdate ! date
       integer      :: fld_idx, i
       logical      :: do_rotation_wind, do_rotation_stre, force_newcoeff, update_monthly_flag
-      integer      :: yyyy, dd, mm
+!PS       integer      :: yyyy, dd, mm
+      integer      :: yyyy, dd, mm, flag_flpyr=0
       integer,   pointer   :: nc_Ntime, t_indx, t_indx_p1
       real(wp),  pointer   :: nc_time(:)
       character(len=MAX_PATH)               :: filename
@@ -1135,10 +1239,13 @@ CONTAINS
 
       force_newcoeff=.false.
       if (yearnew/=yearold) then
-         rdate = real(julday(yearnew,1,1),WP)
-         call calendar_date(int(rdate),yyyy,dd,mm)
+!PS          rdate = real(julday(yearnew,1,1),WP)
+!PS          call calendar_date(int(rdate),yyyy,dd,mm)
+!PS          ! use next set of forcing files
+!PS          call nc_sbc_ini_fillnames(yyyy)
          ! use next set of forcing files
-         call nc_sbc_ini_fillnames(yyyy)
+         call nc_sbc_ini_fillnames(yearnew)
+         
          ! we assume that all NetCDF files have identical grid and time variable
          do fld_idx = 1, i_totfl
             call nc_readTimeGrid(sbc_flfi(fld_idx), partit)            
@@ -1147,12 +1254,44 @@ CONTAINS
       end if
       
 
-      rdate = real(julday(yearnew,1,1),WP)
-      rdate = rdate+real(daynew-1,WP)+timenew/86400._WP-dt/86400._WP/2._WP
+!PS       rdate = real(julday(yearnew,1,1),WP)
+!PS       rdate = rdate+real(daynew-1,WP)+timenew/86400._WP-dt/86400._WP/2._WP
       do_rotation_wind=.false.
       do_rotation_stre=.false.
 
       do fld_idx = 1, i_totfl
+        ! compute model rdate based on the calendar option of the forcing file so
+        ! match up
+        rdate = real(julday(yearnew,1,1, sbc_flfi(fld_idx)%calendar ),WP)
+        rdate = rdate+real(daynew-1,WP)+timenew/86400._WP-dt/86400._WP/2._WP
+
+        !_______________________________________________________________________
+        ! special case if include_fleapyear==False but the calendar of the forcing 
+        ! is julian or gregorian, so has the potential to contain a fleapyear value 
+        if ((include_fleapyear .eqv. .False.) .and.  &
+            ((trim(sbc_flfi(fld_idx)%calendar).eq.'julian'             ) .or. &
+             (trim(sbc_flfi(fld_idx)%calendar).eq.'gregorian'          ) .or. &
+             (trim(sbc_flfi(fld_idx)%calendar).eq.'proleptic_gregorian') .or. &
+             (trim(sbc_flfi(fld_idx)%calendar).eq.'standard'           ))) then
+
+            ! Need to know what is the original year of the forcing file. In case of 
+            ! ozgures problem where forcing files get re-linked it can happen that 
+            ! non-leapyears are represented by a leapyear file thus the indexing 
+            ! and counting needs to be adapted
+            ! --> sbc_flfi(fld_idx)%year_orig ... year according to original time axis 
+            ! --> sbc_flfi(fld_idx)%year      ... year according to filename 
+            call is_fleapyr(sbc_flfi(fld_idx)%year_orig, flag_flpyr)
+
+            ! here skip the 29.Feb (28 Feb is the 59 day in year) in the counting 
+            ! go from 28.Feb directly to 1.Mar for the case the forcing file contains 
+            ! a leapyear.
+            if (flag_flpyr==1 .and. daynew>59) then 
+                rdate = real(julday(yearnew,1,1, sbc_flfi(fld_idx)%calendar ),WP)
+                rdate = rdate+real(daynew-1+1,WP)+timenew/86400._WP-dt/86400._WP/2._WP
+            end if 
+        end if 
+
+        !_______________________________________________________________________ 
          nc_time  =>sbc_flfi(fld_idx)%nc_time
          t_indx_p1=>sbc_flfi(fld_idx)%t_indx_p1
          t_indx   =>sbc_flfi(fld_idx)%t_indx
@@ -1247,13 +1386,16 @@ CONTAINS
 
      end if
 
-
+      if (partit%mype==0) then 
+        write(*,*) 'sbc_do --> mstep:',mstep, ' rdate=', rdate
+      end if 
       ! interpolate in time
       call data_timeinterp(rdate, partit)
    END SUBROUTINE sbc_do
 
 
-   FUNCTION julday(yyyy,mm,dd)
+!PS    FUNCTION julday(yyyy,mm,dd)
+   FUNCTION julday(yyyy, mm, dd, calendar)
 
    IMPLICIT NONE
       integer, INTENT(IN) :: mm, dd, yyyy
@@ -1264,11 +1406,18 @@ CONTAINS
       integer, PARAMETER  :: IGREG=15+31*(10+12*1582)
       ! Gregorian Calendar adopted Oct. 15, 1582.
       integer             :: ja,jm,jy
+      character(len=*) :: calendar
+      
       if (y_perpetual) then !to work with COREI forcing
          julday=0
          return
       end if
-      if (include_fleapyear) then
+!PS       if (include_fleapyear) then
+      !if (include_fleapyear) then
+      if ((trim(calendar).eq.'julian'             ) .or. &
+          (trim(calendar).eq.'gregorian'          ) .or. &
+          (trim(calendar).eq.'proleptic_gregorian') .or. &
+          (trim(calendar).eq.'standard'           )) then
          jy = yyyy
          if (jy == 0) STOP 'julday: there is no year zero'
          if (jy < 0) jy=jy+1
@@ -1290,7 +1439,8 @@ CONTAINS
    END FUNCTION julday
 
 
-   SUBROUTINE calendar_date(julian,yyyy,mm,dd)
+!PS    SUBROUTINE calendar_date(julian,yyyy,mm,dd)
+   SUBROUTINE calendar_date(julian, yyyy, mm, dd, calendar)
 
 !  Converts a Julian day to a calendar date (year, month and day). Numerical Recipes
    IMPLICIT NONE
@@ -1301,9 +1451,15 @@ CONTAINS
       integer, parameter :: IGREG=2299161
       integer            :: ja,jb,jc,jd,je
       real(wp)           :: x
+      character(len = *) :: calendar
+      
       !
       !-----------------------------------------------------------------------
-      if (include_fleapyear) then
+!PS       if (include_fleapyear) then
+      if ((trim(calendar).eq.'julian'             ) .or. &
+          (trim(calendar).eq.'gregorian'          ) .or. &
+          (trim(calendar).eq.'proleptic_gregorian') .or. &
+          (trim(calendar).eq.'standard'           )) then
          if (julian >= IGREG ) then
             x = ((julian-1867216)-0.25_WP)/36524.25_WP
             ja = julian+1+int(x)-int(0.25*x)


### PR DESCRIPTION
- redo avoid leapyear problem of ozgures 
- Solve special problem here: Ozgurs wants to repeat only a part of the JRA55 forcing periodically (e.g repeat the period 1958-1967) through re-linking of the original forcing files.

    1st problem: This will mess up the leap year cycle of the entire forcing, so the model has to run best without leapyear although the calendar system of the forcing remains gregorian (so with leapyear) This can be solved by makeing the treatment of the time-axes depending on the calendar of the forcing files, not alone from the include_fleapyear flag

    2nd problem: In the case of a periodically repeated forcing period through re-linking of the original files it happens that e.g. the year 1968 is linked to the file 1958. In that case the time axis of the 1968 forcing file remains that of the original 1958 file. So the time axis needs to be resetted properly to the right year they are supposed to represent

-  did this to ensure  their isnt a bug in it, and results remain identical to the default test case 

- year 1958 (non-leapyear)
![image](https://github.com/user-attachments/assets/25a3a064-3153-4e09-af7f-86959a843b40)

- year 1960 (1st leapyear, flpyrF is with out 29. Feb 1960)
![image](https://github.com/user-attachments/assets/010fc75d-9803-4e5e-9c38-089423650f19)
