### PR TITLE
Remove superfluous 'use MOD_PARSUP' from clock_init

### DIFF
--- a/src/gen_modules_clock.F90
+++ b/src/gen_modules_clock.F90
@@ -69,7 +69,6 @@ contains
   !
   subroutine clock_init(partit)
     USE MOD_PARTIT
-    USE MOD_PARSUP
     use g_config
     use mod_transit, only: ti_transit, ti_start_transit
     implicit none


### PR DESCRIPTION
This is not needed here and it leads to circular module dependencies, preventing compilation with some compiler(-versions). This should fix #646.