### PR TITLE
updated Juwels env file

### DIFF
--- a/env/juwels/shell
+++ b/env/juwels/shell
@@ -1,44 +1,20 @@
-##########
-module --force purge 
-module use /gpfs/software/juwels/otherstages   
-module load Stages/2020
-module load Intel/2020.2.254-GCC-9.3.0
-module load ParaStationMPI/5.4.7-1
-module load CMake/3.18.0
-module load imkl/2020.2.254
-module load netCDF-Fortran/4.5.3
-module load netCDF/4.7.4
-module load Perl/5.32.0
-module load netCDF
+#!/usr/bin/bash
+# ENVIRONMENT used in new_test15_compute_20000101-20000101.run
+# Use this file to source the environment in your
+# preprocessing or postprocessing scripts
 
-export LC_ALL=en_US.UTF-8
-export TMPDIR=/tmp
-export FC=mpifort
-export F77=mpifort
-export MPIFC=mpifort
-export FCFLAGS=-free
-export CC=mpicc
-export CXX=mpic++
-
-export NETCDF_Fortran_INCLUDE_DIRECTORIES=$EBROOTNETCDFMINFORTRAN/include
-export NETCDF_Fortran_LIBRARIES=$EBROOTNETCDFMINFORTRAN/lib
-
-#module use /gpfs/software/juwels/otherstages
-#module load Stages/2019a                
-#module load StdEnv
-## For intel MPI
-##module load Intel/2019.3.199-GCC-8.3.0  IntelMPI/2018.5.288 imkl/2019.3.199
-##export FC=mpiifort CC=mpiicc CXX=mpiicpc
-
-## For ParaStation MPI 
-#module load  Intel/2019.3.199-GCC-8.3.0 ParaStationMPI/5.4 imkl/2019.5.281
-#export FC=mpifort CC=mpicc CXX=mpicxx
-
-#module load netCDF/4.6.3 
-#module load netCDF-Fortran/4.4.5 
-#module load CMake
-#export NETCDF_DIR=$EBROOTNETCDF
-#export NETCDFF_DIR=$EBROOTNETCDFMINFORTRAN
-#export NETCDF_Fortran_INCLUDE_DIRECTORIES=${NETCDFF_DIR}/include/
-#export NETCDF_C_INCLUDE_DIRECTORIES=${NETCDF_DIR}/include/
-#export NETCDF_CXX_INCLUDE_DIRECTORIES=${NETCDFCXX_DIR}/include/
+module --force purge
+module use $OTHERSTAGES
+module --force purge
+module load Stages/2023
+module load GCC/11.3.0
+module load OpenMPI/4.1.4
+module load CMake/3.26.3
+module load Python/3.10.4
+module load imkl/2022.1.0
+module load Perl/5.34.1
+module load git
+module load CDO
+module unload ecCodes
+module load libaec FFTW imkl cURL netCDF netCDF-Fortran
+module list

--- a/mesh_part/CMakeLists.txt
+++ b/mesh_part/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.4)
 project(fesom_ini C Fortran)
 find_package(MPI REQUIRED)
 
+
+
 # get our source files
 set(src_home ${CMAKE_CURRENT_LIST_DIR}/../src)
 set(sources_Fortran ${src_home}/MOD_MESH.F90 ${src_home}/oce_modules.F90 ${src_home}/gen_modules_config.F90 ${src_home}/gen_modules_partitioning.F90 ${src_home}/gen_modules_rotate_grid.F90 ${src_home}/fvom_init.F90 ${src_home}/oce_local.F90 ${src_home}/gen_comm.F90 ${src_home}/MOD_READ_BINARY_ARRAYS.F90 ${src_home}/MOD_WRITE_BINARY_ARRAYS.F90 ${src_home}/MOD_PARTIT.F90)
@@ -27,5 +29,5 @@ elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL  GNU )
       target_compile_options(${PROJECT_NAME} PRIVATE -fallow-argument-mismatch) # gfortran v10 is strict about erroneous API calls: "Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)"
    endif()
 endif()
-target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_C)
+target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_C MPI::MPI_Fortran)
 set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE Fortran)

--- a/mesh_part/CMakeLists.txt
+++ b/mesh_part/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.4)
 
 project(fesom_ini C Fortran)
+find_package(MPI REQUIRED)
 
 # get our source files
 set(src_home ${CMAKE_CURRENT_LIST_DIR}/../src)


### PR DESCRIPTION
the env file for Juwels was outated since the last update on their system. Here is the content for the updated file:

```
#!/usr/bin/bash
# ENVIRONMENT used in new_test15_compute_20000101-20000101.run
# Use this file to source the environment in your
# preprocessing or postprocessing scripts

module --force purge
module use $OTHERSTAGES
module --force purge
module load Stages/2023
module load GCC/11.3.0
module load OpenMPI/4.1.4
module load CMake/3.26.3
module load Python/3.10.4
module load imkl/2022.1.0
module load Perl/5.34.1
module load git
module load CDO
module unload ecCodes
module load libaec FFTW imkl cURL netCDF netCDF-Fortran
module list
```