### PR TITLE
Fix/ibhf ocea ale tra

### DIFF
--- a/src/oce_ale_tracer.F90
+++ b/src/oce_ale_tracer.F90
@@ -992,10 +992,11 @@ subroutine diff_ver_part_impl_ale(tr_num, dynamics, tracers, ice, partit, mesh)
         !_______________________________________________________________________
         ! case of activated shortwave penetration into the ocean, ad 3d contribution
         if (use_icebergs .and. (.not. turn_off_hf) .and. tracers%data(tr_num)%ID==1) then
-            do nz=nzmin, nzmax-1
+            do nz=nzmin, nzmax
+            
                 zinv=1.0_WP*dt  !/(zbar(nz)-zbar(nz+1)) ale!
                 !!PS tr(nz)=tr(nz)+(sw_3d(nz, n)-sw_3d(nz+1, n) * ( area(nz+1,n)/areasvol(nz,n)) ) * zinv
-                tr(nz)=tr(nz)+(ibhf_n(nz, n)-ibhf_n(nz+1, n) * area(nz+1,n)/areasvol(nz,n)) * zinv / vcpw
+                tr(nz)=tr(nz) + ibhf_n(nz, n) * zinv / vcpw
             end do
         end if
 


### PR DESCRIPTION
The iceberg related heat flux in `oce_ale_tracer` was treated as the sw penetration before. This was wrong because it is rather a level-wise "internal" heat source that does not penetrate through different levels.