### PR TITLE
Abort model cleanly in ifsinterface and standalone on errors

### DIFF
--- a/src/gen_model_setup.F90
+++ b/src/gen_model_setup.F90
@@ -31,16 +31,35 @@ subroutine setup_model(partit)
     endif
     call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
   endif
-  read (fileunit, NML=modelname)
-  read (fileunit, NML=timestep)
-  read (fileunit, NML=clockinit) 
-  read (fileunit, NML=paths)
-  read (fileunit, NML=restart_log)
-  read (fileunit, NML=ale_def)
-  read (fileunit, NML=geometry)
-  read (fileunit, NML=calendar)
-  read (fileunit, NML=run_config)
-  read (fileunit,NML=icebergs)
+  read (fileunit, NML=modelname, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'modelname', nmlfile, partit)
+  
+  read (fileunit, NML=timestep, iostat=istat)  
+  if (istat /= 0) call check_namelist_read(fileunit, 'timestep', nmlfile, partit)
+
+  read (fileunit, NML=clockinit, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'clockinit', nmlfile, partit)
+
+  read (fileunit, NML=paths, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'paths', nmlfile, partit)
+
+  read (fileunit, NML=restart_log, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'restart_log', nmlfile, partit)
+
+  read (fileunit, NML=ale_def, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'ale_def', nmlfile, partit)
+
+  read (fileunit, NML=geometry, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'geometry', nmlfile, partit)
+
+  read (fileunit, NML=calendar, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'calendar', nmlfile, partit)
+
+  read (fileunit, NML=run_config, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'run_config', nmlfile, partit)
+
+  read (fileunit, NML=icebergs, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'icebergs', nmlfile, partit)
 
 !!$  read (fileunit, NML=machine)
   close (fileunit)
@@ -69,7 +88,8 @@ subroutine setup_model(partit)
     endif
     call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
   endif
-  read (fileunit, NML=oce_dyn)
+  read (fileunit, NML=oce_dyn, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'oce_dyn', nmlfile, partit)
   close (fileunit)
 
   nmlfile ='namelist.tra'    ! name of ocean namelist file
@@ -80,7 +100,8 @@ subroutine setup_model(partit)
     endif
     call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
   endif
-  read (fileunit, NML=tracer_phys)
+  read (fileunit, NML=tracer_phys, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'tracer_phys', nmlfile, partit)
   close (fileunit)
 
   nmlfile ='namelist.forcing'    ! name of forcing namelist file
@@ -91,11 +112,17 @@ subroutine setup_model(partit)
     endif
     call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
   endif
-  read (fileunit, NML=forcing_exchange_coeff)
-  read (fileunit, NML=forcing_bulk)
-  read (fileunit, NML=land_ice)
-  read (fileunit, NML=age_tracer) !---age-code
-  close (fileunit)
+  read (fileunit, NML=forcing_exchange_coeff, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'forcing_exchange_coeff', nmlfile, partit)
+
+  read (fileunit, NML=forcing_bulk, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'forcing_bulk', nmlfile, partit)
+
+  read (fileunit, NML=land_ice, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'land_ice', nmlfile, partit)
+
+  read (fileunit, NML=age_tracer, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'age_tracer', nmlfile, partit)
 
 !   if(use_ice) then
 !   nmlfile ='namelist.ice'    ! name of ice namelist file
@@ -113,7 +140,8 @@ subroutine setup_model(partit)
     endif
     call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
   endif
-  read (fileunit, NML=diag_list)
+  read (fileunit, NML=diag_list, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'diag_list', nmlfile, partit)
   close (fileunit)
 
 #if defined (__recom)
@@ -125,38 +153,102 @@ subroutine setup_model(partit)
     endif
     call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
   endif
-  read (fileunit, NML=pavariables)
-  read (fileunit, NML=pasinking)
-  read (fileunit, NML=painitialization_N)
-  read (fileunit, NML=paArrhenius)
-  read (fileunit, NML=palimiter_function)
-  read (fileunit, NML=palight_calculations)
-  read (fileunit, NML=paphotosynthesis)
-  read (fileunit, NML=paassimilation)
-  read (fileunit, NML=pairon_chem)
-  read (fileunit, NML=pazooplankton)
-  read (fileunit, NML=pasecondzooplankton)
-  read (fileunit, NML=pathirdzooplankton)
-  read (fileunit, NML=pagrazingdetritus)
-  read (fileunit, NML=paaggregation)
-  read (fileunit, NML=padin_rho_N)
-  read (fileunit, NML=padic_rho_C1)
-  read (fileunit, NML=paphytoplankton_N)
-  read (fileunit, NML=paphytoplankton_C)
-  read (fileunit, NML=paphytoplankton_ChlA)
-  read (fileunit, NML=padetritus_N)
-  read (fileunit, NML=padetritus_C)
-  read (fileunit, NML=paheterotrophs)
-  read (fileunit, NML=paseczooloss)
-  read (fileunit, NML=pathirdzooloss)
-  read (fileunit, NML=paco2lim)
-  read (fileunit, NML=pairon)
-  read (fileunit, NML=pacalc)
-  read (fileunit, NML=pabenthos_decay_rate)
-  read (fileunit, NML=paco2_flux_param)
-  read (fileunit, NML=paalkalinity_restoring)
-  read (fileunit, NML=paballasting)
-  read (fileunit, NML=paciso)
+  read (fileunit, NML=pavariables, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'pavariables', nmlfile, partit)
+
+  read (fileunit, NML=pasinking, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'pasinking', nmlfile, partit)
+
+  read (fileunit, NML=painitialization_N, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'painitialization_N', nmlfile, partit)
+
+  read (fileunit, NML=paArrhenius, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'paArrhenius', nmlfile, partit)
+
+  read (fileunit, NML=palimiter_function, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'palimiter_function', nmlfile, partit)
+
+  read (fileunit, NML=palight_calculations, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'palight_calculations', nmlfile, partit)
+
+  read (fileunit, NML=paphotosynthesis, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'paphotosynthesis', nmlfile, partit)
+
+  read (fileunit, NML=paassimilation, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'paassimilation', nmlfile, partit)
+
+  read (fileunit, NML=pairon_chem, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'pairon_chem', nmlfile, partit)
+
+  read (fileunit, NML=pazooplankton, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'pazooplankton', nmlfile, partit)
+
+  read (fileunit, NML=pasecondzooplankton, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'pasecondzooplankton', nmlfile, partit)
+
+  read (fileunit, NML=pathirdzooplankton, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'pathirdzooplankton', nmlfile, partit)
+
+  read (fileunit, NML=pagrazingdetritus, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'pagrazingdetritus', nmlfile, partit)
+
+  read (fileunit, NML=paaggregation, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'paaggregation', nmlfile, partit)
+
+  read (fileunit, NML=padin_rho_N, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'padin_rho_N', nmlfile, partit)
+
+  read (fileunit, NML=padic_rho_C1, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'padic_rho_C1', nmlfile, partit)
+
+  read (fileunit, NML=paphytoplankton_N, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'paphytoplankton_N', nmlfile, partit)
+
+  read (fileunit, NML=paphytoplankton_C, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'paphytoplankton_C', nmlfile, partit)
+
+  read (fileunit, NML=paphytoplankton_ChlA, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'paphytoplankton_ChlA', nmlfile, partit)
+
+  read (fileunit, NML=padetritus_N, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'padetritus_N', nmlfile, partit)
+
+  read (fileunit, NML=padetritus_C, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'padetritus_C', nmlfile, partit)
+
+  read (fileunit, NML=paheterotrophs, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'paheterotrophs', nmlfile, partit)
+
+  read (fileunit, NML=paseczooloss, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'paseczooloss', nmlfile, partit)
+
+  read (fileunit, NML=pathirdzooloss, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'pathirdzooloss', nmlfile, partit)
+
+  read (fileunit, NML=paco2lim, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'paco2lim', nmlfile, partit)
+
+  read (fileunit, NML=pairon, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'pairon', nmlfile, partit)
+
+  read (fileunit, NML=pacalc, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'pacalc', nmlfile, partit)
+
+  read (fileunit, NML=pabenthos_decay_rate, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'pabenthos_decay_rate', nmlfile, partit)
+
+  read (fileunit, NML=paco2_flux_param, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'paco2_flux_param', nmlfile, partit)
+
+  read (fileunit, NML=paalkalinity_restoring, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'paalkalinity_restoring', nmlfile, partit)
+
+  read (fileunit, NML=paballasting, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'paballasting', nmlfile, partit)
+
+  read (fileunit, NML=paciso, iostat=istat)
+  if (istat /= 0) call check_namelist_read(fileunit, 'paciso', nmlfile, partit)
+
   close (fileunit)
 #endif
 
@@ -263,3 +355,22 @@ end subroutine get_run_steps
 
     
 ! ==============================================================
+
+subroutine check_namelist_read(fileunit, nml_name, nmlfile, partit)
+    use MOD_PARTIT
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    implicit none
+    integer,          intent(in) :: fileunit
+    character(len=*), intent(in) :: nml_name
+    character(len=*), intent(in) :: nmlfile
+    type(t_partit),   intent(in) :: partit
+    character(len=256) :: line
+
+    backspace(fileunit)
+    read(fileunit, fmt='(A)') line
+    if(partit%mype==0) then
+        write(error_unit,'(A)') 'ERROR: Could not read namelist '//trim(nml_name)//' from '//trim(nmlfile)
+        write(error_unit,'(A)') 'Invalid line in namelist: '//trim(line)
+    endif
+    call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
+end subroutine

--- a/src/gen_model_setup.F90
+++ b/src/gen_model_setup.F90
@@ -19,12 +19,18 @@ subroutine setup_model(partit)
   implicit none
   type(t_partit), intent(inout), target :: partit
   character(len=MAX_PATH)               :: nmlfile
-  integer fileunit
+  integer                               :: fileunit, istat
 
   namelist /clockinit/ timenew, daynew, yearnew
 
   nmlfile ='namelist.config'    ! name of general configuration namelist file
-  open (newunit=fileunit, file=nmlfile)
+  open (newunit=fileunit, file=nmlfile, status='OLD', iostat=istat)
+  if (istat /= 0) then
+    if(partit%mype==0) then
+      write(*,*) 'ERROR: Could not open namelist file ', trim(nmlfile)
+    endif
+    call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
+  endif
   read (fileunit, NML=modelname)
   read (fileunit, NML=timestep)
   read (fileunit, NML=clockinit) 
@@ -56,17 +62,35 @@ subroutine setup_model(partit)
 ! =================================
  
   nmlfile ='namelist.oce'    ! name of ocean namelist file
-  open (newunit=fileunit, file=nmlfile)
+  open (newunit=fileunit, file=nmlfile, status='OLD', iostat=istat)
+  if (istat /= 0) then
+    if(partit%mype==0) then
+      write(*,*) 'ERROR: Could not open namelist file ', trim(nmlfile)
+    endif
+    call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
+  endif
   read (fileunit, NML=oce_dyn)
   close (fileunit)
 
   nmlfile ='namelist.tra'    ! name of ocean namelist file
-  open (newunit=fileunit, file=nmlfile)
+  open (newunit=fileunit, file=nmlfile, status='OLD', iostat=istat)
+  if (istat /= 0) then
+    if(partit%mype==0) then
+      write(*,*) 'ERROR: Could not open namelist file ', trim(nmlfile)
+    endif
+    call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
+  endif
   read (fileunit, NML=tracer_phys)
   close (fileunit)
 
   nmlfile ='namelist.forcing'    ! name of forcing namelist file
-  open (newunit=fileunit, file=nmlfile)
+  open (newunit=fileunit, file=nmlfile, status='OLD', iostat=istat)
+  if (istat /= 0) then
+    if(partit%mype==0) then
+      write(*,*) 'ERROR: Could not open namelist file ', trim(nmlfile)
+    endif
+    call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
+  endif
   read (fileunit, NML=forcing_exchange_coeff)
   read (fileunit, NML=forcing_bulk)
   read (fileunit, NML=land_ice)
@@ -82,13 +106,25 @@ subroutine setup_model(partit)
 !   endif
   
   nmlfile ='namelist.io'    ! name of forcing namelist file
-  open (newunit=fileunit, file=nmlfile)
+  open (newunit=fileunit, file=nmlfile, status='OLD', iostat=istat)
+  if (istat /= 0) then
+    if(partit%mype==0) then
+      write(*,*) 'ERROR: Could not open namelist file ', trim(nmlfile)
+    endif
+    call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
+  endif
   read (fileunit, NML=diag_list)
   close (fileunit)
 
 #if defined (__recom)
   nmlfile ='namelist.recom'    ! name of recom namelist file
-  open (newunit=fileunit, file=nmlfile)
+  open (newunit=fileunit, file=nmlfile, iostat=istat)
+  if (istat /= 0) then
+    if(partit%mype==0) then
+      write(*,*) 'ERROR: Could not open namelist file ', trim(nmlfile)
+    endif
+    call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
+  endif
   read (fileunit, NML=pavariables)
   read (fileunit, NML=pasinking)
   read (fileunit, NML=painitialization_N)

--- a/src/gen_model_setup.F90
+++ b/src/gen_model_setup.F90
@@ -358,6 +358,7 @@ end subroutine get_run_steps
 
 subroutine check_namelist_read(fileunit, nml_name, nmlfile, partit)
     use MOD_PARTIT
+    use MOD_PARSUP
     use, intrinsic :: iso_fortran_env, only: error_unit
     implicit none
     integer,          intent(in) :: fileunit

--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -178,18 +178,25 @@ subroutine ini_mean_io(ice, dynamics, tracers, partit, mesh)
     ! OPEN and read namelist for I/O
     open( unit=nm_io_unit, file='namelist.io', form='formatted', access='sequential', status='old', iostat=iost )
     if (iost == 0) then
-    if (mype==0) WRITE(*,*) '     file   : ', 'namelist.io',' open ok'
-        else
-    if (mype==0) WRITE(*,*) 'ERROR: --> bad opening file   : ', 'namelist.io',' ; iostat=',iost
-        call par_ex(partit%MPI_COMM_FESOM, partit%mype)
-        stop
+      if (mype==0) WRITE(*,*) '     file   : ', 'namelist.io',' open ok'
+    else
+      if (mype==0) WRITE(*,*) 'ERROR: --> file not found   : ', 'namelist.io',' ; iostat=',iost
+      call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
+      stop
     endif
+
     READ(nm_io_unit, nml=nml_general,  iostat=iost )
+    if (iost/=0) then
+       if (mype==0) WRITE(*,*) 'ERROR: in reading nml_general block in namelist.io, invalid formatting.'
+       call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
+    endif
+
     allocate(io_list(io_listsize))
     READ(nm_io_unit, nml=nml_list,     iostat=iost )
     close(nm_io_unit )
 
     !___________________________________________________________________________
+    ! TODO: unknown variable found then write clearly in log, saves lot of frustration.
     do i=1, io_listsize
         if (trim(io_list(i)%id)=='unknown   ') then
             if (mype==0) write(*,*) 'io_listsize will be changed from ', io_listsize, ' to ', i-1, '!'
@@ -2236,7 +2243,7 @@ subroutine def_stream_after_dimension_specific(entry, name, description, units, 
       allocate(data_strategy_nf_float_type :: entry%data_strategy)
     else
        if (partit%mype==0) write(*,*) 'not supported output accuracy:',accuracy,'for',trim(name)
-       call par_ex(partit%MPI_COMM_FESOM, partit%mype)
+       call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
        stop
     endif ! accuracy
 
@@ -2270,6 +2277,7 @@ subroutine def_stream_after_dimension_specific(entry, name, description, units, 
 !      write(*,*) 'total elem=', mesh%elem2D, entry_index
     else
       if(partit%mype == 0) print *,"can not determine if ",trim(name)," is node or elem based"
+      call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
       stop
     end if
     

--- a/src/oce_mesh.F90
+++ b/src/oce_mesh.F90
@@ -244,7 +244,7 @@ MPI_COMM_FESOM=>partit%MPI_COMM_FESOM
        write (unit=error_unit, fmt='(3A)') &
          '### error: can not open file ', file_name, &
          ', error: ' // trim(errmsg)
-       call MPI_Abort(MPI_COMM_FESOM, 1, ierror)
+ !call MPI_Abort(MPI_COMM_FESOM, 1, ierror) # dont call abort here yet called bellow
      end if
      allocate(partit%part(npes+1))
      part=>partit%part
@@ -264,7 +264,6 @@ MPI_COMM_FESOM=>partit%MPI_COMM_FESOM
      write(*,*) n
      write(*,*) 'error: NPES does not coincide with that of the mesh'
      call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
-     call MPI_Abort(MPI_COMM_FESOM, 1, ierror)
   end if
   ! broadcasting partitioning vector to the other procs
   if (mype/=0) then
@@ -423,7 +422,7 @@ MPI_COMM_FESOM=>partit%MPI_COMM_FESOM
         write(*,*) '____________________________________________________________________'
         print *, achar(27)//'[0m'
         write(*,*)
-        call par_ex(partit%MPI_COMM_FESOM, partit%mype, 0)
+        call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
     !___________________________________________________________________________
     ! check if rotation needs to be applied to an unrotated mesh
     elseif ((mype==0) .and. (.not. force_rotation) .and. (flag_checkmustrot==1) .and. (.not. toy_ocean)) then
@@ -444,7 +443,7 @@ MPI_COMM_FESOM=>partit%MPI_COMM_FESOM
         write(*,*) '____________________________________________________________________'
         print *, achar(27)//'[0m'
         write(*,*)
-        call par_ex(partit%MPI_COMM_FESOM, partit%mype, 0)
+        call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
     end if
   
   
@@ -545,7 +544,7 @@ MPI_COMM_FESOM=>partit%MPI_COMM_FESOM
         call MPI_BCast(mesh%nl, 1, MPI_INTEGER, 0, MPI_COMM_FESOM, ierror)
         if (mesh%nl < 3) then
             write(*,*) '!!!Number of levels is less than 3, model will stop!!!'
-            call par_ex(partit%MPI_COMM_FESOM, partit%mype)
+            call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
             stop
         end if
         allocate(mesh%zbar(mesh%nl))              ! allocate the array for storing the standard depths
@@ -566,7 +565,7 @@ MPI_COMM_FESOM=>partit%MPI_COMM_FESOM
             write(*,*) '        --> model stops here'
             write(*,*) '____________________________________________________________________'
         end if
-        call par_ex(partit%MPI_COMM_FESOM, partit%mype, 0)
+        call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
     end if
     
  !______________________________________________________________________________
@@ -586,7 +585,7 @@ MPI_COMM_FESOM=>partit%MPI_COMM_FESOM
         call MPI_BCast(mesh%nl, 1, MPI_INTEGER, 0, MPI_COMM_FESOM, ierror)
         if (mesh%nl < 3) then
             write(*,*) '!!!Number of levels is less than 3, model will stop!!!'
-            call par_ex(partit%MPI_COMM_FESOM, partit%mype)
+            call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
             stop
         end if
         allocate(mesh%zbar(mesh%nl))              ! allocate the array for storing the standard depths
@@ -609,7 +608,7 @@ MPI_COMM_FESOM=>partit%MPI_COMM_FESOM
             write(*,*) '            use_depthfile= "aux3d" or "depth@" and your meshfolder'
             write(*,*) '        --> model stops here'
             write(*,*) '____________________________________________________________________'
-            call par_ex(partit%MPI_COMM_FESOM, partit%mype, 0)
+            call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
         end if 
     end if 
     
@@ -634,7 +633,7 @@ MPI_COMM_FESOM=>partit%MPI_COMM_FESOM
             write(*,*) '            use_depthfile= "aux3d" or "depth@" and your meshfolder '
             write(*,*) '        --> model stops here'
             write(*,*) '____________________________________________________________________'
-            call par_ex(partit%MPI_COMM_FESOM, partit%mype, 0)
+            call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
         end if
     end if     
  end if 
@@ -766,7 +765,7 @@ if ((mype==0) .and. (flag_wrongaux3d==1)) then
     write(*,*) '____________________________________________________________________'
     print *, achar(27)//'[0m'
     write(*,*)
-    call par_ex(partit%MPI_COMM_FESOM, partit%mype, 0)
+    call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
 end if 
 
  ! ==============================
@@ -1156,7 +1155,7 @@ subroutine find_levels_cavity(partit, mesh)
             write(*,*) '____________________________________________________________________'
             print *, achar(27)//'[0m'
             write(*,*)
-            call par_ex(partit%MPI_COMM_FESOM, partit%mype)
+            call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
         end if 
     end if
     
@@ -1244,7 +1243,7 @@ subroutine find_levels_cavity(partit, mesh)
             write(*,*) '____________________________________________________________________'
             print *, achar(27)//'[0m'
             write(*,*)
-            call par_ex(partit%MPI_COMM_FESOM, partit%mype)
+            call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
         end if    
     end if
     
@@ -1409,7 +1408,7 @@ subroutine find_levels_cavity(partit, mesh)
             write(*,*) '____________________________________________________________________'
             print *, achar(27)//'[0m'
             write(*,*)
-            call par_ex(partit%MPI_COMM_FESOM, partit%mype)
+            call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
         end if 
     end if
     

--- a/src/oce_mesh.F90
+++ b/src/oce_mesh.F90
@@ -244,7 +244,6 @@ MPI_COMM_FESOM=>partit%MPI_COMM_FESOM
        write (unit=error_unit, fmt='(3A)') &
          '### error: can not open file ', file_name, &
          ', error: ' // trim(errmsg)
- !call MPI_Abort(MPI_COMM_FESOM, 1, ierror) # dont call abort here yet called bellow
      end if
      allocate(partit%part(npes+1))
      part=>partit%part


### PR DESCRIPTION
Some of old features lost in my branches that didn't make it into main, part 1.

- clean and exit model with par_ex instead of abort, this avoids a few annoying model hanging in ifs_interface.
- checks for namelists exist and show line where error happens and abort cleanly. 


TODO in another PR:
- model stop with par_ex should also be used consistently in checks should also be used in cvmix routines and ib routines. 
- add namelist checks in all other modules in style similar to this PR 
