### PR TITLE
Add ecbundle support

### DIFF
--- a/.github/workflows/ecbundle_release.yml
+++ b/.github/workflows/ecbundle_release.yml
@@ -1,0 +1,254 @@
+name: FESOM2 ecbundle CTest Framework (Release)
+
+# Run on pull requests to main and manual workflow dispatch
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches: [ main ]
+# TODO: Uncomment this when we have a release workflow
+#  release:
+#    types: [published, created]
+  
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      continue_on_test_failure:
+        description: 'Continue workflow even if tests fail'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+      test_timeout:
+        description: 'Test timeout in seconds'
+        required: false
+        default: '600'
+        type: string
+      test_pattern:
+        description: 'Run only tests matching this pattern (optional)'
+        required: false
+        default: ''
+        type: string
+      build_type:
+        description: 'CMake build type'
+        required: false
+        default: 'Release'
+        type: choice
+        options:
+          - 'Debug'
+          - 'Release'
+          - 'RelWithDebInfo'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  ecbundle_ctest_framework:
+    # Run directly on Ubuntu runner
+    runs-on: ubuntu-latest
+    
+    env:
+      # Set environment variables for the build
+      CC: gcc
+      CXX: g++
+      FC: gfortran
+      OMPI_MCA_rmaps_base_oversubscribe: yes
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Install system dependencies
+        run: |
+          echo "Installing FESOM2 dependencies..."
+          sudo apt-get update
+          sudo apt-get install -y \
+            gcc \
+            gfortran \
+            g++ \
+            cmake \
+            make \
+            openmpi-bin \
+            libopenmpi-dev \
+            libnetcdf-dev \
+            libnetcdff-dev \
+            pkg-config \
+            git \
+            wget \
+            ca-certificates \
+            gnupg \
+            lsb-release \
+            python3 \
+            python3-pip
+          
+          echo "Installing CMake 3.25+ from Kitware repository..."
+          # Add Kitware's signing key
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+          
+          # Add Kitware repository
+          echo "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
+          
+          # Update package list and install latest CMake
+          sudo apt-get update
+          sudo apt-get install -y cmake
+          
+          echo "Installing ecbundle..."
+          pip install ecbundle
+          
+          echo "Verifying installations..."
+          gcc --version
+          gfortran --version
+          mpirun --version
+          cmake --version
+          pkg-config --modversion netcdf
+          pkg-config --modversion netcdf-fortran
+          ecbundle --version
+          
+      - name: Set up environment variables
+        run: |
+          echo "Setting up environment for FESOM2 build..."
+          
+          # Set NetCDF paths
+          echo "NETCDF_ROOT=/usr" >> $GITHUB_ENV
+          echo "NETCDF_Fortran_ROOT=/usr" >> $GITHUB_ENV
+          
+          # Set compiler flags for better compatibility
+          echo "FCFLAGS=-fallow-argument-mismatch" >> $GITHUB_ENV
+          echo "FFLAGS=-fallow-argument-mismatch" >> $GITHUB_ENV
+          
+          # MPI settings for GitHub Actions
+          echo "OMPI_MCA_btl_vader_single_copy_mechanism=none" >> $GITHUB_ENV
+          echo "OMPI_MCA_rmaps_base_oversubscribe=yes" >> $GITHUB_ENV
+          echo "OMPI_MCA_btl_base_warn_component_unused=0" >> $GITHUB_ENV
+      
+      - name: Set up ecbundle bundle
+        run: |
+          echo "Setting up ecbundle bundle..."
+          
+          # Create bundle
+          ecbundle-create
+          
+          echo "ecbundle bundle setup completed"
+      
+      - name: Configure FESOM2 build with ecbundle
+        run: |
+          echo "Configuring FESOM2 build with ecbundle..."
+          
+          # Create build directory
+          mkdir -p build
+          cd build
+          
+          # Configure with CMake directly (skip configure.sh for more control)
+          cmake \
+            -DCMAKE_BUILD_TYPE=${{ github.event.inputs.build_type || 'Release' }} \
+            -DBUILD_TESTING=ON \
+            -DENABLE_INTEGRATION_TESTS=ON \
+            -DENABLE_MPI_TESTS=ON \
+            -DTEST_TIMEOUT=${{ github.event.inputs.test_timeout || '600' }} \
+            -DCMAKE_C_COMPILER=gcc \
+            -DCMAKE_CXX_COMPILER=g++ \
+            -DCMAKE_Fortran_COMPILER=gfortran \
+            -DMPI_C_COMPILER=mpicc \
+            -DMPI_CXX_COMPILER=mpicxx \
+            -DMPI_Fortran_COMPILER=mpifort \
+            -DNetCDF_ROOT=/usr \
+            -DNetCDF_Fortran_ROOT=/usr \
+            -DCMAKE_Fortran_FLAGS="-fallow-argument-mismatch" \
+            ../source
+          
+          echo "CMake configuration completed"
+      
+      - name: Build FESOM2 with ecbundle
+        run: |
+          echo "Building FESOM2 with ecbundle..."
+          cd build
+          
+          # Build with multiple cores
+          make -j$(nproc) VERBOSE=1
+          
+          echo "Build completed successfully"
+          
+          # Verify executable exists
+          if [ -f "bin/fesom.x" ]; then
+            echo "✅ FESOM2 executable created successfully"
+            ls -la bin/fesom.x
+          else
+            echo "❌ FESOM2 executable not found"
+            find . -name "fesom.x" -type f || echo "No fesom.x found anywhere"
+            exit 1
+          fi
+            
+      - name: List available tests
+        run: |
+          echo "Discovering available tests..."
+          cd build
+          
+          # List tests in different formats
+          echo "=== Available Tests (Summary) ==="
+          ctest -N
+          
+          echo ""
+          echo "=== Available Tests (Detailed JSON) ==="
+          ctest --show-only=json-v1 > available_tests.json
+          
+          echo ""
+          echo "=== Test Count Summary ==="
+          ctest -N | grep "Total Tests:" || echo "No tests found or different format"
+          
+          # Show test details if available
+          if [ -f available_tests.json ]; then
+            echo ""
+            echo "=== Test Details ==="
+            cat available_tests.json | jq '.tests[].name' 2>/dev/null || echo "jq not available, raw JSON saved"
+          fi
+      
+      - name: Run ecbundle CTest framework
+        id: run_tests
+        continue-on-error: ${{ github.event.inputs.continue_on_test_failure == 'true' || github.event.inputs.continue_on_test_failure == '' }}
+        run: |
+          cd build
+          echo "Running selected ecbundle tests..."
+          
+          # Set test pattern if provided via workflow dispatch
+          TEST_PATTERN="${{ github.event.inputs.test_pattern }}"
+          
+          # Configure test execution parameters
+          CTEST_ARGS="--output-on-failure --verbose --timeout ${{ github.event.inputs.test_timeout || '600' }}"
+          
+          if [ -n "$TEST_PATTERN" ]; then
+            echo "Running tests matching pattern: $TEST_PATTERN"
+            ctest $CTEST_ARGS -R "$TEST_PATTERN"
+          else
+            echo "Running selected ecbundle tests:"
+            echo "- ecbundle_basic_build"
+            echo "- ecbundle_with_meshpart"
+            echo "- ecbundle_with_omp"
+            
+            # Run only the specified ecbundle tests using regex pattern
+            ctest $CTEST_ARGS -R "(ecbundle_basic_build|ecbundle_with_meshpart|ecbundle_with_omp)"
+          fi
+          
+          # Capture exit code
+          TEST_EXIT_CODE=$?
+          echo "CTest exit code: $TEST_EXIT_CODE"
+          
+          # Save exit code for later steps
+          echo "TEST_EXIT_CODE=$TEST_EXIT_CODE" >> $GITHUB_ENV
+      
+      - name: Create test summary
+        run: |
+          echo "## FESOM2 ecbundle CTest Summary" >> $GITHUB_STEP_SUMMARY
+          echo "**Release Tag:** ${{ github.event.release.tag_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Build Type:** ${{ github.event.inputs.build_type || 'Release' }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Tests Run:** ecbundle_basic_build, ecbundle_with_meshpart, ecbundle_with_omp" >> $GITHUB_STEP_SUMMARY
+          echo "**Test Exit Code:** ${{ env.TEST_EXIT_CODE }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          if [ "${{ env.TEST_EXIT_CODE }}" -eq 0 ]; then
+            echo "✅ All ecbundle tests passed successfully!" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "❌ Some ecbundle tests failed. Check the logs for details." >> $GITHUB_STEP_SUMMARY
+          fi 

--- a/.github/workflows/fesom2_ctest_runner.yml
+++ b/.github/workflows/fesom2_ctest_runner.yml
@@ -193,9 +193,9 @@ jobs:
         continue-on-error: ${{ github.event.inputs.continue_on_test_failure == 'true' || github.event.inputs.continue_on_test_failure == '' }}
         run: |
           cd build
-          echo "Running FESOM2 test suite..."
+          echo "Running selected FESOM2 tests..."
           
-          # Set test pattern if provided
+          # Set test pattern if provided via workflow dispatch
           TEST_PATTERN="${{ github.event.inputs.test_pattern }}"
           
           # Configure test execution parameters
@@ -205,8 +205,14 @@ jobs:
             echo "Running tests matching pattern: $TEST_PATTERN"
             ctest $CTEST_ARGS -R "$TEST_PATTERN"
           else
-            echo "Running all available tests"
-            ctest $CTEST_ARGS
+            echo "Running selected integration tests:"
+            echo "- integration_full_run_mpi2"
+            echo "- integration_full_run_mpi8" 
+            echo "- integration_pi_cavity_mpi2"
+            echo "- integration_test_data_check"
+            
+            # Run only the specified tests using regex pattern
+            ctest $CTEST_ARGS -R "(integration_full_run_mpi2|integration_full_run_mpi8|integration_pi_cavity_mpi2|integration_test_data_check)"
           fi
           
           # Capture exit code

--- a/bundle.yml
+++ b/bundle.yml
@@ -4,7 +4,7 @@
 ### to build ecbundle-build --help 
 ### e.g,: ecbundle-build --with-meshpart=ON will build meshpartitioner along
 name    : fesom-bundle
-version : 2.x
+version : 2.6
 projects :
 
   #    - ecbuild :
@@ -14,7 +14,7 @@ projects :
 
     - fesom :
         git     : https://github.com/FESOM/fesom2.git
-        version : main
+        version : add_ecbundle_support
         cmake   : >
             ENABLE_IFS_INTERFACE=OFF
             DISABLE_MULTITHREADING=ON

--- a/bundle.yml
+++ b/bundle.yml
@@ -1,6 +1,8 @@
 ---
 ### Bundle
-
+### to create bundle use ecbundle-create; it downloads sources
+### to build ecbundle-build --help 
+### e.g,: ecbundle-build --with-meshpart=ON will build meshpartitioner along
 name    : fesom-bundle
 version : 2.x
 projects :

--- a/bundle.yml
+++ b/bundle.yml
@@ -1,0 +1,42 @@
+---
+### Bundle
+
+name    : fesom-bundle
+version : 2.x
+projects :
+
+  #    - ecbuild :
+  #      git     : https://github.com/ecmwf/ecbuild
+  #      version : main
+  #      bundle  : false
+
+    - fesom :
+        git     : https://github.com/FESOM/fesom2.git
+        version : main
+        cmake   : >
+            ENABLE_IFS_INTERFACE=OFF
+            DISABLE_MULTITHREADING=ON
+            ENABLE_OPENMP=OFF
+            BUILD_MESHPARTITIONER=OFF
+            BUILD_TESTING=OFF
+
+options :
+
+  - with-testing:
+        help  : Build with fesom testing [ON|OFF]
+        cmake : BUILD_TESTING={{value}}
+
+  - with-meshpart:
+        help  : Build also the mesh partitioner [ON|OFF]
+        cmake : BUILD_MESHPARTITIONER={{value}}
+
+  - with-omp-parallel:
+        help  : Build with openmp support
+        cmake : >
+            ENABLE_OPENMP=ON
+            OPENMP_REPRODUCIBLE=OFF
+  - with-omp-parallel-reproducable:
+        help  : Build with openmp support and reproducable
+        cmake : >
+            ENABLE_OPENMP=ON
+            OPENMP_REPRODUCIBLE=ON

--- a/mesh_part/configure.sh
+++ b/mesh_part/configure.sh
@@ -57,8 +57,8 @@ fi
 mkdir -p "${BIN_DIR}"
 
 # Create a symlink in the bin directory
-ln -sf "${BUILD_DIR}/fesom_meshpart" "${BIN_DIR}/fesom_meshpart"
-ln -sf "${BUILD_DIR}/fesom_meshpart" "${BIN_DIR}/fesom_ini.x"
+ln -sf "${BUILD_DIR}/bin/fesom_meshpart" "${BIN_DIR}/fesom_meshpart"
+ln -sf "${BUILD_DIR}/bin/fesom_meshpart" "${BIN_DIR}/fesom_ini.x"
 
 # Install the executable
 make install

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,11 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/CMakeLists.txt")
     add_subdirectory(unit)
 endif()
 
+# Add ecbundle tests if ecbundle is available
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ecbundle/CMakeLists.txt")
+    add_subdirectory(ecbundle)
+endif()
+
 # Create a convenience target to run all tests
 add_custom_target(run_tests
     COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure

--- a/tests/ecbundle/CMakeLists.txt
+++ b/tests/ecbundle/CMakeLists.txt
@@ -1,0 +1,93 @@
+#===============================================================================
+# tests/ecbundle/CMakeLists.txt - ecbundle build tests for FESOM2
+#===============================================================================
+
+# Check if ecbundle is available
+find_program(ECBUNDLE_CREATE ecbundle-create)
+find_program(ECBUNDLE_BUILD ecbundle-build)
+
+if(NOT ECBUNDLE_CREATE OR NOT ECBUNDLE_BUILD)
+    message(WARNING "ecbundle tools not found. Skipping ecbundle tests.")
+    message(STATUS "To install ecbundle, see: https://github.com/ecmwf/ecbundle")
+    return()
+endif()
+
+message(STATUS "Found ecbundle tools:")
+message(STATUS "  ecbundle-create: ${ECBUNDLE_CREATE}")
+message(STATUS "  ecbundle-build: ${ECBUNDLE_BUILD}")
+
+# Create test directory
+set(ECBUNDLE_TEST_DIR "${CMAKE_BINARY_DIR}/test_ecbundle")
+file(MAKE_DIRECTORY "${ECBUNDLE_TEST_DIR}")
+
+# Test 1: Basic ecbundle build (default options)
+add_test(
+    NAME ecbundle_basic_build
+    COMMAND ${CMAKE_COMMAND}
+        -DECBUNDLE_CREATE=${ECBUNDLE_CREATE}
+        -DECBUNDLE_BUILD=${ECBUNDLE_BUILD}
+        -DBUNDLE_FILE=${CMAKE_SOURCE_DIR}/bundle.yml
+        -DTEST_DIR=${ECBUNDLE_TEST_DIR}/basic
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/test_ecbundle_basic.cmake
+)
+
+set_tests_properties(ecbundle_basic_build PROPERTIES
+    TIMEOUT 1800  # 30 minutes timeout
+    LABELS "ecbundle"
+)
+
+# Test 2: ecbundle build with meshpartitioner enabled
+add_test(
+    NAME ecbundle_with_meshpart
+    COMMAND ${CMAKE_COMMAND}
+        -DECBUNDLE_CREATE=${ECBUNDLE_CREATE}
+        -DECBUNDLE_BUILD=${ECBUNDLE_BUILD}
+        -DBUNDLE_FILE=${CMAKE_SOURCE_DIR}/bundle.yml
+        -DTEST_DIR=${ECBUNDLE_TEST_DIR}/meshpart
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/test_ecbundle_meshpart.cmake
+)
+
+set_tests_properties(ecbundle_with_meshpart PROPERTIES
+    TIMEOUT 1800  # 30 minutes timeout
+    LABELS "ecbundle"
+)
+
+# Test 3: ecbundle build with OpenMP support
+add_test(
+    NAME ecbundle_with_omp
+    COMMAND ${CMAKE_COMMAND}
+        -DECBUNDLE_CREATE=${ECBUNDLE_CREATE}
+        -DECBUNDLE_BUILD=${ECBUNDLE_BUILD}
+        -DBUNDLE_FILE=${CMAKE_SOURCE_DIR}/bundle.yml
+        -DTEST_DIR=${ECBUNDLE_TEST_DIR}/omp
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/test_ecbundle_omp.cmake
+)
+
+set_tests_properties(ecbundle_with_omp PROPERTIES
+    TIMEOUT 1800  # 30 minutes timeout
+    LABELS "ecbundle"
+)
+
+# Test 4: ecbundle build with testing enabled
+add_test(
+    NAME ecbundle_with_testing
+    COMMAND ${CMAKE_COMMAND}
+        -DECBUNDLE_CREATE=${ECBUNDLE_CREATE}
+        -DECBUNDLE_BUILD=${ECBUNDLE_BUILD}
+        -DBUNDLE_FILE=${CMAKE_SOURCE_DIR}/bundle.yml
+        -DTEST_DIR=${ECBUNDLE_TEST_DIR}/testing
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/test_ecbundle_testing.cmake
+)
+
+set_tests_properties(ecbundle_with_testing PROPERTIES
+    TIMEOUT 1800  # 30 minutes timeout
+    LABELS "ecbundle"
+)
+
+# Create a convenience target to run all ecbundle tests
+add_custom_target(run_ecbundle_tests
+    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -L ecbundle
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Running FESOM2 ecbundle tests"
+    VERBATIM
+) 

--- a/tests/ecbundle/README.md
+++ b/tests/ecbundle/README.md
@@ -24,7 +24,7 @@ Tests the basic ecbundle build process using default options from `bundle.yml`.
 - `ecbundle-create` successfully downloads FESOM sources
 - `ecbundle-build` successfully builds FESOM with default options
 - FESOM executable is created and is executable
-- Basic functionality test (--help command)
+- Basic functionality test (--info command)
 
 ### 2. `ecbundle_with_meshpart`
 Tests building FESOM with meshpartitioner enabled using `--with-meshpart=ON`.
@@ -32,7 +32,8 @@ Tests building FESOM with meshpartitioner enabled using `--with-meshpart=ON`.
 **What it tests:**
 - All basic build functionality
 - Meshpartitioner executable is created and is executable
-- Both FESOM and meshpartitioner executables are functional
+- Meshpartitioner correctly fails with namelist.config error (expected behavior)
+- FESOM executable is functional (--info command)
 
 ### 3. `ecbundle_with_omp`
 Tests building FESOM with OpenMP support using `--with-omp-parallel`.
@@ -41,6 +42,7 @@ Tests building FESOM with OpenMP support using `--with-omp-parallel`.
 - All basic build functionality
 - Checks for OpenMP library linkage using `ldd` and `nm`
 - Verifies OpenMP support was properly configured
+- FESOM executable is functional (--info command)
 
 ### 4. `ecbundle_with_testing`
 Tests building FESOM with testing enabled using `--with-testing=ON`.
@@ -49,6 +51,7 @@ Tests building FESOM with testing enabled using `--with-testing=ON`.
 - All basic build functionality
 - Checks for test executables and test files
 - Attempts to run tests using CTest if available
+- FESOM executable is functional (--info command)
 
 ## Running the Tests
 

--- a/tests/ecbundle/README.md
+++ b/tests/ecbundle/README.md
@@ -1,0 +1,137 @@
+# FESOM2 ecbundle Tests
+
+This directory contains CTest tests for building FESOM2 using ecbundle.
+
+## Overview
+
+ecbundle is a tool from ECMWF that helps manage and build software bundles. It provides two main scripts:
+- `ecbundle-create`: Downloads and checks out sources based on a bundle configuration
+- `ecbundle-build`: Builds the software using CMake with various options
+
+## Prerequisites
+
+1. **Install ecbundle**: Follow the installation instructions at https://github.com/ecmwf/ecbundle
+2. **Ensure ecbundle tools are in PATH**: The tests look for `ecbundle-create` and `ecbundle-build` executables
+
+## Available Tests
+
+The following tests are available:
+
+### 1. `ecbundle_basic_build`
+Tests the basic ecbundle build process using default options from `bundle.yml`.
+
+**What it tests:**
+- `ecbundle-create` successfully downloads FESOM sources
+- `ecbundle-build` successfully builds FESOM with default options
+- FESOM executable is created and is executable
+- Basic functionality test (--help command)
+
+### 2. `ecbundle_with_meshpart`
+Tests building FESOM with meshpartitioner enabled using `--with-meshpart=ON`.
+
+**What it tests:**
+- All basic build functionality
+- Meshpartitioner executable is created and is executable
+- Both FESOM and meshpartitioner executables are functional
+
+### 3. `ecbundle_with_omp`
+Tests building FESOM with OpenMP support using `--with-omp-parallel`.
+
+**What it tests:**
+- All basic build functionality
+- Checks for OpenMP library linkage using `ldd` and `nm`
+- Verifies OpenMP support was properly configured
+
+### 4. `ecbundle_with_testing`
+Tests building FESOM with testing enabled using `--with-testing=ON`.
+
+**What it tests:**
+- All basic build functionality
+- Checks for test executables and test files
+- Attempts to run tests using CTest if available
+
+## Running the Tests
+
+### From CMake build directory:
+```bash
+# Run all ecbundle tests
+ctest -L ecbundle
+
+# Run a specific test
+ctest -R ecbundle_basic_build
+
+# Run with verbose output
+ctest -L ecbundle --output-on-failure
+```
+
+### Using the convenience target:
+```bash
+# Run all ecbundle tests
+make run_ecbundle_tests
+```
+
+### From the test directory:
+```bash
+# Run all ecbundle tests
+cd test/ecbundle
+ctest --output-on-failure
+```
+
+## Test Configuration
+
+### Timeout
+Each test has a 30-minute timeout (1800 seconds) to account for download and build times.
+
+### Test Directory Structure
+Tests create the following structure in `${CMAKE_BINARY_DIR}/test_ecbundle/`:
+```
+test_ecbundle/
+├── basic/           # Basic build test
+├── meshpart/        # Meshpartitioner test
+├── omp/            # OpenMP test
+└── testing/        # Testing enabled test
+```
+
+Each subdirectory contains:
+- `sources/` - Downloaded source code
+- `build/` - Build artifacts and executables
+
+## Bundle Configuration
+
+The tests use the `bundle.yml` file from the FESOM2 root directory, which defines:
+- FESOM2 source repository and version
+- Default CMake options
+- Available build options (meshpart, OpenMP, testing)
+
+## Troubleshooting
+
+### ecbundle tools not found
+If you see a warning about ecbundle tools not being found:
+1. Ensure ecbundle is properly installed
+2. Check that `ecbundle-create` and `ecbundle-build` are in your PATH
+3. Try running `which ecbundle-create` and `which ecbundle-build`
+
+### Build failures
+- Check that all required dependencies are installed
+- Verify network connectivity for downloading sources
+- Check build logs in the test directories for specific error messages
+
+### Test timeouts
+- Increase the timeout in the CMakeLists.txt if builds take longer on your system
+- Check system resources (CPU, memory, disk space)
+
+## Adding New Tests
+
+To add a new ecbundle test:
+
+1. Create a new test script (e.g., `test_ecbundle_newfeature.cmake`)
+2. Add the test to `CMakeLists.txt` following the existing pattern
+3. Update this README with documentation for the new test
+
+## Integration with CI/CD
+
+These tests can be integrated into continuous integration pipelines to ensure:
+- ecbundle builds work correctly
+- Different build configurations are tested
+- Build artifacts are properly created
+- No regressions in the build process 

--- a/tests/ecbundle/test_ecbundle_basic.cmake
+++ b/tests/ecbundle/test_ecbundle_basic.cmake
@@ -87,25 +87,24 @@ if(NOT EXEC_TEST_RESULT EQUAL 0)
     message(FATAL_ERROR "FESOM executable is not executable")
 endif()
 
-# Step 4: Test that the executable can run (version check)
+# Step 4: Test that the executable can run (info check)
 message(STATUS "Step 4: Testing FESOM executable...")
 execute_process(
-    COMMAND ${TEST_DIR}/build/bin/fesom.x --help
-    RESULT_VARIABLE HELP_RESULT
-    OUTPUT_VARIABLE HELP_OUTPUT
-    ERROR_VARIABLE HELP_ERROR
+    COMMAND ${TEST_DIR}/build/bin/fesom.x --info
+    RESULT_VARIABLE INFO_RESULT
+    OUTPUT_VARIABLE INFO_OUTPUT
+    ERROR_VARIABLE INFO_ERROR
     OUTPUT_STRIP_TRAILING_WHITESPACE
     ERROR_STRIP_TRAILING_WHITESPACE
 )
 
-# Note: We don't fail here if --help doesn't work, as FESOM does not support it
-# But we log the result for debugging
-if(HELP_RESULT EQUAL 0)
-    message(STATUS "FESOM --help command successful")
-    message(STATUS "Help output: ${HELP_OUTPUT}")
+# FESOM should return info successfully
+if(INFO_RESULT EQUAL 0)
+    message(STATUS "FESOM --info command successful")
+    message(STATUS "Info output: ${INFO_OUTPUT}")
 else()
-    message(STATUS "FESOM --help command failed (this might be expected)")
-    message(STATUS "Help error: ${HELP_ERROR}")
+    message(FATAL_ERROR "FESOM --info command failed")
+    message(FATAL_ERROR "Info error: ${INFO_ERROR}")
 endif()
 
 message(STATUS "Basic ecbundle build test completed successfully!") 

--- a/tests/ecbundle/test_ecbundle_basic.cmake
+++ b/tests/ecbundle/test_ecbundle_basic.cmake
@@ -1,0 +1,111 @@
+#===============================================================================
+# test/ecbundle/test_ecbundle_basic.cmake - Basic ecbundle build test
+#===============================================================================
+
+# This script tests the basic ecbundle build process for FESOM2
+# It uses the default options from bundle.yml
+
+message(STATUS "Starting basic ecbundle build test")
+message(STATUS "Test directory: ${TEST_DIR}")
+message(STATUS "Bundle file: ${BUNDLE_FILE}")
+
+# Create test directory
+file(MAKE_DIRECTORY "${TEST_DIR}")
+
+# Step 1: Use ecbundle-create to checkout sources
+message(STATUS "Step 1: Running ecbundle-create...")
+execute_process(
+    COMMAND ${ECBUNDLE_CREATE} --bundle ${BUNDLE_FILE}
+    WORKING_DIRECTORY ${TEST_DIR}
+    RESULT_VARIABLE CREATE_RESULT
+    OUTPUT_VARIABLE CREATE_OUTPUT
+    ERROR_VARIABLE CREATE_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+
+if(NOT CREATE_RESULT EQUAL 0)
+    message(FATAL_ERROR "ecbundle-create failed with result ${CREATE_RESULT}")
+    message(FATAL_ERROR "Output: ${CREATE_OUTPUT}")
+    message(FATAL_ERROR "Error: ${CREATE_ERROR}")
+endif()
+
+message(STATUS "ecbundle-create completed successfully")
+message(STATUS "Output: ${CREATE_OUTPUT}")
+
+# Verify that source directory was created
+if(NOT EXISTS "${TEST_DIR}/source")
+    message(FATAL_ERROR "source directory was not created by ecbundle-create")
+endif()
+
+# Verify that FESOM sources are present
+if(NOT EXISTS "${TEST_DIR}/source/fesom")
+    message(FATAL_ERROR "FESOM sources not found in ${TEST_DIR}/source/fesom")
+endif()
+
+# Step 2: Use ecbundle-build to build with default options
+message(STATUS "Step 2: Running ecbundle-build with default options...")
+execute_process(
+    COMMAND ${ECBUNDLE_BUILD}
+    WORKING_DIRECTORY ${TEST_DIR}
+    RESULT_VARIABLE BUILD_RESULT
+    OUTPUT_VARIABLE BUILD_OUTPUT
+    ERROR_VARIABLE BUILD_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+
+if(NOT BUILD_RESULT EQUAL 0)
+    message(FATAL_ERROR "ecbundle-build failed with result ${BUILD_RESULT}")
+    message(FATAL_ERROR "Output: ${BUILD_OUTPUT}")
+    message(FATAL_ERROR "Error: ${BUILD_ERROR}")
+endif()
+
+message(STATUS "ecbundle-build completed successfully")
+message(STATUS "Output: ${BUILD_OUTPUT}")
+
+# Step 3: Verify that the build produced the expected artifacts
+message(STATUS "Step 3: Verifying build artifacts...")
+
+# Check for build directory
+if(NOT EXISTS "${TEST_DIR}/build")
+    message(FATAL_ERROR "build directory was not created by ecbundle-build")
+endif()
+
+# Check for FESOM executable (should be in build/bin)
+if(NOT EXISTS "${TEST_DIR}/build/bin/fesom.x")
+    message(FATAL_ERROR "FESOM executable not found in ${TEST_DIR}/build/bin/fesom.x")
+endif()
+
+# Check that executable is actually executable
+execute_process(
+    COMMAND test -x "${TEST_DIR}/build/bin/fesom.x"
+    RESULT_VARIABLE EXEC_TEST_RESULT
+)
+
+if(NOT EXEC_TEST_RESULT EQUAL 0)
+    message(FATAL_ERROR "FESOM executable is not executable")
+endif()
+
+# Step 4: Test that the executable can run (version check)
+message(STATUS "Step 4: Testing FESOM executable...")
+execute_process(
+    COMMAND ${TEST_DIR}/build/bin/fesom.x --help
+    RESULT_VARIABLE HELP_RESULT
+    OUTPUT_VARIABLE HELP_OUTPUT
+    ERROR_VARIABLE HELP_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+
+# Note: We don't fail here if --help doesn't work, as FESOM does not support it
+# But we log the result for debugging
+if(HELP_RESULT EQUAL 0)
+    message(STATUS "FESOM --help command successful")
+    message(STATUS "Help output: ${HELP_OUTPUT}")
+else()
+    message(STATUS "FESOM --help command failed (this might be expected)")
+    message(STATUS "Help error: ${HELP_ERROR}")
+endif()
+
+message(STATUS "Basic ecbundle build test completed successfully!") 

--- a/tests/ecbundle/test_ecbundle_meshpart.cmake
+++ b/tests/ecbundle/test_ecbundle_meshpart.cmake
@@ -1,0 +1,146 @@
+#===============================================================================
+# test/ecbundle/test_ecbundle_meshpart.cmake - ecbundle build test with meshpartitioner
+#===============================================================================
+
+# This script tests the ecbundle build process for FESOM2 with meshpartitioner enabled
+# It uses the --with-meshpart=ON option from bundle.yml
+
+message(STATUS "Starting ecbundle build test with meshpartitioner")
+message(STATUS "Test directory: ${TEST_DIR}")
+message(STATUS "Bundle file: ${BUNDLE_FILE}")
+
+# Create test directory
+file(MAKE_DIRECTORY "${TEST_DIR}")
+
+# Step 1: Use ecbundle-create to checkout sources
+message(STATUS "Step 1: Running ecbundle-create...")
+execute_process(
+    COMMAND ${ECBUNDLE_CREATE} --bundle ${BUNDLE_FILE}
+    WORKING_DIRECTORY ${TEST_DIR}
+    RESULT_VARIABLE CREATE_RESULT
+    OUTPUT_VARIABLE CREATE_OUTPUT
+    ERROR_VARIABLE CREATE_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+
+if(NOT CREATE_RESULT EQUAL 0)
+    message(FATAL_ERROR "ecbundle-create failed with result ${CREATE_RESULT}")
+    message(FATAL_ERROR "Output: ${CREATE_OUTPUT}")
+    message(FATAL_ERROR "Error: ${CREATE_ERROR}")
+endif()
+
+message(STATUS "ecbundle-create completed successfully")
+message(STATUS "Output: ${CREATE_OUTPUT}")
+
+# Verify that source directory was created
+if(NOT EXISTS "${TEST_DIR}/source")
+    message(FATAL_ERROR "source directory was not created by ecbundle-create")
+endif()
+
+# Verify that FESOM sources are present
+if(NOT EXISTS "${TEST_DIR}/source/fesom")
+    message(FATAL_ERROR "FESOM sources not found in ${TEST_DIR}/source/fesom")
+endif()
+
+# Step 2: Use ecbundle-build to build with meshpartitioner enabled
+message(STATUS "Step 2: Running ecbundle-build with --with-meshpart=ON...")
+execute_process(
+    COMMAND ${ECBUNDLE_BUILD} --with-meshpart=ON
+    WORKING_DIRECTORY ${TEST_DIR}
+    RESULT_VARIABLE BUILD_RESULT
+    OUTPUT_VARIABLE BUILD_OUTPUT
+    ERROR_VARIABLE BUILD_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+
+if(NOT BUILD_RESULT EQUAL 0)
+    message(FATAL_ERROR "ecbundle-build with meshpartitioner failed with result ${BUILD_RESULT}")
+    message(FATAL_ERROR "Output: ${BUILD_OUTPUT}")
+    message(FATAL_ERROR "Error: ${BUILD_ERROR}")
+endif()
+
+message(STATUS "ecbundle-build with meshpartitioner completed successfully")
+message(STATUS "Output: ${BUILD_OUTPUT}")
+
+# Step 3: Verify that the build produced the expected artifacts
+message(STATUS "Step 3: Verifying build artifacts...")
+
+# Check for build directory
+if(NOT EXISTS "${TEST_DIR}/build")
+    message(FATAL_ERROR "build directory was not created by ecbundle-build")
+endif()
+
+# Check for FESOM executable (should be in build/bin)
+if(NOT EXISTS "${TEST_DIR}/build/bin/fesom.x")
+    message(FATAL_ERROR "FESOM executable not found in ${TEST_DIR}/build/bin/fesom.x")
+endif()
+
+# Check for meshpartitioner executable (should be in build/bin)
+if(NOT EXISTS "${TEST_DIR}/build/bin/fesom_meshpart")
+    message(FATAL_ERROR "meshpartitioner executable not found in ${TEST_DIR}/build/bin/fesom_meshpart")
+endif()
+
+# Check that executables are actually executable
+execute_process(
+    COMMAND test -x "${TEST_DIR}/build/bin/fesom.x"
+    RESULT_VARIABLE FESOM_EXEC_TEST_RESULT
+)
+
+if(NOT FESOM_EXEC_TEST_RESULT EQUAL 0)
+    message(FATAL_ERROR "FESOM executable is not executable")
+endif()
+
+execute_process(
+    COMMAND test -x "${TEST_DIR}/build/bin/fesom_meshpart"
+    RESULT_VARIABLE MESHPART_EXEC_TEST_RESULT
+)
+
+if(NOT MESHPART_EXEC_TEST_RESULT EQUAL 0)
+    message(FATAL_ERROR "meshpartitioner executable is not executable")
+endif()
+
+# Step 4: Test that the meshpartitioner executable can run
+message(STATUS "Step 4: Testing meshpartitioner executable...")
+execute_process(
+    COMMAND ${TEST_DIR}/build/bin/fesom_meshpart --help
+    RESULT_VARIABLE MESHPART_HELP_RESULT
+    OUTPUT_VARIABLE MESHPART_HELP_OUTPUT
+    ERROR_VARIABLE MESHPART_HELP_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+
+# Note: We don't fail here if --help doesn't work, as meshpartitioner might not support it
+# But we log the result for debugging
+if(MESHPART_HELP_RESULT EQUAL 0)
+    message(STATUS "meshpartitioner --help command successful")
+    message(STATUS "Help output: ${MESHPART_HELP_OUTPUT}")
+else()
+    message(STATUS "meshpartitioner --help command failed (this might be expected)")
+    message(STATUS "Help error: ${MESHPART_HELP_ERROR}")
+endif()
+
+# Step 5: Test that the FESOM executable can run
+message(STATUS "Step 5: Testing FESOM executable...")
+execute_process(
+    COMMAND ${TEST_DIR}/build/bin/fesom.x --help
+    RESULT_VARIABLE FESOM_HELP_RESULT
+    OUTPUT_VARIABLE FESOM_HELP_OUTPUT
+    ERROR_VARIABLE FESOM_HELP_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+
+# Note: We don't fail here if --help doesn't work, as FESOM does not support it yet
+# But we log the result for debugging
+if(FESOM_HELP_RESULT EQUAL 0)
+    message(STATUS "FESOM --help command successful")
+    message(STATUS "Help output: ${FESOM_HELP_OUTPUT}")
+else()
+    message(STATUS "FESOM --help command failed (this might be expected)")
+    message(STATUS "Help error: ${FESOM_HELP_ERROR}")
+endif()
+
+message(STATUS "ecbundle build test with meshpartitioner completed successfully!") 

--- a/tests/ecbundle/test_ecbundle_meshpart.cmake
+++ b/tests/ecbundle/test_ecbundle_meshpart.cmake
@@ -104,43 +104,49 @@ endif()
 # Step 4: Test that the meshpartitioner executable can run
 message(STATUS "Step 4: Testing meshpartitioner executable...")
 execute_process(
-    COMMAND ${TEST_DIR}/build/bin/fesom_meshpart --help
-    RESULT_VARIABLE MESHPART_HELP_RESULT
-    OUTPUT_VARIABLE MESHPART_HELP_OUTPUT
-    ERROR_VARIABLE MESHPART_HELP_ERROR
+    COMMAND ${TEST_DIR}/build/bin/fesom_meshpart
+    RESULT_VARIABLE MESHPART_RESULT
+    OUTPUT_VARIABLE MESHPART_OUTPUT
+    ERROR_VARIABLE MESHPART_ERROR
     OUTPUT_STRIP_TRAILING_WHITESPACE
     ERROR_STRIP_TRAILING_WHITESPACE
 )
 
-# Note: We don't fail here if --help doesn't work, as meshpartitioner might not support it
-# But we log the result for debugging
-if(MESHPART_HELP_RESULT EQUAL 0)
-    message(STATUS "meshpartitioner --help command successful")
-    message(STATUS "Help output: ${MESHPART_HELP_OUTPUT}")
+# meshpartitioner should fail with namelist.config error (expected behavior)
+if(NOT MESHPART_RESULT EQUAL 0)
+    message(STATUS "meshpartitioner failed as expected (no namelist.config)")
+    message(STATUS "Error output: ${MESHPART_ERROR}")
+    
+    # Check if the error contains the expected message
+    string(FIND "${MESHPART_ERROR}" "namelist.config" NAMELIST_ERROR_FOUND)
+    if(NAMELIST_ERROR_FOUND GREATER -1)
+        message(STATUS "✓ meshpartitioner correctly reported namelist.config error")
+    else()
+        message(WARNING "meshpartitioner error doesn't contain expected 'namelist.config' message")
+        message(WARNING "Actual error: ${MESHPART_ERROR}")
+    endif()
 else()
-    message(STATUS "meshpartitioner --help command failed (this might be expected)")
-    message(STATUS "Help error: ${MESHPART_HELP_ERROR}")
+    message(FATAL_ERROR "meshpartitioner should have failed due to missing namelist.config")
 endif()
 
 # Step 5: Test that the FESOM executable can run
 message(STATUS "Step 5: Testing FESOM executable...")
 execute_process(
-    COMMAND ${TEST_DIR}/build/bin/fesom.x --help
-    RESULT_VARIABLE FESOM_HELP_RESULT
-    OUTPUT_VARIABLE FESOM_HELP_OUTPUT
-    ERROR_VARIABLE FESOM_HELP_ERROR
+    COMMAND ${TEST_DIR}/build/bin/fesom.x --info
+    RESULT_VARIABLE FESOM_INFO_RESULT
+    OUTPUT_VARIABLE FESOM_INFO_OUTPUT
+    ERROR_VARIABLE FESOM_INFO_ERROR
     OUTPUT_STRIP_TRAILING_WHITESPACE
     ERROR_STRIP_TRAILING_WHITESPACE
 )
 
-# Note: We don't fail here if --help doesn't work, as FESOM does not support it yet
-# But we log the result for debugging
-if(FESOM_HELP_RESULT EQUAL 0)
-    message(STATUS "FESOM --help command successful")
-    message(STATUS "Help output: ${FESOM_HELP_OUTPUT}")
+# FESOM should return info successfully
+if(FESOM_INFO_RESULT EQUAL 0)
+    message(STATUS "FESOM --info command successful")
+    message(STATUS "Info output: ${FESOM_INFO_OUTPUT}")
 else()
-    message(STATUS "FESOM --help command failed (this might be expected)")
-    message(STATUS "Help error: ${FESOM_HELP_ERROR}")
+    message(FATAL_ERROR "FESOM --info command failed")
+    message(FATAL_ERROR "Info error: ${FESOM_INFO_ERROR}")
 endif()
 
 message(STATUS "ecbundle build test with meshpartitioner completed successfully!") 

--- a/tests/ecbundle/test_ecbundle_omp.cmake
+++ b/tests/ecbundle/test_ecbundle_omp.cmake
@@ -138,22 +138,21 @@ endif()
 # Step 5: Test that the executable can run
 message(STATUS "Step 5: Testing FESOM executable...")
 execute_process(
-    COMMAND ${TEST_DIR}/build/bin/fesom.x --help
-    RESULT_VARIABLE HELP_RESULT
-    OUTPUT_VARIABLE HELP_OUTPUT
-    ERROR_VARIABLE HELP_ERROR
+    COMMAND ${TEST_DIR}/build/bin/fesom.x --info
+    RESULT_VARIABLE INFO_RESULT
+    OUTPUT_VARIABLE INFO_OUTPUT
+    ERROR_VARIABLE INFO_ERROR
     OUTPUT_STRIP_TRAILING_WHITESPACE
     ERROR_STRIP_TRAILING_WHITESPACE
 )
 
-# Note: We don't fail here if --help doesn't work, as FESOM might not support it
-# But we log the result for debugging
-if(HELP_RESULT EQUAL 0)
-    message(STATUS "FESOM --help command successful")
-    message(STATUS "Help output: ${HELP_OUTPUT}")
+# FESOM should return info successfully
+if(INFO_RESULT EQUAL 0)
+    message(STATUS "FESOM --info command successful")
+    message(STATUS "Info output: ${INFO_OUTPUT}")
 else()
-    message(STATUS "FESOM --help command failed (this might be expected)")
-    message(STATUS "Help error: ${HELP_ERROR}")
+    message(FATAL_ERROR "FESOM --info command failed")
+    message(FATAL_ERROR "Info error: ${INFO_ERROR}")
 endif()
 
 message(STATUS "ecbundle build test with OpenMP support completed successfully!") 

--- a/tests/ecbundle/test_ecbundle_omp.cmake
+++ b/tests/ecbundle/test_ecbundle_omp.cmake
@@ -1,0 +1,159 @@
+#===============================================================================
+# test/ecbundle/test_ecbundle_omp.cmake - ecbundle build test with OpenMP support
+#===============================================================================
+
+# This script tests the ecbundle build process for FESOM2 with OpenMP support
+# It uses the --with-omp-parallel option from bundle.yml
+
+message(STATUS "Starting ecbundle build test with OpenMP support")
+message(STATUS "Test directory: ${TEST_DIR}")
+message(STATUS "Bundle file: ${BUNDLE_FILE}")
+
+# Create test directory
+file(MAKE_DIRECTORY "${TEST_DIR}")
+
+# Step 1: Use ecbundle-create to checkout sources
+message(STATUS "Step 1: Running ecbundle-create...")
+execute_process(
+    COMMAND ${ECBUNDLE_CREATE} --bundle ${BUNDLE_FILE}
+    WORKING_DIRECTORY ${TEST_DIR}
+    RESULT_VARIABLE CREATE_RESULT
+    OUTPUT_VARIABLE CREATE_OUTPUT
+    ERROR_VARIABLE CREATE_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+
+if(NOT CREATE_RESULT EQUAL 0)
+    message(FATAL_ERROR "ecbundle-create failed with result ${CREATE_RESULT}")
+    message(FATAL_ERROR "Output: ${CREATE_OUTPUT}")
+    message(FATAL_ERROR "Error: ${CREATE_ERROR}")
+endif()
+
+message(STATUS "ecbundle-create completed successfully")
+message(STATUS "Output: ${CREATE_OUTPUT}")
+
+# Verify that source directory was created
+if(NOT EXISTS "${TEST_DIR}/source")
+    message(FATAL_ERROR "source directory was not created by ecbundle-create")
+endif()
+
+# Verify that FESOM sources are present
+if(NOT EXISTS "${TEST_DIR}/source/fesom")
+    message(FATAL_ERROR "FESOM sources not found in ${TEST_DIR}/source/fesom")
+endif()
+
+# Step 2: Use ecbundle-build to build with OpenMP support
+message(STATUS "Step 2: Running ecbundle-build with --with-omp-parallel...")
+execute_process(
+    COMMAND ${ECBUNDLE_BUILD} --with-omp-parallel
+    WORKING_DIRECTORY ${TEST_DIR}
+    RESULT_VARIABLE BUILD_RESULT
+    OUTPUT_VARIABLE BUILD_OUTPUT
+    ERROR_VARIABLE BUILD_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+
+if(NOT BUILD_RESULT EQUAL 0)
+    message(FATAL_ERROR "ecbundle-build with OpenMP support failed with result ${BUILD_RESULT}")
+    message(FATAL_ERROR "Output: ${BUILD_OUTPUT}")
+    message(FATAL_ERROR "Error: ${BUILD_ERROR}")
+endif()
+
+message(STATUS "ecbundle-build with OpenMP support completed successfully")
+message(STATUS "Output: ${BUILD_OUTPUT}")
+
+# Step 3: Verify that the build produced the expected artifacts
+message(STATUS "Step 3: Verifying build artifacts...")
+
+# Check for build directory
+if(NOT EXISTS "${TEST_DIR}/build")
+    message(FATAL_ERROR "build directory was not created by ecbundle-build")
+endif()
+
+# Check for FESOM executable (should be in build/bin)
+if(NOT EXISTS "${TEST_DIR}/build/bin/fesom.x")
+    message(FATAL_ERROR "FESOM executable not found in ${TEST_DIR}/build/bin/fesom.x")
+endif()
+
+# Check that executable is actually executable
+execute_process(
+    COMMAND test -x "${TEST_DIR}/build/bin/fesom.x"
+    RESULT_VARIABLE EXEC_TEST_RESULT
+)
+
+if(NOT EXEC_TEST_RESULT EQUAL 0)
+    message(FATAL_ERROR "FESOM executable is not executable")
+endif()
+
+# Step 4: Check if the executable was built with OpenMP support
+message(STATUS "Step 4: Checking OpenMP support...")
+
+# Try to check if the executable was linked with OpenMP libraries
+# This is a basic check - we look for common OpenMP library names in the executable
+execute_process(
+    COMMAND ldd "${TEST_DIR}/build/bin/fesom.x"
+    RESULT_VARIABLE LDD_RESULT
+    OUTPUT_VARIABLE LDD_OUTPUT
+    ERROR_VARIABLE LDD_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+
+if(LDD_RESULT EQUAL 0)
+    message(STATUS "ldd output: ${LDD_OUTPUT}")
+    
+    # Check for OpenMP libraries in the ldd output
+    string(FIND "${LDD_OUTPUT}" "libgomp" GOMP_FOUND)
+    string(FIND "${LDD_OUTPUT}" "libiomp" IOMP_FOUND)
+    string(FIND "${LDD_OUTPUT}" "libomp" OMP_FOUND)
+    
+    if(GOMP_FOUND GREATER -1 OR IOMP_FOUND GREATER -1 OR OMP_FOUND GREATER -1)
+        message(STATUS "OpenMP libraries detected in executable")
+    else()
+        message(STATUS "No OpenMP libraries detected in executable (this might be expected)")
+    endif()
+else()
+    message(STATUS "ldd command failed (this might be expected on some systems)")
+    message(STATUS "ldd error: ${LDD_ERROR}")
+endif()
+
+# Alternative check: try to check the executable with objdump or nm
+execute_process(
+    COMMAND nm "${TEST_DIR}/build/bin/fesom.x" 2>/dev/null | grep -i omp || echo "No OpenMP symbols found"
+    RESULT_VARIABLE NM_RESULT
+    OUTPUT_VARIABLE NM_OUTPUT
+    ERROR_VARIABLE NM_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+
+if(NM_RESULT EQUAL 0)
+    message(STATUS "nm output (OpenMP symbols): ${NM_OUTPUT}")
+else()
+    message(STATUS "nm command failed or no OpenMP symbols found")
+endif()
+
+# Step 5: Test that the executable can run
+message(STATUS "Step 5: Testing FESOM executable...")
+execute_process(
+    COMMAND ${TEST_DIR}/build/bin/fesom.x --help
+    RESULT_VARIABLE HELP_RESULT
+    OUTPUT_VARIABLE HELP_OUTPUT
+    ERROR_VARIABLE HELP_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+
+# Note: We don't fail here if --help doesn't work, as FESOM might not support it
+# But we log the result for debugging
+if(HELP_RESULT EQUAL 0)
+    message(STATUS "FESOM --help command successful")
+    message(STATUS "Help output: ${HELP_OUTPUT}")
+else()
+    message(STATUS "FESOM --help command failed (this might be expected)")
+    message(STATUS "Help error: ${HELP_ERROR}")
+endif()
+
+message(STATUS "ecbundle build test with OpenMP support completed successfully!") 

--- a/tests/ecbundle/test_ecbundle_setup.sh
+++ b/tests/ecbundle/test_ecbundle_setup.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#===============================================================================
+# test/ecbundle/test_ecbundle_setup.sh - Test ecbundle setup
+#===============================================================================
+
+set -e
+
+echo "Testing ecbundle setup..."
+
+# Check if ecbundle-create is available
+if command -v ecbundle-create >/dev/null 2>&1; then
+    echo "✓ ecbundle-create found: $(which ecbundle-create)"
+else
+    echo "✗ ecbundle-create not found in PATH"
+    echo "  Please install ecbundle from https://github.com/ecmwf/ecbundle"
+    exit 1
+fi
+
+# Check if ecbundle-build is available
+if command -v ecbundle-build >/dev/null 2>&1; then
+    echo "✓ ecbundle-build found: $(which ecbundle-build)"
+else
+    echo "✗ ecbundle-build not found in PATH"
+    echo "  Please install ecbundle from https://github.com/ecmwf/ecbundle"
+    exit 1
+fi
+
+# Check if bundle.yml exists
+if [ -f "bundle.yml" ]; then
+    echo "✓ bundle.yml found"
+else
+    echo "✗ bundle.yml not found in current directory"
+    echo "  Please run this script from the FESOM2 root directory"
+    exit 1
+fi
+
+# Test ecbundle-create help
+echo "Testing ecbundle-create help..."
+if ecbundle-create --help >/dev/null 2>&1; then
+    echo "✓ ecbundle-create --help works"
+else
+    echo "✗ ecbundle-create --help failed"
+fi
+
+# Test ecbundle-build help
+echo "Testing ecbundle-build help..."
+if ecbundle-build --help >/dev/null 2>&1; then
+    echo "✓ ecbundle-build --help works"
+else
+    echo "✗ ecbundle-build --help failed"
+fi
+
+echo ""
+echo "ecbundle setup test completed successfully!"
+echo "You can now run the ecbundle tests with:"
+echo "  ctest -L ecbundle"
+echo "  or"
+echo "  make run_ecbundle_tests" 

--- a/tests/ecbundle/test_ecbundle_testing.cmake
+++ b/tests/ecbundle/test_ecbundle_testing.cmake
@@ -1,0 +1,172 @@
+#===============================================================================
+# test/ecbundle/test_ecbundle_testing.cmake - ecbundle build test with testing enabled
+#===============================================================================
+
+# This script tests the ecbundle build process for FESOM2 with testing enabled
+# It uses the --with-testing=ON option from bundle.yml
+
+message(STATUS "Starting ecbundle build test with testing enabled")
+message(STATUS "Test directory: ${TEST_DIR}")
+message(STATUS "Bundle file: ${BUNDLE_FILE}")
+
+# Create test directory
+file(MAKE_DIRECTORY "${TEST_DIR}")
+
+# Step 1: Use ecbundle-create to checkout sources
+message(STATUS "Step 1: Running ecbundle-create...")
+execute_process(
+    COMMAND ${ECBUNDLE_CREATE} --bundle ${BUNDLE_FILE}
+    WORKING_DIRECTORY ${TEST_DIR}
+    RESULT_VARIABLE CREATE_RESULT
+    OUTPUT_VARIABLE CREATE_OUTPUT
+    ERROR_VARIABLE CREATE_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+
+if(NOT CREATE_RESULT EQUAL 0)
+    message(FATAL_ERROR "ecbundle-create failed with result ${CREATE_RESULT}")
+    message(FATAL_ERROR "Output: ${CREATE_OUTPUT}")
+    message(FATAL_ERROR "Error: ${CREATE_ERROR}")
+endif()
+
+message(STATUS "ecbundle-create completed successfully")
+message(STATUS "Output: ${CREATE_OUTPUT}")
+
+# Verify that source directory was created
+if(NOT EXISTS "${TEST_DIR}/source")
+    message(FATAL_ERROR "source directory was not created by ecbundle-create")
+endif()
+
+# Verify that FESOM sources are present
+if(NOT EXISTS "${TEST_DIR}/source/fesom")
+    message(FATAL_ERROR "FESOM sources not found in ${TEST_DIR}/source/fesom")
+endif()
+
+# Step 2: Use ecbundle-build to build with testing enabled
+message(STATUS "Step 2: Running ecbundle-build with --with-testing=ON...")
+execute_process(
+    COMMAND ${ECBUNDLE_BUILD} --with-testing=ON
+    WORKING_DIRECTORY ${TEST_DIR}
+    RESULT_VARIABLE BUILD_RESULT
+    OUTPUT_VARIABLE BUILD_OUTPUT
+    ERROR_VARIABLE BUILD_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+
+if(NOT BUILD_RESULT EQUAL 0)
+    message(FATAL_ERROR "ecbundle-build with testing enabled failed with result ${BUILD_RESULT}")
+    message(FATAL_ERROR "Output: ${BUILD_OUTPUT}")
+    message(FATAL_ERROR "Error: ${BUILD_ERROR}")
+endif()
+
+message(STATUS "ecbundle-build with testing enabled completed successfully")
+message(STATUS "Output: ${BUILD_OUTPUT}")
+
+# Step 3: Verify that the build produced the expected artifacts
+message(STATUS "Step 3: Verifying build artifacts...")
+
+# Check for build directory
+if(NOT EXISTS "${TEST_DIR}/build")
+    message(FATAL_ERROR "build directory was not created by ecbundle-build")
+endif()
+
+# Check for FESOM executable (should be in build/bin)
+if(NOT EXISTS "${TEST_DIR}/build/bin/fesom.x")
+    message(FATAL_ERROR "FESOM executable not found in ${TEST_DIR}/build/bin/fesom.x")
+endif()
+
+# Check that executable is actually executable
+execute_process(
+    COMMAND test -x "${TEST_DIR}/build/bin/fesom.x"
+    RESULT_VARIABLE EXEC_TEST_RESULT
+)
+
+if(NOT EXEC_TEST_RESULT EQUAL 0)
+    message(FATAL_ERROR "FESOM executable is not executable")
+endif()
+
+# Step 4: Check for test executables and test files
+message(STATUS "Step 4: Checking for test artifacts...")
+
+# Check if test executables were built
+# Look for common test executable patterns
+file(GLOB TEST_EXECUTABLES 
+    "${TEST_DIR}/build/bin/*test*"
+    "${TEST_DIR}/build/bin/test_*"
+    "${TEST_DIR}/build/bin/*_test"
+)
+
+if(TEST_EXECUTABLES)
+    message(STATUS "Found test executables: ${TEST_EXECUTABLES}")
+else()
+    message(STATUS "No test executables found (this might be expected)")
+endif()
+
+# Check if test files were created
+if(EXISTS "${TEST_DIR}/build/Testing")
+    message(STATUS "Testing directory found")
+else()
+    message(STATUS "No Testing directory found (this might be expected)")
+endif()
+
+# Check for CMake test files
+file(GLOB CMAKE_TEST_FILES "${TEST_DIR}/build/CMakeFiles/*.cmake")
+if(CMAKE_TEST_FILES)
+    message(STATUS "Found CMake test files: ${CMAKE_TEST_FILES}")
+else()
+    message(STATUS "No CMake test files found (this might be expected)")
+endif()
+
+# Step 5: Try to run the tests if CTest is available
+message(STATUS "Step 5: Attempting to run tests...")
+
+find_program(CTEST_EXECUTABLE ctest)
+if(CTEST_EXECUTABLE)
+    message(STATUS "Found CTest: ${CTEST_EXECUTABLE}")
+    
+    # Try to run tests
+    execute_process(
+        COMMAND ${CTEST_EXECUTABLE} --output-on-failure
+        WORKING_DIRECTORY ${TEST_DIR}/build
+        RESULT_VARIABLE CTEST_RESULT
+        OUTPUT_VARIABLE CTEST_OUTPUT
+        ERROR_VARIABLE CTEST_ERROR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_STRIP_TRAILING_WHITESPACE
+    )
+    
+    if(CTEST_RESULT EQUAL 0)
+        message(STATUS "CTest ran successfully")
+        message(STATUS "CTest output: ${CTEST_OUTPUT}")
+    else()
+        message(STATUS "CTest failed (this might be expected if no tests are configured)")
+        message(STATUS "CTest error: ${CTEST_ERROR}")
+    endif()
+else()
+    message(STATUS "CTest not found")
+endif()
+
+# Step 6: Test that the main executable can run
+message(STATUS "Step 6: Testing FESOM executable...")
+execute_process(
+    COMMAND ${TEST_DIR}/build/bin/fesom.x --help
+    RESULT_VARIABLE HELP_RESULT
+    OUTPUT_VARIABLE HELP_OUTPUT
+    ERROR_VARIABLE HELP_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+
+# Note: We don't fail here if --help doesn't work, as FESOM might not support it
+# But we log the result for debugging
+if(HELP_RESULT EQUAL 0)
+    message(STATUS "FESOM --help command successful")
+    message(STATUS "Help output: ${HELP_OUTPUT}")
+else()
+    message(STATUS "FESOM --help command failed (this might be expected)")
+    message(STATUS "Help error: ${HELP_ERROR}")
+endif()
+
+message(STATUS "ecbundle build test with testing enabled completed successfully!") 

--- a/tests/ecbundle/test_ecbundle_testing.cmake
+++ b/tests/ecbundle/test_ecbundle_testing.cmake
@@ -151,22 +151,21 @@ endif()
 # Step 6: Test that the main executable can run
 message(STATUS "Step 6: Testing FESOM executable...")
 execute_process(
-    COMMAND ${TEST_DIR}/build/bin/fesom.x --help
-    RESULT_VARIABLE HELP_RESULT
-    OUTPUT_VARIABLE HELP_OUTPUT
-    ERROR_VARIABLE HELP_ERROR
+    COMMAND ${TEST_DIR}/build/bin/fesom.x --info
+    RESULT_VARIABLE INFO_RESULT
+    OUTPUT_VARIABLE INFO_OUTPUT
+    ERROR_VARIABLE INFO_ERROR
     OUTPUT_STRIP_TRAILING_WHITESPACE
     ERROR_STRIP_TRAILING_WHITESPACE
 )
 
-# Note: We don't fail here if --help doesn't work, as FESOM might not support it
-# But we log the result for debugging
-if(HELP_RESULT EQUAL 0)
-    message(STATUS "FESOM --help command successful")
-    message(STATUS "Help output: ${HELP_OUTPUT}")
+# FESOM should return info successfully
+if(INFO_RESULT EQUAL 0)
+    message(STATUS "FESOM --info command successful")
+    message(STATUS "Info output: ${INFO_OUTPUT}")
 else()
-    message(STATUS "FESOM --help command failed (this might be expected)")
-    message(STATUS "Help error: ${HELP_ERROR}")
+    message(FATAL_ERROR "FESOM --info command failed")
+    message(FATAL_ERROR "Info error: ${INFO_ERROR}")
 endif()
 
 message(STATUS "ecbundle build test with testing enabled completed successfully!") 


### PR DESCRIPTION
good news for ifs-fesom enthusiasts: 
- This adds ecbundle build support and ctest to test fesom.x and fesom_meshpart builds with ecbundle. 
- ecbundle should be auto downloaded and set up for ctests
- add a github action to (simple) test fesom.x and fesom_meshpart installation in case of use with ecbundle. 
```
mkdir build 
cd build 
cmake ../ -DBUILD_TESTING=ON
ctest -V
#or
./configure.sh ubuntu -DBUILD_TESTING=ON
cd build
ctest -V  
```
current bundle.yml points to this branch which should be changed to main.

current ecbundle ctest doesn't detect fesom ctests, that needs to be fixed later. 

this serves as template later for more elaborate tests to check fesom with multio, fesom and ifs as MPMD, fesom with atlas etc.