### PR TITLE
Add option to build mesh partitioner with main build

### DIFF
--- a/lib/metis-5.1.0/CMakeLists.txt
+++ b/lib/metis-5.1.0/CMakeLists.txt
@@ -3,7 +3,7 @@ project(METIS)
 
 #set(GKLIB_PATH "GKlib" CACHE PATH "path to GKlib")
 #set(GKLIB_PATH "${CMAKE_SOURCE_DIR}/lib/metis-5.1.0/GKlib" CACHE PATH "path to GKlib")
-set(GKLIB_PATH "${CMAKE_SOURCE_DIR}/../lib/metis-5.1.0/GKlib" CACHE PATH "path to GKlib")
+set(GKLIB_PATH "${CMAKE_CURRENT_SOURCE_DIR}/GKlib" CACHE PATH "path to GKlib")
 set(SHARED FALSE CACHE BOOL "build a shared library")
 
 #if(MSVC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,6 +87,11 @@ endif()
 option(USE_ICEPACK "Use ICEPACK" OFF)
 message(STATUS "USE_ICEPACK: ${USE_ICEPACK}")
 
+
+option(BUILD_MESHPARTITIONER "build mesh partitioner" OFF)
+message(STATUS "BUILD_MESHPARTITIONER: ${BUILD_MESHPARTITIONER}")
+
+
 # option to trigger building a library version of FESOM
 # we do not always build the library along with the executable to avoid having two targets here in the CMakeLists.txt
 # two targets would allow e.g. setting different compiler options or preprocessor definition, which would be error prone.
@@ -444,3 +449,32 @@ message(STATUS " --> Final Compile options for ${PROJECT_NAME}: ${FLAGS}")
 ### Export and installation
 
 fesom_export(TARGETS ${PROJECT_NAME} fesom.x)
+
+
+# mesh partitioner
+
+if(BUILD_MESHPARTITIONER)
+  set(meshpartitioner_sources_Fortran ${src_home}/MOD_MESH.F90 ${src_home}/oce_modules.F90 ${src_home}/gen_modules_config.F90 ${src_home}/gen_modules_partitioning.F90 ${src_home}/gen_modules_rotate_grid.F90 ${src_home}/fvom_init.F90 ${src_home}/oce_local.F90 ${src_home}/gen_comm.F90 ${src_home}/MOD_READ_BINARY_ARRAYS.F90 ${src_home}/MOD_WRITE_BINARY_ARRAYS.F90 ${src_home}/MOD_PARTIT.F90)
+  set(meshpartitioner_sources_C ${src_home}/fort_part.c)
+  
+  add_subdirectory(${src_home}/../lib/metis-5.1.0 ${PROJECT_BINARY_DIR}/metis)
+  include_directories(${src_home}/../lib/metis-5.1.0/include)
+  
+  add_library(meshpartitioner_C ${meshpartitioner_sources_C})
+  target_compile_definitions(meshpartitioner_C PRIVATE USE_MPI REAL=double DBL HAS_BLAS FORTRAN_UNDERSCORE VOID_POINTER_SIZE_8 SGI LINUX UNDER_ MPI2)
+  target_link_libraries(meshpartitioner_C metis)
+  
+  add_executable(meshpartitioner ${meshpartitioner_sources_Fortran})
+  # CMAKE_Fortran_COMPILER_ID will also work if a wrapper is being used (e.g. mpif90 wraps ifort -> compiler id is Intel)
+  if(${CMAKE_Fortran_COMPILER_ID} STREQUAL  Intel )
+  	target_compile_options(meshpartitioner PRIVATE -r8 -i4 -fp-model precise -no-prec-div -no-prec-sqrt -fast-transcendentals -xHost -ip)
+  #	target_compile_options(${PROJECT_NAME} PRIVATE -r8 -i4 -fp-model precise -no-prec-div -no-prec-sqrt -fast-transcendentals -xHost -ip -g -traceback -check all,noarg_temp_created,bounds,uninit) 
+  elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL  GNU )
+  	target_compile_options(meshpartitioner PRIVATE -fdefault-real-8 -ffree-line-length-none)
+    if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10 )
+        target_compile_options(meshpartitioner PRIVATE -fallow-argument-mismatch) # gfortran v10 is strict about erroneous API calls: "Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)"
+     endif()
+  endif()
+  target_link_libraries(meshpartitioner meshpartitioner_C MPI::MPI_Fortran)
+  set_target_properties(meshpartitioner PROPERTIES LINKER_LANGUAGE Fortran)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -454,27 +454,27 @@ fesom_export(TARGETS ${PROJECT_NAME} fesom.x)
 # mesh partitioner
 
 if(BUILD_MESHPARTITIONER)
-  set(meshpartitioner_sources_Fortran ${src_home}/MOD_MESH.F90 ${src_home}/oce_modules.F90 ${src_home}/gen_modules_config.F90 ${src_home}/gen_modules_partitioning.F90 ${src_home}/gen_modules_rotate_grid.F90 ${src_home}/fvom_init.F90 ${src_home}/oce_local.F90 ${src_home}/gen_comm.F90 ${src_home}/MOD_READ_BINARY_ARRAYS.F90 ${src_home}/MOD_WRITE_BINARY_ARRAYS.F90 ${src_home}/MOD_PARTIT.F90)
-  set(meshpartitioner_sources_C ${src_home}/fort_part.c)
+  set(fesom_meshpart_sources_Fortran ${src_home}/MOD_MESH.F90 ${src_home}/oce_modules.F90 ${src_home}/gen_modules_config.F90 ${src_home}/gen_modules_partitioning.F90 ${src_home}/gen_modules_rotate_grid.F90 ${src_home}/fvom_init.F90 ${src_home}/oce_local.F90 ${src_home}/gen_comm.F90 ${src_home}/MOD_READ_BINARY_ARRAYS.F90 ${src_home}/MOD_WRITE_BINARY_ARRAYS.F90 ${src_home}/MOD_PARTIT.F90)
+  set(fesom_meshpart_sources_C ${src_home}/fort_part.c)
   
   add_subdirectory(${src_home}/../lib/metis-5.1.0 ${PROJECT_BINARY_DIR}/metis)
   include_directories(${src_home}/../lib/metis-5.1.0/include)
   
-  add_library(meshpartitioner_C ${meshpartitioner_sources_C})
-  target_compile_definitions(meshpartitioner_C PRIVATE USE_MPI REAL=double DBL HAS_BLAS FORTRAN_UNDERSCORE VOID_POINTER_SIZE_8 SGI LINUX UNDER_ MPI2)
-  target_link_libraries(meshpartitioner_C metis)
+  add_library(fesom_meshpart_C ${fesom_meshpart_sources_C})
+  target_compile_definitions(fesom_meshpart_C PRIVATE USE_MPI REAL=double DBL HAS_BLAS FORTRAN_UNDERSCORE VOID_POINTER_SIZE_8 SGI LINUX UNDER_ MPI2)
+  target_link_libraries(fesom_meshpart_C metis)
   
-  add_executable(meshpartitioner ${meshpartitioner_sources_Fortran})
+  add_executable(fesom_meshpart ${fesom_meshpart_sources_Fortran})
   # CMAKE_Fortran_COMPILER_ID will also work if a wrapper is being used (e.g. mpif90 wraps ifort -> compiler id is Intel)
   if(${CMAKE_Fortran_COMPILER_ID} STREQUAL  Intel )
-  	target_compile_options(meshpartitioner PRIVATE -r8 -i4 -fp-model precise -no-prec-div -no-prec-sqrt -fast-transcendentals -xHost -ip)
+  	target_compile_options(fesom_meshpart PRIVATE -r8 -i4 -fp-model precise -no-prec-div -no-prec-sqrt -fast-transcendentals -xHost -ip)
   #	target_compile_options(${PROJECT_NAME} PRIVATE -r8 -i4 -fp-model precise -no-prec-div -no-prec-sqrt -fast-transcendentals -xHost -ip -g -traceback -check all,noarg_temp_created,bounds,uninit) 
   elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL  GNU )
-  	target_compile_options(meshpartitioner PRIVATE -fdefault-real-8 -ffree-line-length-none)
+  	target_compile_options(fesom_meshpart PRIVATE -fdefault-real-8 -ffree-line-length-none)
     if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10 )
-        target_compile_options(meshpartitioner PRIVATE -fallow-argument-mismatch) # gfortran v10 is strict about erroneous API calls: "Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)"
+        target_compile_options(fesom_meshpart PRIVATE -fallow-argument-mismatch) # gfortran v10 is strict about erroneous API calls: "Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)"
      endif()
   endif()
-  target_link_libraries(meshpartitioner meshpartitioner_C MPI::MPI_Fortran)
-  set_target_properties(meshpartitioner PROPERTIES LINKER_LANGUAGE Fortran)
+  target_link_libraries(fesom_meshpart fesom_meshpart_C MPI::MPI_Fortran)
+  set_target_properties(fesom_meshpart PROPERTIES LINKER_LANGUAGE Fortran)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,7 +88,7 @@ option(USE_ICEPACK "Use ICEPACK" OFF)
 message(STATUS "USE_ICEPACK: ${USE_ICEPACK}")
 
 
-option(BUILD_MESHPARTITIONER "build mesh partitioner" OFF)
+option(BUILD_MESHPARTITIONER "build mesh partitioner" ON)
 message(STATUS "BUILD_MESHPARTITIONER: ${BUILD_MESHPARTITIONER}")
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -451,6 +451,8 @@ message(STATUS " --> Final Compile options for ${PROJECT_NAME}: ${FLAGS}")
 # mesh partitioner
 
 if(BUILD_MESHPARTITIONER)
+block()
+set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/module/fesom_meshpart)
   set(fesom_meshpart_sources_Fortran ${src_home}/MOD_MESH.F90 ${src_home}/oce_modules.F90 ${src_home}/gen_modules_config.F90 ${src_home}/gen_modules_partitioning.F90 ${src_home}/gen_modules_rotate_grid.F90 ${src_home}/fvom_init.F90 ${src_home}/oce_local.F90 ${src_home}/gen_comm.F90 ${src_home}/MOD_READ_BINARY_ARRAYS.F90 ${src_home}/MOD_WRITE_BINARY_ARRAYS.F90 ${src_home}/MOD_PARTIT.F90)
   set(fesom_meshpart_sources_C ${src_home}/fort_part.c)
   
@@ -474,6 +476,7 @@ if(BUILD_MESHPARTITIONER)
   endif()
   target_link_libraries(fesom_meshpart fesom_meshpart_C MPI::MPI_Fortran)
   set_target_properties(fesom_meshpart PROPERTIES LINKER_LANGUAGE Fortran)
+endblock()
 endif()
 
 ### Export and installation

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -446,9 +446,6 @@ get_target_property(FLAGS ${PROJECT_NAME} COMPILE_OPTIONS)
 message(STATUS " --> Final Compile options for ${PROJECT_NAME}: ${FLAGS}")
 
 
-### Export and installation
-
-fesom_export(TARGETS ${PROJECT_NAME} fesom.x)
 
 
 # mesh partitioner
@@ -478,3 +475,7 @@ if(BUILD_MESHPARTITIONER)
   target_link_libraries(fesom_meshpart fesom_meshpart_C MPI::MPI_Fortran)
   set_target_properties(fesom_meshpart PROPERTIES LINKER_LANGUAGE Fortran)
 endif()
+
+### Export and installation
+
+fesom_export(TARGETS ${PROJECT_NAME} fesom.x fesom_meshpart)

--- a/work/job_ini_albedo
+++ b/work/job_ini_albedo
@@ -14,7 +14,7 @@ ulimit -s unlimited
 
 source ../env/albedo/shell
 
-ln -s ../bin/fesom_ini.x         .           # cp -n ../bin/fvom_ini.x
+ln -s ../bin/fesom_meshpart      .
 cp -n ../config/namelist.config  .
 #cp -n ../config/namelist.forcing .
 #cp -n ../config/namelist.oce     .
@@ -27,6 +27,5 @@ fname="fesom2_${SLURM_JOB_NAME}_${jobid}.out"
 
 #___PUT JOB IN QUEUE____________________________________________________________
 date
-srun --mpi=pmi2 --ntasks=1 ./fesom_ini.x >> ${fname}
+srun --mpi=pmi2 --ntasks=1 ./fesom_meshpart >> ${fname}
 date
-

--- a/work/job_ini_juwels
+++ b/work/job_ini_juwels
@@ -15,14 +15,14 @@ ulimit -s unlimited
 # determine JOBID
 JOBID=`echo $SLURM_JOB_ID |cut -d"." -f1`
 
-ln -s ../bin/fesom_ini.x .           # cp -n ../bin/fesom.x
+ln -s ../bin/fesom_meshpart      .
 cp -n ../config/namelist.config  .
 cp -n ../config/namelist.forcing .
 cp -n ../config/namelist.oce     .
 cp -n ../config/namelist.ice     .
 
 date
-srun --mpi=pmi2 ./fesom_ini.x > "fesom_ini.out"
+srun --mpi=pmi2 ./fesom_meshpart > "fesom_meshpart.out"
 date
 
 #qstat -f $PBS_JOBID

--- a/work/job_ini_levante
+++ b/work/job_ini_levante
@@ -19,7 +19,7 @@ squeue -u $USER
 # determine JOBID
 JOBID=`echo $SLURM_JOB_ID |cut -d"." -f1`
 
-ln -s ../bin/fesom_ini.x .           # cp -n ../bin/fesom.x
+ln -s ../bin/fesom_meshpart .
 cp -n ../config/namelist.config  .
 cp -n ../config/namelist.forcing .
 cp -n ../config/namelist.oce     .
@@ -27,7 +27,7 @@ cp -n ../config/namelist.ice     .
 cp -n ../config/namelist.icepack .
 
 date
-srun -l fesom_ini.x > "fesom_ini.out"
+srun -l fesom_meshpart > "fesom_meshpart.out"
 date
 
 # qstat -f $PBS_JOBID

--- a/work/job_ini_lumi
+++ b/work/job_ini_lumi
@@ -13,7 +13,7 @@ ulimit -s unlimited
 
 source ../env/lumi/shell
 
-ln -s ../bin/fesom_ini.x         .           # cp -n ../bin/fvom_ini.x
+ln -s ../bin/fesom_meshpart      .
 cp -n ../config/namelist.config  .
 #cp -n ../config/namelist.forcing .
 #cp -n ../config/namelist.oce     .
@@ -26,6 +26,6 @@ fname="fesom2_${SLURM_JOB_NAME}_${jobid}.out"
 
 #___PUT JOB IN QUEUE____________________________________________________________
 date
-srun --mpi=pmi2 --ntasks=1 ./fesom_ini.x >> ${fname}
+srun --mpi=pmi2 --ntasks=1 ./fesom_meshpart >> ${fname}
 date
 

--- a/work/job_ini_mistral
+++ b/work/job_ini_mistral
@@ -15,12 +15,12 @@ ulimit -s unlimited
 # determine JOBID
 JOBID=`echo $SLURM_JOB_ID |cut -d"." -f1`
 
-ln -s ../bin/fesom_ini.x         .           # cp -n ../bin/fvom_ini.x
+ln -s ../bin/fesom_meshpart      .
 cp -n ../config/namelist.config  .
 cp -n ../config/namelist.forcing .
 cp -n ../config/namelist.oce     .
 cp -n ../config/namelist.ice     .
 
 date
-srun --mpi=pmi2 --ntasks=1 ./fesom_ini.x > "fesom_ini.out"
+srun --mpi=pmi2 --ntasks=1 ./fesom_meshpart > "fesom_meshpartut"
 date

--- a/work/job_ini_mistral
+++ b/work/job_ini_mistral
@@ -22,5 +22,5 @@ cp -n ../config/namelist.oce     .
 cp -n ../config/namelist.ice     .
 
 date
-srun --mpi=pmi2 --ntasks=1 ./fesom_meshpart > "fesom_meshpartut"
+srun --mpi=pmi2 --ntasks=1 ./fesom_meshpart > "fesom_meshpart.out"
 date


### PR DESCRIPTION
Adds a new option BUILD_MESHPARTITIONER to the main fesom build that will build the mesh partitioner as well.

This makes it easier to build it together with the model in the ifs-bundle, so that we can add some automation to generate missing partitioning files. 

I would like to keep this as the only way to build the partitioner to have only one central CMakeLists.txt but I left the current option because I don't know if anything (ESMtools...? @mandresm ) relies on this being build this way. 