### PR TITLE
Fix cmake install rpath paths for meshpart

### DIFF
--- a/.github/workflows/metis.yml
+++ b/.github/workflows/metis.yml
@@ -38,5 +38,5 @@ jobs:
       - name: Run partitioner
         run: |
           cd work_pi
-          cp ../bin/fesom_ini.x .
+          ln ../bin/fesom_ini.x .
           ./fesom_ini.x

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ endif()
 
 project(FESOM2.0)
 
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake ${CMAKE_MODULE_PATH})
+
 set(BUILD_SHARED_LIBS ON CACHE BOOL "Default to using shared libs")
 set(TOPLEVEL_DIR ${CMAKE_CURRENT_LIST_DIR})
 set(FESOM_COUPLED OFF CACHE BOOL "compile fesom standalone or with oasis support (i.e. coupled)")

--- a/mesh_part/CMakeLists.txt
+++ b/mesh_part/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(fesom_meshpart C Fortran)
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake ${CMAKE_MODULE_PATH})
+include(fesom_setup)
 
 # Find required packages
 find_package(MPI REQUIRED)
@@ -7,13 +9,13 @@ find_package(MPI REQUIRED)
 # Determine source directory - works for both standalone and integrated builds
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     # This is a standalone build
-    set(src_home ${CMAKE_SOURCE_DIR}/../src)
-    set(METIS_ROOT ${CMAKE_SOURCE_DIR}/../lib/metis-5.1.0)
+    set(src_home ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+    set(METIS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../lib/metis-5.1.0)
     message(STATUS "Building as standalone mesh partitioner")
     
     # Set default install prefix if not specified
     if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-        set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/.. CACHE PATH "Install path prefix" FORCE)
+        set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/.. CACHE PATH "Install path prefix" FORCE)
     endif()
     
     # Add uninstall target
@@ -27,8 +29,10 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     endif()
 else()
     # This is part of the main FESOM build
-    set(src_home ${CMAKE_SOURCE_DIR}/src)
-    set(METIS_ROOT ${CMAKE_SOURCE_DIR}/lib/metis-5.1.0)
+    set(src_home ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+    set(METIS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../lib/metis-5.1.0)
+    #set(src_home ${CMAKE_SOURCE_DIR}/src)
+    #set(METIS_ROOT ${CMAKE_SOURCE_DIR}/lib/metis-5.1.0)
     message(STATUS "Building as part of FESOM main build")
 endif()
 
@@ -111,7 +115,7 @@ elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
         target_compile_options(${PROJECT_NAME} PRIVATE -fallow-argument-mismatch)
     endif()
 endif()
-target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_C MPI::MPI_Fortran)
+target_link_libraries(${PROJECT_NAME} PUBLIC ${PROJECT_NAME}_C MPI::MPI_Fortran)
 set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE Fortran)
 
 # Install the executable

--- a/mesh_part/configure.sh
+++ b/mesh_part/configure.sh
@@ -57,8 +57,8 @@ fi
 mkdir -p "${BIN_DIR}"
 
 # Create a symlink in the bin directory
-ln -sf "${BUILD_DIR}/fesom_meshpart" "${BIN_DIR}/fesom_meshpart"
-ln -sf "${BUILD_DIR}/fesom_meshpart" "${BIN_DIR}/fesom_ini.x"
+ln -sf "${BUILD_DIR}/bin/fesom_meshpart" "${BIN_DIR}/fesom_meshpart"
+ln -sf "${BUILD_DIR}/bin/fesom_meshpart" "${BIN_DIR}/fesom_ini.x"
 
 # Install the executable
 make install

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 # Include our testing utilities
-include(${CMAKE_SOURCE_DIR}/cmake/FesomTesting.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/FesomTesting.cmake)
 
 # Set up MPI for testing
 setup_mpi_testing()


### PR DESCRIPTION
this fixes issues with using fesom as library in other project like IFS,  RPATH used in case of mesh_part was not properly set needing needless LD_LIBRARY_PATH to be set. 