### PR TITLE
Runid fixes

### DIFF
--- a/src/gen_modules_config.F90
+++ b/src/gen_modules_config.F90
@@ -11,7 +11,7 @@ module g_config
   save
   !_____________________________________________________________________________
   ! *** Modelname ***
-  character(5)           :: runid='test1'       ! a model/setup name
+  character(10)           :: runid='test1'       ! a model/setup name
   namelist /modelname/ runid
   
   !_____________________________________________________________________________

--- a/src/io_mesh_info.F90
+++ b/src/io_mesh_info.F90
@@ -62,7 +62,7 @@ implicit none
 
   call MPI_AllREDUCE(maxval(nod_in_elem2D_num), N_max, 1, MPI_INTEGER, MPI_MAX, MPI_COMM_FESOM, MPIerr)
 
-  filename=trim(ResultPath)//runid//'.mesh.diag.nc'
+  filename=trim(ResultPath)//trim(runid)//'.mesh.diag.nc'
   call my_create(filename, IOR(NF_CLOBBER,IOR(NF_NETCDF4,NF_CLASSIC_MODEL)), ncid, partit)
 
   ! NOTE(PG): For naming conventions of node, edge, face, please see here:

--- a/src/io_restart.F90
+++ b/src/io_restart.F90
@@ -300,12 +300,12 @@ subroutine restart(istep, nstart, ntotal, l_read, which_readr, ice, dynamics, tr
   ! initialize directory for core dump restart 
   if(.not. initialized_raw) then
     initialized_raw = .true.
-    raw_restart_dirpath  = trim(ResultPath)//"fesom_raw_restart/np"//int_to_txt(partit%npes)
-    raw_restart_infopath = trim(ResultPath)//"fesom_raw_restart/np"//int_to_txt(partit%npes)//".info"
+    raw_restart_dirpath  = trim(ResultPath)//trim(runid)//"_raw_restart/np"//int_to_txt(partit%npes)
+    raw_restart_infopath = trim(ResultPath)//trim(runid)//"_raw_restart/np"//int_to_txt(partit%npes)//".info"
     if(raw_restart_length_unit /= "off") then
       if(partit%mype == RAW_RESTART_METADATA_RANK) then
         ! execute_command_line with mkdir sometimes fails, use a custom implementation around mkdir from C instead
-        call mkdir(trim(ResultPath)//"fesom_raw_restart") ! we have no mkdir -p, create the intermediate dirs separately
+        call mkdir(trim(ResultPath)//trim(runid)//"_raw_restart") ! we have no mkdir -p, create the intermediate dirs separately
         call mkdir(raw_restart_dirpath)
       end if
       call MPI_Barrier(partit%MPI_COMM_FESOM, mpierr) ! make sure the dir has been created before we continue...
@@ -316,12 +316,12 @@ subroutine restart(istep, nstart, ntotal, l_read, which_readr, ice, dynamics, tr
   ! initialize directory for derived type binary restart
   if(.not. initialized_bin) then
     initialized_bin = .true.
-    bin_restart_dirpath  = trim(ResultPath)//"fesom_bin_restart/np"//int_to_txt(partit%npes)
-    bin_restart_infopath = trim(ResultPath)//"fesom_bin_restart/np"//int_to_txt(partit%npes)//".info"
+    bin_restart_dirpath  = trim(ResultPath)//trim(runid)//"_bin_restart/np"//int_to_txt(partit%npes)
+    bin_restart_infopath = trim(ResultPath)//trim(runid)//"_bin_restart/np"//int_to_txt(partit%npes)//".info"
     if(bin_restart_length_unit /= "off") then
         if(partit%mype == RAW_RESTART_METADATA_RANK) then
             ! execute_command_line with mkdir sometimes fails, use a custom implementation around mkdir from C instead
-            call mkdir(trim(ResultPath)//"fesom_bin_restart") ! we have no mkdir -p, create the intermediate dirs separately
+            call mkdir(trim(ResultPath)//trim(runid)//"_bin_restart") ! we have no mkdir -p, create the intermediate dirs separately
             call mkdir(bin_restart_dirpath)
         end if
         call MPI_Barrier(partit%MPI_COMM_FESOM, mpierr) ! make sure the dir has been created before we continue...


### PR DESCRIPTION
tiny fixes for when runid is used it should consistently be used in naming (useful for testing and benchmarking without need to create new result dirs)
- fixes name of meshdiag not to have empty spaces when runid is smaller then its defined size. 
- fixes names of bin restart and raw restart dirs to use runid.