### PR TITLE
Add uke advection to dynamic backscatter

### DIFF
--- a/src/MOD_DYN.F90
+++ b/src/MOD_DYN.F90
@@ -109,6 +109,7 @@ TYPE T_DYN
 
     ! coefficients and options for opt_visc=8 (dynamic backscatter)
     logical                                     :: uke_scaling        = .true.
+    logical                                     :: uke_advection      = .false.
     real(kind=WP)                               :: uke_scaling_factor = 1._WP
     real(kind=WP)                               :: rosb_dis           = 1._WP
     integer                                     :: smooth_back        = 2

--- a/src/MOD_DYN.F90
+++ b/src/MOD_DYN.F90
@@ -109,8 +109,8 @@ TYPE T_DYN
 
     ! coefficients and options for opt_visc=8 (dynamic backscatter)
     logical                                     :: uke_scaling        = .true.
-    logical                                     :: uke_advection      = .false.
     real(kind=WP)                               :: uke_scaling_factor = 1._WP
+    logical                                     :: uke_advection      = .false.
     real(kind=WP)                               :: rosb_dis           = 1._WP
     integer                                     :: smooth_back        = 2
     integer                                     :: smooth_dis         = 2

--- a/src/gen_modules_backscatter.F90
+++ b/src/gen_modules_backscatter.F90
@@ -343,9 +343,7 @@ module g_backscatter
                 + elem_area(el)*(advnode(1:nl1,elem2D_nodes(1,el)) &
                 + advnode(1:nl1,elem2D_nodes(2,el)) & 
                 + advnode(1:nl1,elem2D_nodes(3,el)))/ 3.0_WP
-        end do
 
-        do el=1, myDim_elem2D
             do nz=1,nlevels(el)-1   
                 uke_adv(nz,el)=dt*uke_adv(nz,el)/elem_area(el)
             end do

--- a/src/oce_setup_step.F90
+++ b/src/oce_setup_step.F90
@@ -255,7 +255,7 @@ subroutine ocean_setup(dynamics, tracers, partit, mesh)
     
     !___________________________________________________________________________
     ! initialise arrays that are needed for backscatter_coef
-    if(dynamics%opt_visc==8) call init_backscatter(partit, mesh)
+    if(dynamics%opt_visc==8) call init_backscatter(dynamics, partit, mesh)
         
     
     !___________________________________________________________________________
@@ -495,6 +495,7 @@ SUBROUTINE dynamics_init(dynamics, partit, mesh)
     logical        :: use_ivertvisc=.true.
     logical        :: uke_scaling=.true.
     real(kind=WP)  :: uke_scaling_factor=1._WP
+    logical        :: uke_advection=.false.
     real(kind=WP)  :: rosb_dis=1._WP
     integer        :: smooth_back=2
     integer        :: smooth_dis=2
@@ -516,8 +517,8 @@ SUBROUTINE dynamics_init(dynamics, partit, mesh)
     
     namelist /dynamics_visc   / opt_visc, check_opt_visc, visc_gamma0, visc_gamma1, visc_gamma2,  &
                                 use_ivertvisc, visc_easybsreturn, &
-                                uke_scaling, uke_scaling_factor, rosb_dis, smooth_back,           &
-                                smooth_dis, smooth_back_tend, K_back, c_back
+                                uke_scaling, uke_scaling_factor, uke_advection, &
+                                rosb_dis, smooth_back, smooth_dis, smooth_back_tend, K_back, c_back
 
     namelist /dynamics_general/ momadv_opt, use_freeslip, use_wsplit, wsplit_maxcfl, & 
                                 ldiag_KE, AB_order,                                  &
@@ -557,6 +558,7 @@ nl => mesh%nl
     dynamics%visc_easybsreturn   = visc_easybsreturn
     dynamics%uke_scaling         = uke_scaling
     dynamics%uke_scaling_factor  = uke_scaling_factor
+    dynamics%uke_advection       = uke_advection
     dynamics%rosb_dis            = rosb_dis
     dynamics%smooth_back         = smooth_back
     dynamics%smooth_dis          = smooth_dis


### PR DESCRIPTION
Implementation of uke advection for dynamic backscatter viscosity option. Original codes from Ekaterina Bagaeva ([https://doi.org/10.1029/2023MS003972](https://doi.org/10.1029/2023MS003972)). New flag added in namelist.dyn to turn on uke advection, defaults to False. 