### PR TITLE
Revert "update mpif.h to use mpi"

### DIFF
--- a/src/MOD_PARTIT.F90
+++ b/src/MOD_PARTIT.F90
@@ -5,12 +5,12 @@ USE O_PARAM
 USE, intrinsic :: ISO_FORTRAN_ENV, only : int32
 USE MOD_WRITE_BINARY_ARRAYS
 USE MOD_READ_BINARY_ARRAYS
-USE mpi
 #if defined(_OPENMP)
     USE OMP_LIB
 #endif
 IMPLICIT NONE
 SAVE
+include 'mpif.h'
 integer, parameter   :: MAX_LAENDERECK=16
 integer, parameter   :: MAX_NEIGHBOR_PARTITIONS=32
 

--- a/src/fortran_utils.F90
+++ b/src/fortran_utils.F90
@@ -1,6 +1,5 @@
  ! synopsis: basic Fortran utilities, no MPI, dependencies only to INTRINSIC modules
 module fortran_utils
-  use mpi
   implicit none
 
 contains
@@ -49,6 +48,7 @@ contains
     integer mype
     integer npes
     integer mpierr
+    include 'mpif.h'
 
     call MPI_Comm_Rank(mpicomm, mype, mpierr)
     call MPI_Comm_Size(mpicomm, npes, mpierr)

--- a/src/gen_modules_partitioning.F90
+++ b/src/gen_modules_partitioning.F90
@@ -113,7 +113,7 @@ subroutine par_ex(COMM, mype, abort)       ! finalizes MPI
 #ifndef __oasis
   if (present(abort)) then
      if (mype==0) write(*,*) 'Run finished unexpectedly!'
-     call MPI_ABORT(MPI_COMM_WORLD, 1, error)
+     call MPI_ABORT(MPI_COMM_WORLD, 1 )
   else
           ! TODO: this is where fesom standalone, ifsinterface etc get to 
           !1. there no abort actually even when model calls abort, and barrier may hang
@@ -580,3 +580,4 @@ if (res /= 0 ) then
     call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
 endif
 end subroutine status_check
+

--- a/src/ifs_interface/mpp_io.F90
+++ b/src/ifs_interface/mpp_io.F90
@@ -6,7 +6,6 @@
 !-----------------------------------------------------
 
 MODULE mpp_io
-    USE mpi
 #if defined(__MULTIO)        
     USE iom, only : iom_enable_multio, iom_initialize, iom_init_server, iom_finalize
 #endif
@@ -31,6 +30,7 @@ MODULE mpp_io
     
     SUBROUTINE mpp_io_init( iicomm,  lio, irequired, iprovided, lmpi1 ) 
 
+        INCLUDE "mpif.h"
         INTEGER, INTENT(INOUT) :: iicomm
         LOGICAL, INTENT(INOUT) :: lio
         INTEGER, INTENT(INOUT) :: irequired, iprovided
@@ -126,6 +126,7 @@ MODULE mpp_io
         INTEGER :: icode, ierr, icolor, iicommx, iicommm, iicommo
         INTEGER :: ji,inum
         LOGICAL :: lcompp
+        INCLUDE "mpif.h"
 
         ! Construct multio server communicator
 

--- a/src/io_restart.F90
+++ b/src/io_restart.F90
@@ -12,7 +12,6 @@ MODULE io_RESTART
   use MOD_PARTIT
   use MOD_PARSUP
   use fortran_utils
-  use mpi
 #if defined(__recom)
   use recom_glovar
   use recom_config
@@ -772,6 +771,7 @@ subroutine read_all_raw_restarts(mpicomm, mype)
   integer fileunit
   integer status
   integer mpierr
+  include 'mpif.h'
 
   if(mype == RAW_RESTART_METADATA_RANK) then
     ! read metadata info for the raw restart
@@ -860,6 +860,7 @@ end subroutine
 !
 !_______________________________________________________________________________
 subroutine read_restart(path, filegroup, mpicomm, mype)
+  include 'mpif.h'        
   character(len=*), intent(in) :: path
   type(restart_file_group), intent(inout) :: filegroup
   integer, intent(in) :: mpicomm
@@ -1003,6 +1004,7 @@ end subroutine
 !     integer mype
 !     integer npes
 !     integer mpierr
+!     include 'mpif.h'
 !   
 !     call MPI_Comm_Rank(mpicomm, mype, mpierr)
 !     call MPI_Comm_Size(mpicomm, npes, mpierr)

--- a/src/temp/MOD_PARTIT.F90
+++ b/src/temp/MOD_PARTIT.F90
@@ -5,9 +5,9 @@ USE O_PARAM
 USE, intrinsic :: ISO_FORTRAN_ENV
 USE MOD_WRITE_BINARY_ARRAYS
 USE MOD_READ_BINARY_ARRAYS
-USE mpi
 IMPLICIT NONE
 SAVE
+include 'mpif.h'
 integer, parameter   :: MAX_LAENDERECK=16
 integer, parameter   :: MAX_NEIGHBOR_PARTITIONS=32
 


### PR DESCRIPTION
This reverts commit 0e5bfdc1b402347cc1b707cfb6396142e8aba447. @ackerlar found that with the recent MPI changes, his AWI-ESM2 setup crashes on compile time. @sebastianbeyer is on holiday. I suggest we revert until things can be fixed. 