### PR TITLE
Update mpi again

### DIFF
--- a/src/MOD_PARTIT.F90
+++ b/src/MOD_PARTIT.F90
@@ -5,12 +5,12 @@ USE O_PARAM
 USE, intrinsic :: ISO_FORTRAN_ENV, only : int32
 USE MOD_WRITE_BINARY_ARRAYS
 USE MOD_READ_BINARY_ARRAYS
+USE mpi
 #if defined(_OPENMP)
     USE OMP_LIB
 #endif
 IMPLICIT NONE
 SAVE
-include 'mpif.h'
 integer, parameter   :: MAX_LAENDERECK=16
 integer, parameter   :: MAX_NEIGHBOR_PARTITIONS=32
 

--- a/src/cpl_driver.F90
+++ b/src/cpl_driver.F90
@@ -57,7 +57,7 @@ module cpl_driver
   integer                    :: localRank      ! local MPI rank
   integer                    :: localSize      ! local MPI size
   integer                    :: localComm      ! local MPI size
-  logical                    :: commRank       ! true for ranks doing OASIS communication
+  integer                    :: commRank
   integer                    :: comp_id        ! id returned by oasis_init_comp
 
   logical, save              :: oasis_was_initialized
@@ -774,11 +774,11 @@ include "associate_mesh_ass.h"
 !------------------------------------------------------------------
 
    call oasis_enddef(ierror)
-   if (commRank) print *, 'fesom oasis_enddef: COMPLETED'
+   if (ierror .eq. oasis_ok) print *, 'fesom oasis_enddef: COMPLETED'
 #ifndef __oifs
-   if (commRank) print *, 'FESOM: calling exchange_roots'
+   if (ierror .eq. oasis_ok) print *, 'FESOM: calling exchange_roots'
    call exchange_roots(source_root, target_root, 1, partit%MPI_COMM_FESOM, MPI_COMM_WORLD)
-   if (commRank) print *, 'FESOM source/target roots: ', source_root, target_root
+   if (ierror .eq. oasis_ok) print *, 'FESOM source/target roots: ', source_root, target_root
 #endif
 
    ! WAS VOM FOLGENDEN BRAUCHE ICH NOCH ??? 

--- a/src/cpl_driver.F90
+++ b/src/cpl_driver.F90
@@ -16,6 +16,7 @@ module cpl_driver
   use g_config, only : dt, use_icebergs, lwiso
   use o_param,  only : rad
   USE MOD_PARTIT
+  use mpi
   implicit none
   save   
   !

--- a/src/fortran_utils.F90
+++ b/src/fortran_utils.F90
@@ -1,5 +1,6 @@
  ! synopsis: basic Fortran utilities, no MPI, dependencies only to INTRINSIC modules
 module fortran_utils
+  use mpi
   implicit none
 
 contains
@@ -48,7 +49,6 @@ contains
     integer mype
     integer npes
     integer mpierr
-    include 'mpif.h'
 
     call MPI_Comm_Rank(mpicomm, mype, mpierr)
     call MPI_Comm_Size(mpicomm, npes, mpierr)

--- a/src/gen_modules_partitioning.F90
+++ b/src/gen_modules_partitioning.F90
@@ -113,7 +113,7 @@ subroutine par_ex(COMM, mype, abort)       ! finalizes MPI
 #ifndef __oasis
   if (present(abort)) then
      if (mype==0) write(*,*) 'Run finished unexpectedly!'
-     call MPI_ABORT(MPI_COMM_WORLD, 1 )
+     call MPI_ABORT(MPI_COMM_WORLD, 1, error)
   else
           ! TODO: this is where fesom standalone, ifsinterface etc get to 
           !1. there no abort actually even when model calls abort, and barrier may hang
@@ -580,4 +580,3 @@ if (res /= 0 ) then
     call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
 endif
 end subroutine status_check
-

--- a/src/ifs_interface/mpp_io.F90
+++ b/src/ifs_interface/mpp_io.F90
@@ -6,6 +6,7 @@
 !-----------------------------------------------------
 
 MODULE mpp_io
+    USE mpi
 #if defined(__MULTIO)        
     USE iom, only : iom_enable_multio, iom_initialize, iom_init_server, iom_finalize
 #endif
@@ -30,7 +31,6 @@ MODULE mpp_io
     
     SUBROUTINE mpp_io_init( iicomm,  lio, irequired, iprovided, lmpi1 ) 
 
-        INCLUDE "mpif.h"
         INTEGER, INTENT(INOUT) :: iicomm
         LOGICAL, INTENT(INOUT) :: lio
         INTEGER, INTENT(INOUT) :: irequired, iprovided
@@ -126,7 +126,6 @@ MODULE mpp_io
         INTEGER :: icode, ierr, icolor, iicommx, iicommm, iicommo
         INTEGER :: ji,inum
         LOGICAL :: lcompp
-        INCLUDE "mpif.h"
 
         ! Construct multio server communicator
 

--- a/src/io_restart.F90
+++ b/src/io_restart.F90
@@ -12,6 +12,7 @@ MODULE io_RESTART
   use MOD_PARTIT
   use MOD_PARSUP
   use fortran_utils
+  use mpi
 #if defined(__recom)
   use recom_glovar
   use recom_config
@@ -771,7 +772,6 @@ subroutine read_all_raw_restarts(mpicomm, mype)
   integer fileunit
   integer status
   integer mpierr
-  include 'mpif.h'
 
   if(mype == RAW_RESTART_METADATA_RANK) then
     ! read metadata info for the raw restart
@@ -860,7 +860,6 @@ end subroutine
 !
 !_______________________________________________________________________________
 subroutine read_restart(path, filegroup, mpicomm, mype)
-  include 'mpif.h'        
   character(len=*), intent(in) :: path
   type(restart_file_group), intent(inout) :: filegroup
   integer, intent(in) :: mpicomm
@@ -1004,7 +1003,6 @@ end subroutine
 !     integer mype
 !     integer npes
 !     integer mpierr
-!     include 'mpif.h'
 !   
 !     call MPI_Comm_Rank(mpicomm, mype, mpierr)
 !     call MPI_Comm_Size(mpicomm, npes, mpierr)

--- a/src/temp/MOD_PARTIT.F90
+++ b/src/temp/MOD_PARTIT.F90
@@ -5,9 +5,9 @@ USE O_PARAM
 USE, intrinsic :: ISO_FORTRAN_ENV
 USE MOD_WRITE_BINARY_ARRAYS
 USE MOD_READ_BINARY_ARRAYS
+USE mpi
 IMPLICIT NONE
 SAVE
-include 'mpif.h'
 integer, parameter   :: MAX_LAENDERECK=16
 integer, parameter   :: MAX_NEIGHBOR_PARTITIONS=32
 


### PR DESCRIPTION
Same as last time, but now I added `use mpi` to `src/cpl_driver.F90` as well, this should fix the error that @ackerlar reported here https://github.com/FESOM/fesom2/pull/627#issuecomment-2399957341 . However, I can not test it, because I can not build with oasis and/or oifs (no access to oasis and if I try to just define `__oifs` I do get 
```
/Users/sebeye001/climateDT/fesom2/src/io_restart.F90:180:90:

  180 |   call ice_files%def_node_var_optional('ice_albedo', 'ice albedo',    '-',   ice%atmcoupl%ice_alb, mesh, partit)
      |                                                                                          1
Error: 'atmcoupl' at (1) is not a member of the 't_ice' structure
```
)