### PR TITLE
Mark issues and PRs as stale after two years of inactivity.

### DIFF
--- a/.github/workflows/close_stale_issues
+++ b/.github/workflows/close_stale_issues
@@ -1,0 +1,34 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '00 14 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-issue-stale: 730
+        days-before-pr-stale: 730
+        days-before-issue-close: 30
+        days-before-pr-close: -1
+        stale-issue-message: 'This issue has been inactive for two years. It will now be marked as stale and closed after 30 days of further inactivity. Please add a comment to reset this automatic closing of this issue or close it if solved.'
+        stale-pr-message: 'This PR has been inactive for two years. It will now be marked as stale. Please close this PR if no longer needed.'
+        stale-issue-label: 'Stale'
+        stale-pr-label: 'Stale'
+        close-issue-label: 'Closed by github-actions'
+        exempt-issue-labels: enhancement, feature request
+        exempt-pr-labels: enhancement, feature request


### PR DESCRIPTION
Closes issues 30 days later if no further update is made. Check is made daily.

Copied from: https://github.com/esm-tools/esm_tools/blob/JanStreffing-patch-1/.github/workflows/stale.yml
