### PR TITLE
Add make uninstall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,16 @@ foreach( _file fesom-config.cmake fesom-config-version.cmake fesom-targets.cmake
   execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink ${PROJECT_BINARY_DIR}/src/${_file} ${PROJECT_BINARY_DIR}/${_file}  )
 endforeach()
 
+# Add uninstall target
+if(NOT TARGET uninstall)
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
+  add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()
+
 # Define ${PROJECT_NAME}_DIR in PARENT_SCOPE so that a `find_package( <this-project> )` in a bundle
 # will easily find the project without requiring a `HINT <this-project>_BINARY_DIR` argument
 if( NOT CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR )

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -1,0 +1,21 @@
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    execute_process(
+      COMMAND ${CMAKE_COMMAND} -E remove "$ENV{DESTDIR}${file}"
+      OUTPUT_VARIABLE rm_out
+      RESULT_VARIABLE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+  else()
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif()
+endforeach()

--- a/configure.sh
+++ b/configure.sh
@@ -6,10 +6,60 @@ HERE=$PWD
 SOURCE_DIR="$( cd $( dirname "${BASH_SOURCE[0]}" ) && pwd -P )"
 BUILD_DIR=${BUILD_DIR:-build}
 
-source env.sh # source this from your run script too
+# Parse arguments
+CLEAN_BUILD=false
+ENV_ARGS=()
+
+# Process arguments
+for arg in "$@"; do
+    if [ "$arg" = "--clean" ]; then
+        CLEAN_BUILD=true
+    else
+        ENV_ARGS+=("$arg")
+    fi
+done
+
+# Clean if requested - do this before sourcing env.sh as cleaning doesn't need environment setup
+if [ "$CLEAN_BUILD" = true ]; then
+    echo "Cleaning build directory and installed files..."
+    if [ -d "${BUILD_DIR}" ]; then
+        if [ -f "${BUILD_DIR}/CMakeCache.txt" ]; then
+            # Only attempt make clean and uninstall if we have a valid build directory
+            cd ${BUILD_DIR}
+            echo "Running make clean..."
+            make clean 2>/dev/null || true
+            
+            echo "Running make uninstall..."
+            make uninstall 2>/dev/null || echo "No uninstall target available"
+            
+            cd ${HERE}
+        fi
+        
+        # Remove the build directory for a completely fresh build
+        echo "Removing build directory..."
+        rm -rf ${BUILD_DIR}
+    fi
+    echo "Clean completed successfully"
+    # Recreate build directory
+    mkdir -p ${BUILD_DIR}
+fi
+
+# Source environment with the original arguments (minus --clean)
+source env.sh "${ENV_ARGS[@]}"
+
 mkdir -p ${BUILD_DIR} # make sure not to commit this to svn or git
 cd ${BUILD_DIR}
-cmake ${SOURCE_DIR} -DCMAKE_INSTALL_PREFIX=$HERE -DCMAKE_BUILD_TYPE=Debug ${CMAKE_ARGS} $@
+
+# Don't pass environment arguments (like 'ubuntu') to cmake
+# Only pass arguments that start with - (like -DENABLE_OPENMP=ON)
+CMAKE_ONLY_ARGS=""
+for arg in "${ENV_ARGS[@]}"; do
+    if [[ "$arg" =~ ^- ]]; then
+        CMAKE_ONLY_ARGS="$CMAKE_ONLY_ARGS $arg"
+    fi
+done
+
+cmake ${SOURCE_DIR} -DCMAKE_INSTALL_PREFIX=$HERE -DCMAKE_BUILD_TYPE=Debug ${CMAKE_ARGS} ${CMAKE_ONLY_ARGS}
     # not required when re-compiling
     # additional cmake arguments can be passed to configure.sh
     # this also includes fesom specific options in CMakeLists, can be used as -DFESOM_COUPLED=ON


### PR DESCRIPTION
adds ability to clean the build and **install** either from build directory with make uninstall or using convenience script ./configure.sh --clean levante.gnu all previous options are supported.

also tested when install is else where (not in fesom root dir) like for use with IFS with ./configure.sh --clean levante.intel -DCMAKE_INSTALL_PREFIX=/blah/blah.

enables a tiny step towards agentic builds.