### PR TITLE
Fix netcdf interfaces

### DIFF
--- a/.github/workflows/fesom2_main.yml
+++ b/.github/workflows/fesom2_main.yml
@@ -49,7 +49,8 @@ jobs:
         pip install ugrid-checks xarray
         # Needed to combine the mesh diag and output
         python3 -c "import xarray as xr; ds1 = xr.open_dataset('./test/output_pi/sst.fesom.1948.nc'); ds2 = xr.open_dataset('./test/output_pi/fesom.mesh.diag.nc'); xr.merge([ds1, ds2]).to_netcdf('./test/output_pi/merged_ugrid_check.nc')"
-        ugrid-checker ./test/output_pi/merged_ugrid_check.nc
+        ugrid-checker ./test/output_pi/fesom.mesh.diag.nc
+        ugrid-checker -e ./test/output_pi/merged_ugrid_check.nc
 
     - name: Check restarts
       run: |

--- a/src/gen_surface_forcing.F90
+++ b/src/gen_surface_forcing.F90
@@ -50,9 +50,9 @@ MODULE g_sbf
 #endif
    USE g_read_other_NetCDF, only: read_other_NetCDF, read_2ddata_on_grid_netcdf
 
-   IMPLICIT NONE
+   USE netcdf
 
-   include 'netcdf.inc'
+   IMPLICIT NONE
 
    public  sbc_ini  ! routine called before 1st time step (open files, read namelist,...)
    public  sbc_do   ! routine called each time step to provide a sbc fileds (wind,...)
@@ -242,7 +242,7 @@ CONTAINS
 
       !open file
       if (partit%mype==0) then
-         iost = nf_open(trim(flf%file_name),NF_NOWRITE,ncid)
+         iost = nf90_open(trim(flf%file_name), NF90_NOWRITE, ncid)
       end if
 
       call MPI_BCast(iost, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
@@ -250,42 +250,42 @@ CONTAINS
 
       ! get dimensions
       if (partit%mype==0) then
-         iost = nf_inq_dimid(ncid,    "LAT",      id_latd)
-         if (iost .ne. NF_NOERR) then
-            iost = nf_inq_dimid(ncid, "lat",      id_latd)
+         iost = nf90_inq_dimid(ncid, "LAT", id_latd)
+         if (iost .ne. NF90_NOERR) then
+            iost = nf90_inq_dimid(ncid, "lat", id_latd)
          end if
-         if (iost .ne. NF_NOERR) then
-            iost = nf_inq_dimid(ncid, "latitude", id_latd)
+         if (iost .ne. NF90_NOERR) then
+            iost = nf90_inq_dimid(ncid, "latitude", id_latd)
          end if
-         if (iost .ne. NF_NOERR) then
-            iost = nf_inq_dimid(ncid, "LAT1",     id_latd)
+         if (iost .ne. NF90_NOERR) then
+            iost = nf90_inq_dimid(ncid, "LAT1", id_latd)
          end if
       end if
       call MPI_BCast(iost, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
       call check_nferr(iost,flf%file_name,partit)  
 
       if (partit%mype==0) then 
-         iost = nf_inq_dimid(ncid,    "LON",       id_lond)
-         if (iost .ne. NF_NOERR) then
-            iost = nf_inq_dimid(ncid, "lon",       id_lond)
+         iost = nf90_inq_dimid(ncid, "LON", id_lond)
+         if (iost .ne. NF90_NOERR) then
+            iost = nf90_inq_dimid(ncid, "lon", id_lond)
          end if
-         if (iost .ne. NF_NOERR) then
-            iost = nf_inq_dimid(ncid, "longitude", id_lond)
+         if (iost .ne. NF90_NOERR) then
+            iost = nf90_inq_dimid(ncid, "longitude", id_lond)
          end if
-         if (iost .ne. NF_NOERR) then
-            iost = nf_inq_dimid(ncid, "LON1",      id_lond)
+         if (iost .ne. NF90_NOERR) then
+            iost = nf90_inq_dimid(ncid, "LON1", id_lond)
          end if
       end if
       call MPI_BCast(iost, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
       call check_nferr(iost,flf%file_name,partit) 
 
       if (partit%mype==0) then   
-         iost = nf_inq_dimid(ncid, "TIME", id_timed)
-         if      (iost .ne. NF_NOERR) then
-                 iost = nf_inq_dimid(ncid, "time",  id_timed)
+         iost = nf90_inq_dimid(ncid, "TIME", id_timed)
+         if (iost .ne. NF90_NOERR) then
+            iost = nf90_inq_dimid(ncid, "time", id_timed)
          end if
-         if      (iost .ne. NF_NOERR) then
-                 iost = nf_inq_dimid(ncid, "TIME1", id_timed)
+         if (iost .ne. NF90_NOERR) then
+            iost = nf90_inq_dimid(ncid, "TIME1", id_timed)
          end if
       end if
       call MPI_BCast(iost, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
@@ -293,58 +293,58 @@ CONTAINS
 
       ! get variable id
       if (partit%mype==0) then
-         iost = nf_inq_varid(ncid,    "LAT",      id_lat)
-         if (iost .ne. NF_NOERR) then
-            iost = nf_inq_varid(ncid, "lat",      id_lat)
+         iost = nf90_inq_varid(ncid, "LAT", id_lat)
+         if (iost .ne. NF90_NOERR) then
+            iost = nf90_inq_varid(ncid, "lat", id_lat)
          end if
-         if (iost .ne. NF_NOERR) then
-            iost = nf_inq_varid(ncid, "latitude", id_lat)
+         if (iost .ne. NF90_NOERR) then
+            iost = nf90_inq_varid(ncid, "latitude", id_lat)
          end if
-         if (iost .ne. NF_NOERR) then
-            iost = nf_inq_varid(ncid, "LAT1",     id_lat)
+         if (iost .ne. NF90_NOERR) then
+            iost = nf90_inq_varid(ncid, "LAT1", id_lat)
          end if
       end if
       call MPI_BCast(iost, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
       call check_nferr(iost,flf%file_name,partit)
       if (partit%mype==0) then
-         iost = nf_inq_varid(ncid,    "LON",       id_lon)
-         if      (iost .ne. NF_NOERR) then
-            iost = nf_inq_varid(ncid, "longitude", id_lon)
+         iost = nf90_inq_varid(ncid, "LON", id_lon)
+         if (iost .ne. NF90_NOERR) then
+            iost = nf90_inq_varid(ncid, "longitude", id_lon)
          end if
-         if (iost .ne. NF_NOERR) then
-            iost = nf_inq_varid(ncid, "lon",       id_lon)
+         if (iost .ne. NF90_NOERR) then
+            iost = nf90_inq_varid(ncid, "lon", id_lon)
          end if
-         if (iost .ne. NF_NOERR) then
-            iost = nf_inq_varid(ncid, "LON1",      id_lon)
+         if (iost .ne. NF90_NOERR) then
+            iost = nf90_inq_varid(ncid, "LON1", id_lon)
          end if
       end if
       call MPI_BCast(iost, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
       call check_nferr(iost,flf%file_name,partit)
 
       if (partit%mype==0) then
-         iost = nf_inq_varid(ncid, "TIME", id_time)
-         if      (iost .ne. NF_NOERR) then
-                 iost = nf_inq_varid(ncid, "time", id_time)
+         iost = nf90_inq_varid(ncid, "TIME", id_time)
+         if (iost .ne. NF90_NOERR) then
+            iost = nf90_inq_varid(ncid, "time", id_time)
          end if
-         if      (iost .ne. NF_NOERR) then
-                 iost = nf_inq_varid(ncid, "TIME1",id_time)
+         if (iost .ne. NF90_NOERR) then
+            iost = nf90_inq_varid(ncid, "TIME1", id_time)
          end if
       end if
       call MPI_BCast(iost, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
       call check_nferr(iost,flf%file_name,partit)   
       ! get dimensions size
       if (partit%mype==0) then
-         iost = nf_inq_dimlen(ncid, id_latd, flf%nc_Nlat)
+         iost = nf90_inquire_dimension(ncid, id_latd, len=flf%nc_Nlat)
       end if
       call MPI_BCast(iost, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
       call check_nferr(iost,flf%file_name,partit)
       if (partit%mype==0) then      
-         iost = nf_inq_dimlen(ncid, id_lond, flf%nc_Nlon)
+         iost = nf90_inquire_dimension(ncid, id_lond, len=flf%nc_Nlon)
       end if
       call MPI_BCast(iost, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
       call check_nferr(iost,flf%file_name,partit)   
       if (partit%mype==0) then      
-         iost = nf_inq_dimlen(ncid, id_timed,flf%nc_Ntime)
+         iost = nf90_inquire_dimension(ncid, id_timed, len=flf%nc_Ntime)
       end if
       call MPI_BCast(iost, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
       call check_nferr(iost,flf%file_name,partit) 
@@ -365,18 +365,14 @@ CONTAINS
     !read variables from file
     ! read lat
       if (partit%mype==0) then
-         nf_start(1)=1
-         nf_edges(1)=flf%nc_Nlat
-         iost = nf_get_vara_double(ncid, id_lat, nf_start, nf_edges, flf%nc_lat)
+         iost = nf90_get_var(ncid, id_lat, flf%nc_lat, start=(/1/), count=(/flf%nc_Nlat/))
       end if
       call MPI_BCast(iost, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
       call check_nferr(iost,flf%file_name,partit)
       
     ! read lon  
       if (partit%mype==0) then
-         nf_start(1)=1
-         nf_edges(1)=flf%nc_Nlon-2
-         iost = nf_get_vara_double(ncid, id_lon, nf_start, nf_edges, flf%nc_lon(2:flf%nc_Nlon-1))
+         iost = nf90_get_var(ncid, id_lon, flf%nc_lon(2:flf%nc_Nlon-1), start=(/1/), count=(/flf%nc_Nlon-2/))
          flf%nc_lon(1)        =flf%nc_lon(flf%nc_Nlon-1)
          flf%nc_lon(flf%nc_Nlon)  =flf%nc_lon(2)
       end if
@@ -385,21 +381,19 @@ CONTAINS
     !____________________________________________________________________________
     ! read time axis from file
     if (partit%mype==0) then
-        nf_start(1)=1
-        nf_edges(1)=flf%nc_Ntime
-        iost = nf_get_vara_double(ncid, id_time, nf_start, nf_edges, flf%nc_time)
+        iost = nf90_get_var(ncid, id_time, flf%nc_time, start=(/1/), count=(/flf%nc_Ntime/))
         ! digg for calendar attribute in time axis variable         
     end if
-    call MPI_BCast(flf%nc_time, flf%nc_Ntime,   MPI_DOUBLE_PRECISION, 0, partit%MPI_COMM_FESOM, ierror)
+    call MPI_BCast(flf%nc_time, flf%nc_Ntime, MPI_DOUBLE_PRECISION, 0, partit%MPI_COMM_FESOM, ierror)
     call MPI_BCast(iost, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
     call check_nferr(iost,flf%file_name,partit)
       
     ! digg for calendar attribute in time axis variable
     if (partit%mype==0) then
-        iost         = nf_inq_attlen(ncid, id_time,'calendar',aux_len)
-        iost         = nf_get_att(ncid, id_time,'calendar',aux_calendar)
+        iost = nf90_inquire_attribute(ncid, id_time, 'calendar', len=aux_len)
+        iost = nf90_get_att(ncid, id_time, 'calendar', aux_calendar)
         aux_calendar = aux_calendar(1:aux_len)
-        if (iost .ne. NF_NOERR) then
+        if (iost .ne. NF90_NOERR) then
             flf%calendar='none'
             write(*,*) ' --> could not find/read calendar attribute in the time axis'
             write(*,*) '     of the forcing file (Is this right?). I assume there is'
@@ -530,7 +524,7 @@ CONTAINS
     endif
 
     if (partit%mype==0) then
-         iost = nf_close(ncid)
+         iost = nf90_close(ncid)
     end if
     call MPI_BCast(iost, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
     call check_nferr(iost,flf%file_name,partit)
@@ -1450,8 +1444,8 @@ if (recom_debug .and. mype==0) print *, achar(27)//'[36m'//'     --> Atm_input'/
             CO2vari     = 'AtmCO2_'//currentCO2year_char
 
             ! open file
-            status=nf_open(filename, nf_nowrite, ncid)
-            if (status.ne.nf_noerr)then
+            status=nf90_open(filename, nf90_nowrite, ncid)
+            if (status.ne.nf90_noerr)then
                 print*,'ERROR: CANNOT READ CO2 FILE CORRECTLY !!!!!'
                 print*,'Error in opening netcdf file '//filename
                 call par_ex(MPI_COMM_FESOM, mype)
@@ -1460,15 +1454,15 @@ if (recom_debug .and. mype==0) print *, achar(27)//'[36m'//'     --> Atm_input'/
 	
             ! data
             allocate(ncdata(12))
-            status=nf_inq_varid(ncid, CO2vari, varid)
+            status=nf90_inq_varid(ncid, CO2vari, varid)
             CO2start = 1
             CO2count = 12
-            status=nf_get_vara_double(ncid,varid,CO2start,CO2count,ncdata)
+            status=nf90_get_var(ncid, varid, ncdata, start=(/CO2start/), count=(/CO2count/))
             AtmCO2(:)=ncdata(:)
             deallocate(ncdata)
             if (mype==0) write(*,*),'Current carbon year=',currentCO2year
             if (mype==0) write(*,*),'Atm CO2=', AtmCO2
-            status=nf_close(ncid)
+            status=nf90_close(ncid)
         end if
     end if
 
@@ -1704,8 +1698,8 @@ if (recom_debug .and. mype==0) print *, achar(27)//'[36m'//'     --> Atm_input'/
       character(len=MAX_PATH), intent(in)            :: fname
       integer, intent(in)                            :: iost
 
-      if (iost .ne. NF_NOERR) then
-         write(*,*) 'ERROR: I/O status= "',trim(nf_strerror(iost)),'";',iost,' file= ',fname
+      if (iost .ne. NF90_NOERR) then
+         write(*,*) 'ERROR: I/O status= "',trim(nf90_strerror(iost)),'";',iost,' file= ',fname
          call par_ex(partit%MPI_COMM_FESOM, partit%mype)
          stop
       endif
@@ -2594,9 +2588,9 @@ subroutine read_runoff_mapper(file, vari, R, partit, mesh)
    USE MOD_PARSUP
    USE g_forcing_arrays,    only: runoff
    use g_support
-   implicit none
+   use netcdf
  
-#include "netcdf.inc"
+   implicit none
    character(*),   intent(in) :: file
    character(*),   intent(in) :: vari
    real(kind=WP),   intent(in):: R
@@ -2624,11 +2618,11 @@ subroutine read_runoff_mapper(file, vari, R, partit, mesh)
    if (mype==0) write(*,*) 'building RUNOFF MAPPER with radius of smoothing= ', R*1.e-3, ' km'
    if (mype==0) then
       ! open file
-      status=nf_open(trim(file), nf_nowrite, ncid)
+      status=nf90_open(trim(file), nf90_nowrite, ncid)
    end if
  
    call MPI_BCast(status, 1, MPI_INTEGER, 0, MPI_COMM_FESOM, ierror)
-   if (status.ne.nf_noerr)then
+   if (status.ne.nf90_noerr)then
       print*,'ERROR: CANNOT READ 2D netCDF FILE CORRECTLY !!!!!'
       print*,'Error in opening netcdf file '//file
       call par_ex(partit%MPI_COMM_FESOM, partit%mype)
@@ -2637,11 +2631,11 @@ subroutine read_runoff_mapper(file, vari, R, partit, mesh)
  
    if (mype==0) then
       ! lat
-      status=nf_inq_dimid(ncid, 'lat', latid)
-      status=nf_inq_dimlen(ncid, latid, latlen)
+      status=nf90_inq_dimid(ncid, 'lat', latid)
+      status=nf90_inquire_dimension(ncid, latid, len=latlen)
       ! lon
-      status=nf_inq_dimid(ncid, 'lon', lonid)
-      status=nf_inq_dimlen(ncid, lonid, lonlen)
+      status=nf90_inq_dimid(ncid, 'lon', lonid)
+      status=nf90_inquire_dimension(ncid, lonid, len=lonlen)
    end if
    call MPI_BCast(latlen, 1, MPI_INTEGER, 0, MPI_COMM_FESOM, ierror)
    call MPI_BCast(lonlen, 1, MPI_INTEGER, 0, MPI_COMM_FESOM, ierror)
@@ -2649,15 +2643,15 @@ subroutine read_runoff_mapper(file, vari, R, partit, mesh)
    ! lat
    if (mype==0) then
       allocate(lat(latlen))
-      status=nf_inq_varid(ncid, 'lat', varid)
-      status=nf_get_vara_double(ncid,varid,1,latlen,lat)
+      status=nf90_inq_varid(ncid, 'lat', varid)
+      status=nf90_get_var(ncid, varid, lat, start=(/1/), count=(/latlen/))
    end if
 
    ! lon
    if (mype==0) then
       allocate(lon(lonlen))
-      status=nf_inq_varid(ncid, 'lon', varid)
-      status=nf_get_vara_double(ncid,varid,1,lonlen,lon)
+      status=nf90_inq_varid(ncid, 'lon', varid)
+      status=nf90_get_var(ncid, varid, lon, start=(/1/), count=(/lonlen/))
    ! make sure range 0. - 360.
    do n=1,lonlen
       if (lon(n)<0.0_WP) then
@@ -2670,12 +2664,12 @@ subroutine read_runoff_mapper(file, vari, R, partit, mesh)
       allocate(ncdata(lonlen,latlen))
       ncdata = 0.0_WP
      ! data
-      status=nf_inq_varid(ncid, trim(vari), varid)
+      status=nf90_inq_varid(ncid, trim(vari), varid)
       istart = (/1,1/)
       icount= (/lonlen,latlen/)
-      status=nf_get_vara_int(ncid,varid,istart,icount,ncdata)
+      status=nf90_get_var(ncid, varid, ncdata, start=istart, count=icount)
      ! close file
-     status=nf_close(ncid)
+     status=nf90_close(ncid)
      number_arrival_points=0
      do i=1, lonlen
         do j=1, latlen

--- a/src/icb_step.F90
+++ b/src/icb_step.F90
@@ -1543,15 +1543,15 @@ subroutine determine_save_count(partit)
   ! computes save_count_buoys and prev_sec_in_year from records in existing netcdf file
   !-----------------------------------------------------------  
   use g_clock
+  use netcdf
 !  use iceberg_params, only : file_icb_netcdf, save_count_buoys, prev_sec_in_year
   !use iceberg_params, only : save_count_buoys, prev_sec_in_year
   implicit none
-
-#include "netcdf.inc" 
   integer		    :: buoy_nrec
   integer                   :: status, ncid
   integer                   :: dimid_rec
   integer                   :: time_varid
+  integer                   :: start_1d(1), count_1d(1)
 type(t_partit), intent(inout), target :: partit
 #include "associate_part_def.h"
 #include "associate_part_ass.h"
@@ -1559,14 +1559,14 @@ type(t_partit), intent(inout), target :: partit
  if (mype==0) then
 
   ! open file
-  status = nf_open(file_icb_netcdf, nf_nowrite, ncid)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_open(file_icb_netcdf, nf90_nowrite, ncid)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   ! inquire time dimension ID and its length
-  status = nf_inq_dimid(ncid, 'time', dimid_rec)
-  if(status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_inq_dimlen(ncid, dimid_rec, buoy_nrec)
-  if(status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_inq_dimid(ncid, 'time', dimid_rec)
+  if(status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_inquire_dimension(ncid, dimid_rec, len=buoy_nrec)
+  if(status .ne. nf90_noerr) call handle_err(status, partit)
 
   ! the next buoy/iceberg record to be saved
   save_count_buoys=buoy_nrec+1
@@ -1574,16 +1574,16 @@ type(t_partit), intent(inout), target :: partit
   write(*,*) 'next record is #',save_count_buoys
 
   ! load sec_in_year up to now in 'prev_sec_in_year', time axis will be continued
-  status=nf_inq_varid(ncid, 'time', time_varid)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status=nf_get_vara_double(ncid, time_varid, save_count_buoys-1, 1, prev_sec_in_year) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status=nf90_inq_varid(ncid, 'time', time_varid)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status=nf90_get_var(ncid, time_varid, prev_sec_in_year) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   write(*,*) 'seconds passed up to now: ',prev_sec_in_year
 
   !close file
-  status=nf_close(ncid)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status=nf90_close(ncid)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 end if
 
@@ -1600,10 +1600,9 @@ subroutine init_buoy_output(partit)
   !-----------------------------------------------------------  
   use g_clock
   use g_config, only : ib_num
+  use netcdf
 !  use iceberg_params, only : file_icb_netcdf, save_count_buoys !ggf in namelist
   implicit none
-
-#include "netcdf.inc" 
   integer                   :: status,ncid,year_start,month_start,day_start
   integer                   :: dimid_ib, dimid_rec, dimids(2)
   integer                   :: time_varid, iter_varid
@@ -1612,7 +1611,7 @@ subroutine init_buoy_output(partit)
   integer                   :: uib_id, vib_id
   integer                   :: height_id, length_id, width_id
   integer                   :: bvl_id, lvlv_id, lvle_id, lvlb_id, felem_id
-  character(100)            :: longname, att_text, description
+  character(100)            :: longname, att_text, description, units
 type(t_partit), intent(inout), target :: partit
 #include "associate_part_def.h"
 #include "associate_part_ass.h"
@@ -1622,21 +1621,21 @@ type(t_partit), intent(inout), target :: partit
  
 
  ! create a file
-  status = nf_create(file_icb_netcdf, nf_clobber, ncid)
-  if (status.ne.nf_noerr)  call handle_err(status, partit)
+  status = nf90_create(file_icb_netcdf, nf90_clobber, ncid)
+  if (status.ne.nf90_noerr)  call handle_err(status, partit)
 
   ! Define the dimensions
-  status = nf_def_dim(ncid, 'number_tracer', ib_num, dimid_ib)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_def_dim(ncid, 'time', NF_UNLIMITED, dimid_rec)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_dim(ncid, 'number_tracer', ib_num, dimid_ib)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_def_dim(ncid, 'time', nf90_unlimited, dimid_rec)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 
   ! Define the time and iteration variables
-  status = nf_def_var(ncid, 'time', NF_DOUBLE, 1, dimid_rec, time_varid)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_def_var(ncid, 'iter', NF_INT, 1, dimid_rec, iter_varid)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'time', nf90_double, dimids=(/dimid_rec/), varid=time_varid)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'iter', nf90_int, dimids=(/dimid_rec/), varid=iter_varid)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   ! Define the netCDF variables for the tracers.
   ! In Fortran, the unlimited dimension must come
@@ -1645,276 +1644,276 @@ type(t_partit), intent(inout), target :: partit
   dimids(2) = dimid_rec
 
 
-  status = nf_def_var(ncid, 'pos_lon_rad', NF_DOUBLE, 2, dimids, lonrad_id)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'pos_lon_rad', nf90_double, dimids=dimids, varid=lonrad_id)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-  status = nf_def_var(ncid, 'pos_lat_rad', NF_DOUBLE, 2, dimids, latrad_id)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'pos_lat_rad', nf90_double, dimids=dimids, varid=latrad_id)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-  status = nf_def_var(ncid, 'pos_lon_deg', NF_DOUBLE, 2, dimids, londeg_id)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'pos_lon_deg', nf90_double, dimids=dimids, varid=londeg_id)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-  status = nf_def_var(ncid, 'pos_lat_deg', NF_DOUBLE, 2, dimids, latdeg_id)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'pos_lat_deg', nf90_double, dimids=dimids, varid=latdeg_id)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-  status = nf_def_var(ncid, 'frozen_in', NF_DOUBLE, 2, dimids, frozen_id)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'frozen_in', nf90_double, dimids=dimids, varid=frozen_id)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-  status = nf_def_var(ncid, 'du_dt', NF_DOUBLE, 2, dimids, dudt_id)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'du_dt', nf90_double, dimids=dimids, varid=dudt_id)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-  status = nf_def_var(ncid, 'dv_dt', NF_DOUBLE, 2, dimids, dvdt_id)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'dv_dt', nf90_double, dimids=dimids, varid=dvdt_id)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-  status = nf_def_var(ncid, 'icb_vel_u', NF_DOUBLE, 2, dimids, uib_id)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'icb_vel_u', nf90_double, dimids=dimids, varid=uib_id)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-  status = nf_def_var(ncid, 'icb_vel_v', NF_DOUBLE, 2, dimids, vib_id)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'icb_vel_v', nf90_double, dimids=dimids, varid=vib_id)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   ! 3 dimensions of the iceberg, comment for buoy case
 
-  status = nf_def_var(ncid, 'height', NF_DOUBLE, 2, dimids, height_id)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'height', nf90_double, dimids=dimids, varid=height_id)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-  status = nf_def_var(ncid, 'length', NF_DOUBLE, 2, dimids, length_id)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'length', nf90_double, dimids=dimids, varid=length_id)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-  status = nf_def_var(ncid, 'width', NF_DOUBLE, 2, dimids, width_id)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'width', nf90_double, dimids=dimids, varid=width_id)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   ! 4 additional iceberg variables (meltrates), comment for buoy case
 
-  status = nf_def_var(ncid, 'bvl', NF_DOUBLE, 2, dimids, bvl_id)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'bvl', nf90_double, dimids=dimids, varid=bvl_id)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-  status = nf_def_var(ncid, 'lvlv', NF_DOUBLE, 2, dimids, lvlv_id)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'lvlv', nf90_double, dimids=dimids, varid=lvlv_id)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-  status = nf_def_var(ncid, 'lvle', NF_DOUBLE, 2, dimids, lvle_id)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'lvle', nf90_double, dimids=dimids, varid=lvle_id)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-  status = nf_def_var(ncid, 'lvlb', NF_DOUBLE, 2, dimids, lvlb_id)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'lvlb', nf90_double, dimids=dimids, varid=lvlb_id)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   ! LA: add felem
-  status = nf_def_var(ncid, 'felem', NF_DOUBLE, 2, dimids, felem_id)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_def_var(ncid, 'felem', nf90_double, dimids=dimids, varid=felem_id)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   ! Assign long_name and units attributes to variables.
   longname='time' ! use NetCDF Climate and Forecast (CF) Metadata Convention
-  status = nf_PUT_ATT_TEXT(ncid, time_varid, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  write(att_text, '(a14,I4.4,a1,I2.2,a1,I2.2,a6)') 'seconds since ', year_start, '-', month_start, '-', day_start, ' 00:00:00'
-  status = nf_PUT_ATT_TEXT(ncid, time_varid, 'units', len_trim(att_text), trim(att_text))
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status=nf90_put_att(ncid, time_varid, 'long_name', trim(longname))
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  units='seconds since model start'
+  status=nf90_put_att(ncid, time_varid, 'units', trim(units))
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
   if (include_fleapyear) then
       att_text='standard'
   else
       att_text='noleap'
   end if
-  status = nf_put_att_text(ncid, time_varid, 'calendar', len_trim(att_text), trim(att_text))
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, time_varid, 'calendar', trim(att_text))
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
   longname='iteration_count'
-  status = nf_PUT_ATT_TEXT(ncid, iter_varid, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, iter_varid, 'long_name', trim(longname)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   longname='longitude of buoy/iceberg position in radiant'
-  status = nf_PUT_ATT_TEXT(ncid, lonrad_id, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_put_att_text(ncid, lonrad_id, 'units', 7, 'radiant')
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, lonrad_id, 'long_name', trim(longname)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, lonrad_id, 'units', 'radiant')
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
   !rotated or not rotated due to setting in iceberg module
   description='(un)rotated according to setting of l_geo_out in iceberg module'
-  status = nf_put_att_text(ncid, lonrad_id, 'description', len_trim(description), trim(description)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, lonrad_id, 'description', trim(description)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   longname='latitude of buoy/iceberg position in radiant'
-  status = nf_PUT_ATT_TEXT(ncid, latrad_id, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_put_att_text(ncid, latrad_id, 'units', 7, 'radiant')
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, latrad_id, 'long_name', trim(longname)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, latrad_id, 'units', 'radiant')
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
   !rotated or not rotated due to setting in iceberg module
   description='(un)rotated according to setting of l_geo_out in iceberg module'
-  status = nf_put_att_text(ncid, latrad_id, 'description', len_trim(description), trim(description)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, latrad_id, 'description', trim(description)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   longname='longitude of buoy/iceberg position in degree'
-  status = nf_PUT_ATT_TEXT(ncid, londeg_id, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_put_att_text(ncid, londeg_id, 'units', 12, 'degrees_east')
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, londeg_id, 'long_name', trim(longname)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, londeg_id, 'units', 'degree')
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
   !rotated or not rotated due to setting in iceberg module
   description='(un)rotated according to setting of l_geo_out in iceberg module'
-  status = nf_put_att_text(ncid, londeg_id, 'description', len_trim(description), trim(description)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, londeg_id, 'description', trim(description)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   longname='latitude of buoy/iceberg position in degree'
-  status = nf_PUT_ATT_TEXT(ncid, latdeg_id, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_put_att_text(ncid, latdeg_id, 'units', 13, 'degrees_north')
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, latdeg_id, 'long_name', trim(longname)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, latdeg_id, 'units', 'degree')
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
   !rotated or not rotated due to setting in iceberg module
   description='(un)rotated according to setting of l_geo_out in iceberg module'
-  status = nf_put_att_text(ncid, latdeg_id, 'description', len_trim(description), trim(description)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, latdeg_id, 'description', trim(description)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   longname='status of buoy/iceberg (frozen in/not frozen in)'
-  status = nf_PUT_ATT_TEXT(ncid, frozen_id, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, frozen_id, 'long_name', trim(longname)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
   description='1 = frozen, 0 = not frozen, else partially frozen'
-  status = nf_put_att_text(ncid, frozen_id, 'description', len_trim(description), trim(description)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_PUT_ATT_TEXT(ncid, frozen_id, 'Coordinates', 23, 'pos_lon_deg pos_lat_deg') ! arcGIS 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, frozen_id, 'description', trim(description)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, frozen_id, 'Coordinates', 'pos_lon_deg pos_lat_deg') ! arcGIS 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   longname='du/dt of buoy/iceberg in last time step'
-  status = nf_PUT_ATT_TEXT(ncid, dudt_id, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_put_att_text(ncid, dudt_id, 'units', 8, 'm s^(-2)')
-  if (status .ne. nf_noerr) call handle_err(status, partit)  
+  status = nf90_put_att(ncid, dudt_id, 'long_name', trim(longname)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, dudt_id, 'units', 'm s^(-2)')
+  if (status .ne. nf90_noerr) call handle_err(status, partit)  
   !rotated or not rotated due to setting in iceberg module
   description='(un)rotated according to setting of l_geo_out in iceberg module'
-  status = nf_put_att_text(ncid, dudt_id, 'description', len_trim(description), trim(description)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_PUT_ATT_TEXT(ncid, dudt_id, 'Coordinates', 23, 'pos_lon_deg pos_lat_deg') ! arcGIS 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, dudt_id, 'description', trim(description)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, dudt_id, 'Coordinates', 'pos_lon_deg pos_lat_deg') ! arcGIS 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   longname='dv/dt of buoy/iceberg in last time step'
-  status = nf_PUT_ATT_TEXT(ncid, dvdt_id, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_put_att_text(ncid, dvdt_id, 'units', 8, 'm s^(-2)')
-  if (status .ne. nf_noerr) call handle_err(status, partit)  
+  status = nf90_put_att(ncid, dvdt_id, 'long_name', trim(longname)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, dvdt_id, 'units', 'm s^(-2)')
+  if (status .ne. nf90_noerr) call handle_err(status, partit)  
   !rotated or not rotated due to setting in iceberg module
   description='(un)rotated according to setting of l_geo_out in iceberg module'
-  status = nf_put_att_text(ncid, dvdt_id, 'description', len_trim(description), trim(description)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_PUT_ATT_TEXT(ncid, dvdt_id, 'Coordinates', 23, 'pos_lon_deg pos_lat_deg') ! arcGIS 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, dvdt_id, 'description', trim(description)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, dvdt_id, 'Coordinates', 'pos_lon_deg pos_lat_deg') ! arcGIS 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   longname='velocity of buoy/iceberg, u component'
-  status = nf_PUT_ATT_TEXT(ncid, uib_id, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_put_att_text(ncid, uib_id, 'units', 8, 'm s^(-1)')
-  if (status .ne. nf_noerr) call handle_err(status, partit)  
+  status = nf90_put_att(ncid, uib_id, 'long_name', trim(longname)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, uib_id, 'units', 'm s^(-1)')
+  if (status .ne. nf90_noerr) call handle_err(status, partit)  
   !rotated or not rotated due to setting in iceberg module
   description='(un)rotated according to setting of l_geo_out in iceberg module'
-  status = nf_put_att_text(ncid, uib_id, 'description', len_trim(description), trim(description)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_PUT_ATT_TEXT(ncid, uib_id, 'Coordinates', 23, 'pos_lon_deg pos_lat_deg') ! arcGIS 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, uib_id, 'description', trim(description)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, uib_id, 'Coordinates', 'pos_lon_deg pos_lat_deg') ! arcGIS 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   longname='velocity of buoy/iceberg, v component'
-  status = nf_PUT_ATT_TEXT(ncid, vib_id, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_put_att_text(ncid, vib_id, 'units', 8, 'm s^(-1)')
-  if (status .ne. nf_noerr) call handle_err(status, partit)  
+  status = nf90_put_att(ncid, vib_id, 'long_name', trim(longname)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, vib_id, 'units', 'm s^(-1)')
+  if (status .ne. nf90_noerr) call handle_err(status, partit)  
   !rotated or not rotated due to setting in iceberg module
   description='(un)rotated according to setting of l_geo_out in iceberg module'
-  status = nf_put_att_text(ncid, vib_id, 'description', len_trim(description), trim(description)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_PUT_ATT_TEXT(ncid, vib_id, 'Coordinates', 23, 'pos_lon_deg pos_lat_deg') ! arcGIS 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, vib_id, 'description', trim(description)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, vib_id, 'Coordinates', 'pos_lon_deg pos_lat_deg') ! arcGIS 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   ! 3 dimensions of the iceberg, comment for buoy case
 
   longname='height of the iceberg'
-  status = nf_PUT_ATT_TEXT(ncid, height_id, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_put_att_text(ncid, height_id, 'units', 1, 'm')
-  if (status .ne. nf_noerr) call handle_err(status, partit)  
+  status = nf90_put_att(ncid, height_id, 'long_name', trim(longname)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, height_id, 'units', 'm')
+  if (status .ne. nf90_noerr) call handle_err(status, partit)  
   description='freeboard + draft'
-  status = nf_put_att_text(ncid, height_id, 'description', len_trim(description), trim(description)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_PUT_ATT_TEXT(ncid, height_id, 'Coordinates', 23, 'pos_lon_deg pos_lat_deg') ! arcGIS 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, height_id, 'description', trim(description)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, height_id, 'Coordinates', 'pos_lon_deg pos_lat_deg') ! arcGIS 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   longname='length of the iceberg'
-  status = nf_PUT_ATT_TEXT(ncid, length_id, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_put_att_text(ncid, length_id, 'units', 1, 'm')
-  if (status .ne. nf_noerr) call handle_err(status, partit)  
+  status = nf90_put_att(ncid, length_id, 'long_name', trim(longname)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, length_id, 'units', 'm')
+  if (status .ne. nf90_noerr) call handle_err(status, partit)  
   description='open'
-  status = nf_put_att_text(ncid, length_id, 'description', len_trim(description), trim(description)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_PUT_ATT_TEXT(ncid, length_id, 'Coordinates', 23, 'pos_lon_deg pos_lat_deg') ! arcGIS 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, length_id, 'description', trim(description)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, length_id, 'Coordinates', 'pos_lon_deg pos_lat_deg') ! arcGIS 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   longname='width of the iceberg'
-  status = nf_PUT_ATT_TEXT(ncid, width_id, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_put_att_text(ncid, width_id, 'units', 1, 'm')
-  if (status .ne. nf_noerr) call handle_err(status, partit)  
+  status = nf90_put_att(ncid, width_id, 'long_name', trim(longname)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, width_id, 'units', 'm')
+  if (status .ne. nf90_noerr) call handle_err(status, partit)  
   description='open'
-  status = nf_put_att_text(ncid, width_id, 'description', len_trim(description), trim(description)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_PUT_ATT_TEXT(ncid, width_id, 'Coordinates', 23, 'pos_lon_deg pos_lat_deg') ! arcGIS 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, width_id, 'description', trim(description)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, width_id, 'Coordinates', 'pos_lon_deg pos_lat_deg') ! arcGIS 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 
   ! 4 additional iceberg variables (meltrates), comment for buoy case
 
   longname='basal volume loss'
-  status = nf_PUT_ATT_TEXT(ncid, bvl_id, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_put_att_text(ncid, bvl_id, 'units', 18, 'm^3 (ice) day^(-1)')
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, bvl_id, 'long_name', trim(longname)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, bvl_id, 'units', 'm^3 (ice) day^(-1)')
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
   description='losses are averaged over the preceding output interval'
-  status = nf_put_att_text(ncid, bvl_id, 'description', len_trim(description), trim(description)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_PUT_ATT_TEXT(ncid, bvl_id, 'Coordinates', 23, 'pos_lon_deg pos_lat_deg') ! arcGIS 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, bvl_id, 'description', trim(description)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, bvl_id, 'Coordinates', 'pos_lon_deg pos_lat_deg') ! arcGIS 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   longname='lateral volume loss due to 1) bouyant convection'
-  status = nf_PUT_ATT_TEXT(ncid, lvlv_id, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_put_att_text(ncid, lvlv_id, 'units', 18, 'm^3 (ice) day^(-1)')
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, lvlv_id, 'long_name', trim(longname)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, lvlv_id, 'units', 'm^3 (ice) day^(-1)')
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
   description='losses are averaged over the preceding output interval'
-  status = nf_put_att_text(ncid, lvlv_id, 'description', len_trim(description), trim(description)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_PUT_ATT_TEXT(ncid, lvlv_id, 'Coordinates', 23, 'pos_lon_deg pos_lat_deg') ! arcGIS 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, lvlv_id, 'description', trim(description)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, lvlv_id, 'Coordinates', 'pos_lon_deg pos_lat_deg') ! arcGIS 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   longname='lateral volume loss due to 2) wave erosion'
-  status = nf_PUT_ATT_TEXT(ncid, lvle_id, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_put_att_text(ncid, lvle_id, 'units', 18, 'm^3 (ice) day^(-1)')
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, lvle_id, 'long_name', trim(longname)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, lvle_id, 'units', 'm^3 (ice) day^(-1)')
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
   description='losses are averaged over the preceding output interval'
-  status = nf_put_att_text(ncid, lvle_id, 'description', len_trim(description), trim(description)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_PUT_ATT_TEXT(ncid, lvle_id, 'Coordinates', 23, 'pos_lon_deg pos_lat_deg') ! arcGIS 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, lvle_id, 'description', trim(description)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, lvle_id, 'Coordinates', 'pos_lon_deg pos_lat_deg') ! arcGIS 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   longname='lateral volume loss due to 3) "basal" formulation'
-  status = nf_PUT_ATT_TEXT(ncid, lvlb_id, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_put_att_text(ncid, lvlb_id, 'units', 18, 'm^3 (ice) day^(-1)')
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, lvlb_id, 'long_name', trim(longname)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, lvlb_id, 'units', 'm^3 (ice) day^(-1)')
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
   description='losses are averaged over the preceding output interval'
-  status = nf_put_att_text(ncid, lvlb_id, 'description', len_trim(description), trim(description)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_PUT_ATT_TEXT(ncid, lvlb_id, 'Coordinates', 23, 'pos_lon_deg pos_lat_deg') ! arcGIS 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, lvlb_id, 'description', trim(description)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, lvlb_id, 'Coordinates', 'pos_lon_deg pos_lat_deg') ! arcGIS 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
   ! LA: add felem
   longname='fesom element'
-  status = nf_PUT_ATT_TEXT(ncid, felem_id, 'long_name', len_trim(longname), trim(longname)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_put_att_text(ncid, felem_id, 'units', 18, '')
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, felem_id, 'long_name', trim(longname)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, felem_id, 'units', '')
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
   description=''
-  status = nf_put_att_text(ncid, felem_id, 'description', len_trim(description), trim(description)) 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
-  status = nf_PUT_ATT_TEXT(ncid, felem_id, 'Coordinates', 23, 'pos_lon_deg pos_lat_deg') ! arcGIS 
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, felem_id, 'description', trim(description)) 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
+  status = nf90_put_att(ncid, felem_id, 'Coordinates', 'pos_lon_deg pos_lat_deg') ! arcGIS 
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-  status = nf_enddef(ncid)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  status = nf90_enddef(ncid)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-  status=nf_close(ncid)
-  if (status .ne. nf_noerr) call handle_err(status, partit) 
+  status = nf90_close(ncid)
+  if (status .ne. nf90_noerr) call handle_err(status, partit) 
 
  ! initialize the counter for saving results
   save_count_buoys=1
@@ -1934,12 +1933,11 @@ subroutine write_buoy_props_netcdf(partit)
 
  use g_config
  use g_clock
+ use netcdf
 ! use iceberg_params, only : buoy_props, file_icb_netcdf, save_count_buoys, prev_sec_in_year, bvl_mean, lvlv_mean, lvle_mean, lvlb_mean
  use g_forcing_param
 
  implicit none
-
-#include "netcdf.inc" 
 
   integer                   :: status,ncid, istep
   integer                   :: dimid_ib, dimid_rec, dimids(2)
@@ -1950,6 +1948,7 @@ subroutine write_buoy_props_netcdf(partit)
   integer                   :: height_id, length_id, width_id
   integer                   :: bvl_id, lvlv_id, lvle_id, lvlb_id, felem_id
   integer                   :: start(2), count(2)
+  integer                   :: start_1d(1), count_1d(1)
   real(kind=8)              :: sec_in_year
 type(t_partit), intent(inout), target :: partit
 !type(t_ice),    intent(inout), target :: ice
@@ -1965,72 +1964,72 @@ type(t_partit), intent(inout), target :: partit
      sec_in_year=dt*istep
 
     ! open files
-     status = nf_open(trim(file_icb_netcdf), nf_write, ncid)
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status = nf90_open(trim(file_icb_netcdf), nf90_write, ncid)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
      ! inquire variable id
 
-     status = nf_inq_varid(ncid, 'time', time_varid)
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status = nf90_inq_varid(ncid, 'time', time_varid)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status=nf_inq_varid(ncid, 'iter', iter_varid)
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status=nf90_inq_varid(ncid, 'iter', iter_varid)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status = nf_inq_varid(ncid, 'pos_lon_rad', lonrad_id)
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status = nf90_inq_varid(ncid, 'pos_lon_rad', lonrad_id)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status = nf_inq_varid(ncid, 'pos_lat_rad', latrad_id)
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status = nf90_inq_varid(ncid, 'pos_lat_rad', latrad_id)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status = nf_inq_varid(ncid, 'pos_lon_deg', londeg_id)
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status = nf90_inq_varid(ncid, 'pos_lon_deg', londeg_id)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status = nf_inq_varid(ncid, 'pos_lat_deg', latdeg_id)
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status = nf90_inq_varid(ncid, 'pos_lat_deg', latdeg_id)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status = nf_inq_varid(ncid, 'frozen_in',  frozen_id)
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status = nf90_inq_varid(ncid, 'frozen_in',  frozen_id)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status = nf_inq_varid(ncid, 'du_dt',  dudt_id)
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status = nf90_inq_varid(ncid, 'du_dt',  dudt_id)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status = nf_inq_varid(ncid, 'dv_dt',  dvdt_id)
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status = nf90_inq_varid(ncid, 'dv_dt',  dvdt_id)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status = nf_inq_varid(ncid, 'icb_vel_u',  uib_id)
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status = nf90_inq_varid(ncid, 'icb_vel_u',  uib_id)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status = nf_inq_varid(ncid, 'icb_vel_v',  vib_id)
-     if (status .ne. nf_noerr) call handle_err(status, partit)  
+     status = nf90_inq_varid(ncid, 'icb_vel_v',  vib_id)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)  
 
      ! inquire 3 additional IDs for iceberg case, comment for buoy case
 
-     status = nf_inq_varid(ncid, 'height',  height_id)
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status = nf90_inq_varid(ncid, 'height',  height_id)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status = nf_inq_varid(ncid, 'length',  length_id)
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status = nf90_inq_varid(ncid, 'length',  length_id)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status = nf_inq_varid(ncid, 'width',  width_id)
-     if (status .ne. nf_noerr) call handle_err(status, partit)  
+     status = nf90_inq_varid(ncid, 'width',  width_id)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)  
 
      ! inquire 4 additional IDs for iceberg case, comment for buoy case
 
-     status = nf_inq_varid(ncid, 'bvl',  bvl_id)
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status = nf90_inq_varid(ncid, 'bvl',  bvl_id)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status = nf_inq_varid(ncid, 'lvlv',  lvlv_id)
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status = nf90_inq_varid(ncid, 'lvlv',  lvlv_id)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status = nf_inq_varid(ncid, 'lvle',  lvle_id)
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status = nf90_inq_varid(ncid, 'lvle',  lvle_id)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status = nf_inq_varid(ncid, 'lvlb',  lvlb_id)
-     if (status .ne. nf_noerr) call handle_err(status, partit) 
+     status = nf90_inq_varid(ncid, 'lvlb',  lvlb_id)
+     if (status .ne. nf90_noerr) call handle_err(status, partit) 
 
      ! * LA: include fesom elemt in output
-     status = nf_inq_varid(ncid, 'felem', felem_id)
-     if (status .ne. nf_noerr) call handle_err(status, partit) 
+     status = nf90_inq_varid(ncid, 'felem', felem_id)
+     if (status .ne. nf90_noerr) call handle_err(status, partit) 
 
      !buoy_props(ib, 1) = lon_rad_out
      !buoy_props(ib, 2) = lat_rad_out
@@ -2050,74 +2049,74 @@ type(t_partit), intent(inout), target :: partit
      !lvle_mean(ib)*step_per_day
      !lvlb_mean(ib)*step_per_day
 
-     ! time and iteration
-     status=nf_put_vara_double(ncid, time_varid, save_count_buoys, 1, prev_sec_in_year+sec_in_year) 
-     if (status .ne. nf_noerr) call handle_err(status, partit)
-     status=nf_put_vara_int(ncid, iter_varid, save_count_buoys, 1, istep)
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+      ! time and iteration
+      status=nf90_put_var(ncid, time_varid, prev_sec_in_year+sec_in_year) 
+      if (status .ne. nf90_noerr) call handle_err(status, partit)
+      status=nf90_put_var(ncid, iter_varid, istep)
+      if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     !variables
-     start=(/1,save_count_buoys/)
-     count=(/ib_num, 1/)
-     status=nf_put_vara_double(ncid, lonrad_id, start, count, buoy_props(:, 1)) 
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+      !variables
+      start=(/1,save_count_buoys/)
+      count=(/ib_num, 1/)
+      status=nf90_put_var(ncid, lonrad_id, buoy_props(:, 1), start=start, count=count) 
+      if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status=nf_put_vara_double(ncid, latrad_id, start, count, buoy_props(:, 2)) 
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status=nf90_put_var(ncid, latrad_id, buoy_props(:, 2), start=start, count=count) 
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status=nf_put_vara_double(ncid, londeg_id, start, count, buoy_props(:, 3)) 
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status=nf90_put_var(ncid, londeg_id, buoy_props(:, 3), start=start, count=count) 
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status=nf_put_vara_double(ncid, latdeg_id, start, count, buoy_props(:, 4)) 
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status=nf90_put_var(ncid, latdeg_id, buoy_props(:, 4), start=start, count=count) 
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status=nf_put_vara_double(ncid, frozen_id, start, count, buoy_props(:, 5)) 
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status=nf90_put_var(ncid, frozen_id, buoy_props(:, 5), start=start, count=count) 
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status=nf_put_vara_double(ncid, dudt_id, start, count, buoy_props(:, 6)) 
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status=nf90_put_var(ncid, dudt_id, buoy_props(:, 6), start=start, count=count) 
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status=nf_put_vara_double(ncid, dvdt_id, start, count, buoy_props(:, 7)) 
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status=nf90_put_var(ncid, dvdt_id, buoy_props(:, 7), start=start, count=count) 
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status=nf_put_vara_double(ncid, uib_id, start, count, buoy_props(:, 8)) 
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status=nf90_put_var(ncid, uib_id, buoy_props(:, 8), start=start, count=count) 
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status=nf_put_vara_double(ncid, vib_id, start, count, buoy_props(:, 9)) 
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status=nf90_put_var(ncid, vib_id, buoy_props(:, 9), start=start, count=count) 
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
      ! write 3 additional variables for iceberg case, comment for buoy case
 
-     status=nf_put_vara_double(ncid, height_id, start, count, buoy_props(:,10)) 
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status=nf90_put_var(ncid, height_id, buoy_props(:,10), start=start, count=count) 
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status=nf_put_vara_double(ncid, length_id, start, count, buoy_props(:,11)) 
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status=nf90_put_var(ncid, length_id, buoy_props(:,11), start=start, count=count) 
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status=nf_put_vara_double(ncid, width_id, start, count, buoy_props(:,12)) 
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status=nf90_put_var(ncid, width_id, buoy_props(:,12), start=start, count=count) 
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
      ! write 4 additional variables for iceberg case, comment for buoy case
 
-     status=nf_put_vara_double(ncid, bvl_id, start, count, bvl_mean(:)*step_per_day) 
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status=nf90_put_var(ncid, bvl_id, bvl_mean(:)*step_per_day, start=start, count=count) 
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status=nf_put_vara_double(ncid, lvlv_id, start, count, lvlv_mean(:)*step_per_day) 
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status=nf90_put_var(ncid, lvlv_id, lvlv_mean(:)*step_per_day, start=start, count=count) 
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status=nf_put_vara_double(ncid, lvle_id, start, count, lvle_mean(:)*step_per_day) 
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status=nf90_put_var(ncid, lvle_id, lvle_mean(:)*step_per_day, start=start, count=count) 
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
-     status=nf_put_vara_double(ncid, lvlb_id, start, count, lvlb_mean(:)*step_per_day) 
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status=nf90_put_var(ncid, lvlb_id, lvlb_mean(:)*step_per_day, start=start, count=count) 
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
      ! LA: add felem
-     status=nf_put_vara_double(ncid, felem_id, start, count, buoy_props(:,13)) 
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status=nf90_put_var(ncid, felem_id, buoy_props(:,13), start=start, count=count) 
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
      !close file
-     status=nf_close(ncid)
-     if (status .ne. nf_noerr) call handle_err(status, partit)
+     status=nf90_close(ncid)
+     if (status .ne. nf90_noerr) call handle_err(status, partit)
 
      save_count_buoys=save_count_buoys+1
 !==========================================================

--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -1609,8 +1609,8 @@ subroutine create_new_file(entry, ice, dynamics, partit, mesh)
     write(att_text, '(a14,I4.4,a1,I2.2,a1,I2.2,a6)') 'seconds since ', yearold, '-', 1, '-', 1, ' 0:0:0'
     call assert_nf( nf90_put_att(entry%ncid, entry%tID, 'units', trim(att_text)), __LINE__)
     call assert_nf( nf90_put_att(entry%ncid, entry%tID, 'axis', 'T'), __LINE__)
-    call assert_nf( nf90_put_att(entry%ncid, entry%tID, 'calendar', 'standard'), __LINE__)
-    
+    call assert_nf( nf90_put_att(entry%ncid, entry%tID, 'stored_direction', 'increasing'), __LINE__)
+
     call assert_nf( nf90_def_var(entry%ncid, trim(entry%name), entry%data_strategy%netcdf_type(), (/entry%dimid(entry%ndim:1:-1), entry%recID/), entry%varID), __LINE__)
 
     call assert_nf( nf90_def_var_deflate(entry%ncid, entry%varID, 0, 1, compression_level), __LINE__)

--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -11,9 +11,9 @@ module io_MEANDATA
   use, intrinsic :: iso_fortran_env, only: real64, real32
   use io_data_strategy_module
   use async_threads_module
+  use netcdf
 
   implicit none
-#include "netcdf.inc"
   private
   public :: def_stream, def_stream2D, def_stream3D, output, finalize_output
 !
@@ -121,7 +121,7 @@ module io_MEANDATA
 subroutine destructor(this)
     type(Meandata), intent(inout) :: this
     ! EO args
-    call assert_nf(nf_close(this%ncid), __LINE__)
+    call assert_nf(nf90_close(this%ncid), __LINE__)
 end subroutine destructor
 !
 !
@@ -1560,118 +1560,119 @@ subroutine create_new_file(entry, ice, dynamics, partit, mesh)
     
     !___________________________________________________________________________
     ! Create file
-    call assert_nf( nf_create(entry%filename, IOR(NF_NOCLOBBER,IOR(NF_NETCDF4,NF_CLASSIC_MODEL)), entry%ncid), __LINE__)
+    call assert_nf( nf90_create(entry%filename, IOR(nf90_noclobber,IOR(nf90_netcdf4,nf90_classic_model)), entry%ncid), __LINE__)
 
     !___________________________________________________________________________
     ! Create mesh related dimensions
     if (entry%ndim==1) then
-        call assert_nf( nf_def_dim(entry%ncid, entry%dimname(1), entry%glsize(2), entry%dimID(1)), __LINE__)
+        call assert_nf( nf90_def_dim(entry%ncid, entry%dimname(1), entry%glsize(2), entry%dimID(1)), __LINE__)
         
     else if (entry%ndim==2) then
-        call assert_nf( nf_def_dim(entry%ncid,  entry%dimname(1), entry%glsize(1), entry%dimID(1)), __LINE__)
+        call assert_nf( nf90_def_dim(entry%ncid,  entry%dimname(1), entry%glsize(1), entry%dimID(1)), __LINE__)
         if (entry%dimname(1)=='nz') then
-            call assert_nf( nf_def_var(entry%ncid,  entry%dimname(1), NF_DOUBLE,   1,  entry%dimID(1), entry%dimvarID(1)), __LINE__)
-            call assert_nf( nf_put_att_text(entry%ncid, entry%dimvarID(1), 'long_name', len_trim('depth at layer interface'),'depth at layer interface'), __LINE__)
+            call assert_nf( nf90_def_var(entry%ncid,  entry%dimname(1), nf90_double,   (/entry%dimID(1)/), entry%dimvarID(1)), __LINE__)
+            call assert_nf( nf90_put_att(entry%ncid, entry%dimvarID(1), 'long_name', 'depth at layer interface'), __LINE__)
             
         elseif (entry%dimname(1)=='nz1') then
-            call assert_nf( nf_def_var(entry%ncid,  entry%dimname(1), NF_DOUBLE,   1,  entry%dimID(1), entry%dimvarID(1)), __LINE__)
-            call assert_nf( nf_put_att_text(entry%ncid, entry%dimvarID(1), 'long_name', len_trim('depth at layer midpoint'),'depth at layer midpoint'), __LINE__)
+            call assert_nf( nf90_def_var(entry%ncid,  entry%dimname(1), nf90_double,   (/entry%dimID(1)/), entry%dimvarID(1)), __LINE__)
+            call assert_nf( nf90_put_att(entry%ncid, entry%dimvarID(1), 'long_name', 'depth at layer midpoint'), __LINE__)
             
         elseif (entry%dimname(1)=='ncat') then
-            call assert_nf( nf_def_var(entry%ncid,  entry%dimname(1), NF_INT   ,   1,  entry%dimID(1), entry%dimvarID(1)), __LINE__)
-            call assert_nf( nf_put_att_text(entry%ncid, entry%dimvarID(1), 'long_name', len_trim('sea-ice thickness class'),'sea-ice thickness class'), __LINE__)
+            call assert_nf( nf90_def_var(entry%ncid,  entry%dimname(1), nf90_int,   (/entry%dimID(1)/), entry%dimvarID(1)), __LINE__)
+            call assert_nf( nf90_put_att(entry%ncid, entry%dimvarID(1), 'long_name', 'sea-ice thickness class'), __LINE__)
         
         elseif (entry%dimname(1)=='ndens') then
-            call assert_nf( nf_def_var(entry%ncid,  entry%dimname(1), NF_INT   ,   1,  entry%dimID(1), entry%dimvarID(1)), __LINE__)
-            call assert_nf( nf_put_att_text(entry%ncid, entry%dimvarID(1), 'long_name', len_trim('sigma2 density class'),'sigma2 density class'), __LINE__)
+            call assert_nf( nf90_def_var(entry%ncid,  entry%dimname(1), nf90_int,   (/entry%dimID(1)/), entry%dimvarID(1)), __LINE__)
+            call assert_nf( nf90_put_att(entry%ncid, entry%dimvarID(1), 'long_name', 'sigma2 density class'), __LINE__)
         
         else
             if (partit%mype==0) write(*,*) 'WARNING: unknown first dimension in 2d mean I/O data'
             
         end if 
-        call assert_nf( nf_put_att_text(entry%ncid, entry%dimvarID(1), 'units', len_trim('m'),'m'), __LINE__)
-        call assert_nf( nf_put_att_text(entry%ncid, entry%dimvarID(1), 'positive', len_trim('down'),'down'), __LINE__)
-        call assert_nf( nf_put_att_text(entry%ncid, entry%dimvarID(1), 'axis', len_trim('Z'),'Z'), __LINE__)
+        call assert_nf( nf90_put_att(entry%ncid, entry%dimvarID(1), 'units', 'm'), __LINE__)
+        call assert_nf( nf90_put_att(entry%ncid, entry%dimvarID(1), 'positive', 'down'), __LINE__)
+        call assert_nf( nf90_put_att(entry%ncid, entry%dimvarID(1), 'axis', 'Z'), __LINE__)
         
-        call assert_nf( nf_def_dim(entry%ncid, entry%dimname(2), entry%glsize(2), entry%dimID(2)), __LINE__)
+        call assert_nf( nf90_def_dim(entry%ncid, entry%dimname(2), entry%glsize(2), entry%dimID(2)), __LINE__)
     end if
   
     !___________________________________________________________________________
     ! Create time related dimensions
-    call assert_nf( nf_def_dim(entry%ncid, 'time', NF_UNLIMITED, entry%recID), __LINE__)
+    call assert_nf( nf90_def_dim(entry%ncid, 'time', nf90_unlimited, entry%recID), __LINE__)
   
     !___________________________________________________________________________
     ! Define the time and iteration variables
-    call assert_nf( nf_def_var(entry%ncid, 'time', NF_DOUBLE, 1, entry%recID, entry%tID), __LINE__)
+    call assert_nf( nf90_def_var(entry%ncid, 'time', nf90_double, (/entry%recID/), entry%tID), __LINE__)
     att_text='time'
-    call assert_nf( nf_put_att_text(entry%ncid, entry%tID, 'long_name', len_trim(att_text), trim(att_text)), __LINE__)
-    call assert_nf( nf_put_att_text(entry%ncid, entry%tID, 'standard_name', len_trim(att_text), trim(att_text)), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, entry%tID, 'long_name', trim(att_text)), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, entry%tID, 'standard_name', trim(att_text)), __LINE__)
     write(att_text, '(a14,I4.4,a1,I2.2,a1,I2.2,a6)') 'seconds since ', yearold, '-', 1, '-', 1, ' 0:0:0'
-    call assert_nf( nf_put_att_text(entry%ncid, entry%tID, 'units', len_trim(att_text), trim(att_text)), __LINE__)
-    call assert_nf( nf_put_att_text(entry%ncid, entry%tID, 'axis', len_trim('T'), trim('T')), __LINE__)
-    call assert_nf( nf_put_att_text(entry%ncid, entry%tID, 'stored_direction', len_trim('increasing'), trim('increasing')), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, entry%tID, 'units', trim(att_text)), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, entry%tID, 'axis', 'T'), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, entry%tID, 'calendar', 'standard'), __LINE__)
     
-    call assert_nf( nf_def_var(entry%ncid, trim(entry%name), entry%data_strategy%netcdf_type(), entry%ndim+1, (/entry%dimid(entry%ndim:1:-1), entry%recID/), entry%varID), __LINE__)
+    call assert_nf( nf90_def_var(entry%ncid, trim(entry%name), entry%data_strategy%netcdf_type(), (/entry%dimid(entry%ndim:1:-1), entry%recID/), entry%varID), __LINE__)
 
-    call assert_nf( nf_def_var_deflate(entry%ncid, entry%varID, 0, 1, compression_level), __LINE__)
-    call assert_nf( nf_put_att_text(entry%ncid, entry%varID, 'description', len_trim(entry%description), entry%description), __LINE__)
-    call assert_nf( nf_put_att_text(entry%ncid, entry%varID, 'long_name', len_trim(entry%description), entry%description), __LINE__)
-    call assert_nf( nf_put_att_text(entry%ncid, entry%varID, 'units',       len_trim(entry%units),       entry%units), __LINE__)
-    call assert_nf( nf_put_att_text(entry%ncid, entry%varID, 'location',       len_trim(entry%defined_on),       entry%defined_on), __LINE__)
-    call assert_nf( nf_put_att_text(entry%ncid, entry%varID, 'mesh',       len_trim(entry%mesh),       entry%mesh), __LINE__)
+    call assert_nf( nf90_def_var_deflate(entry%ncid, entry%varID, 0, 1, compression_level), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, entry%varID, 'description', entry%description), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, entry%varID, 'long_name', entry%description), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, entry%varID, 'units', entry%units), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, entry%varID, 'location', entry%defined_on), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, entry%varID, 'mesh', entry%mesh), __LINE__)
 
 
   !___Global attributes________  
-    call assert_nf( nf_put_att_text(entry%ncid, NF_GLOBAL, 'Conventions', len_trim('UGRID-1.0'),'UGRID-1.0'), __LINE__)
-    call assert_nf( nf_put_att_text(entry%ncid, NF_GLOBAL, global_attributes_prefix//'model', len_trim('FESOM2'),'FESOM2'), __LINE__)
-    call assert_nf( nf_put_att_text(entry%ncid, NF_GLOBAL, global_attributes_prefix//'website', len_trim('fesom.de'), trim('fesom.de')), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, 'title', 'FESOM2 output'), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'model', 'FESOM2'), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'website', 'fesom.de'), __LINE__)
 
-    call assert_nf( nf_put_att_text(entry%ncid, NF_GLOBAL, global_attributes_prefix//'git_SHA', len_trim(fesom_git_sha()), fesom_git_sha()), __LINE__)
-    call assert_nf( nf_put_att_text(entry%ncid, NF_GLOBAL, global_attributes_prefix//'MeshPath', len_trim(MeshPath), trim(MeshPath)), __LINE__)
-    call assert_nf( nf_put_att_text(entry%ncid, NF_GLOBAL, global_attributes_prefix//'mesh_representative_checksum', len(mesh%representative_checksum), mesh%representative_checksum), __LINE__)
-    call assert_nf( nf_put_att_text(entry%ncid, NF_GLOBAL, global_attributes_prefix//'ClimateDataPath', len_trim(ClimateDataPath), trim(ClimateDataPath)), __LINE__)
-    call assert_nf( nf_put_att_text(entry%ncid, NF_GLOBAL, global_attributes_prefix//'which_ALE', len_trim(which_ALE), trim(which_ALE)), __LINE__)
-    call assert_nf( nf_put_att_text(entry%ncid, NF_GLOBAL, global_attributes_prefix//'mix_scheme', len_trim(mix_scheme), trim(mix_scheme)), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'git_SHA', fesom_git_sha()), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'MeshPath', trim(MeshPath)), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'mesh_representative_checksum', mesh%representative_checksum), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'ClimateDataPath', trim(ClimateDataPath)), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'which_ALE', trim(which_ALE)), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'mix_scheme', trim(mix_scheme)), __LINE__)
+    ! Global attributes already set above
 
-  ! call assert_nf( nf_put_att_text(entry%ncid, NF_GLOBAL, global_attributes_prefix//'tra_adv_hor', len_trim(tra_adv_hor), trim(tra_adv_hor)), __LINE__)
-  ! call assert_nf( nf_put_att_text(entry%ncid, NF_GLOBAL, global_attributes_prefix//'tra_adv_ver', len_trim(tra_adv_ver), trim(tra_adv_ver)), __LINE__)
-  ! call assert_nf( nf_put_att_text(entry%ncid, NF_GLOBAL, global_attributes_prefix//'tra_adv_lim', len_trim(tra_adv_lim), trim(tra_adv_lim)), __LINE__)
+  ! call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'tra_adv_hor', trim(tra_adv_hor)), __LINE__)
+  ! call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'tra_adv_ver', trim(tra_adv_ver)), __LINE__)
+  ! call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'tra_adv_lim', trim(tra_adv_lim)), __LINE__)
  
-    call assert_nf( nf_put_att_int(entry%ncid, NF_GLOBAL, global_attributes_prefix//'use_partial_cell', NF_INT, 1,  use_partial_cell), __LINE__)
-    call assert_nf( nf_put_att_int(entry%ncid, NF_GLOBAL, global_attributes_prefix//'force_rotation', NF_INT, 1,  force_rotation), __LINE__)
-    call assert_nf( nf_put_att_int(entry%ncid, NF_GLOBAL, global_attributes_prefix//'include_fleapyear', NF_INT, 1,  include_fleapyear), __LINE__)
-    call assert_nf( nf_put_att_int(entry%ncid, NF_GLOBAL, global_attributes_prefix//'use_floatice', NF_INT, 1,  use_floatice), __LINE__)
-    call assert_nf( nf_put_att_int(entry%ncid, NF_GLOBAL, global_attributes_prefix//'whichEVP'         , NF_INT, 1,  ice%whichEVP), __LINE__)
-    call assert_nf( nf_put_att_int(entry%ncid, NF_GLOBAL, global_attributes_prefix//'evp_rheol_steps'  , NF_INT, 1,  ice%evp_rheol_steps), __LINE__)
-    call assert_nf( nf_put_att_int(entry%ncid, NF_GLOBAL, global_attributes_prefix//'opt_visc'         , NF_INT, 1,  dynamics%opt_visc), __LINE__)
-    call assert_nf( nf_put_att_int(entry%ncid, NF_GLOBAL, global_attributes_prefix//'use_wsplit'       , NF_INT, 1,  dynamics%use_wsplit), __LINE__)
-    call assert_nf( nf_put_att_int(entry%ncid, NF_GLOBAL, global_attributes_prefix//'use_partial_cell', NF_INT, 1,  use_partial_cell), __LINE__)
-    call assert_nf( nf_put_att_int(entry%ncid, NF_GLOBAL, global_attributes_prefix//'autorotate_back_to_geo', NF_INT, 1,  vec_autorotate), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'use_partial_cell', merge(1, 0, use_partial_cell)), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'force_rotation', merge(1, 0, force_rotation)), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'include_fleapyear', merge(1, 0, include_fleapyear)), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'use_floatice', merge(1, 0, use_floatice)), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'whichEVP', ice%whichEVP), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'evp_rheol_steps', ice%evp_rheol_steps), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'opt_visc', dynamics%opt_visc), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'use_wsplit', merge(1, 0, dynamics%use_wsplit)), __LINE__)
+    ! use_partial_cell already set above
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'autorotate_back_to_geo', merge(1, 0, vec_autorotate)), __LINE__)
  
     !___________________________________________________________________________
     ! This ends definition part of the file, below filling in variables is possible
-    call assert_nf( nf_enddef(entry%ncid), __LINE__)
+    call assert_nf( nf90_enddef(entry%ncid), __LINE__)
     if (entry%dimname(1)=='nz') then
-        call assert_nf( nf_put_var_double(entry%ncid, entry%dimvarID(1), abs(mesh%zbar)), __LINE__)
+        call assert_nf( nf90_put_var(entry%ncid, entry%dimvarID(1), abs(mesh%zbar)), __LINE__)
     elseif (entry%dimname(1)=='nz1') then
-        call assert_nf( nf_put_var_double(entry%ncid, entry%dimvarID(1), abs(mesh%Z)), __LINE__)
+        call assert_nf( nf90_put_var(entry%ncid, entry%dimvarID(1), abs(mesh%Z)), __LINE__)
 #if defined(__icepack)    
     elseif (entry%dimname(1)=='ncat') then
         allocate(ncat_arr(entry%glsize(1)))
         do ii= 1, entry%glsize(1)
             ncat_arr(ii)=ii
         end do        
-        call assert_nf( nf_put_var_int(entry%ncid, entry%dimvarID(1), ncat_arr), __LINE__)    
+        call assert_nf( nf90_put_var(entry%ncid, entry%dimvarID(1), ncat_arr), __LINE__)    
         deallocate(ncat_arr)
 #endif
     elseif (entry%dimname(1)=='ndens') then
-        call assert_nf( nf_put_var_double(entry%ncid, entry%dimvarID(1), std_dens), __LINE__)
+        call assert_nf( nf90_put_var(entry%ncid, entry%dimvarID(1), std_dens), __LINE__)
     else
         if (partit%mype==0) write(*,*) 'WARNING: unknown first dimension in 2d mean I/O data'
     end if 
     
     !___________________________________________________________________________
-    call assert_nf( nf_close(entry%ncid), __LINE__)
+    call assert_nf( nf90_close(entry%ncid), __LINE__)
 end subroutine
 !
 !
@@ -1684,15 +1685,15 @@ subroutine assoc_ids(entry)
     write(*,*) 'associating mean I/O file ', trim(entry%filename)
 
     do j=1, entry%ndim
-        call assert_nf( nf_inq_dimid(entry%ncid, entry%dimname(j), entry%dimID(j)), __LINE__)
+        call assert_nf( nf90_inq_dimid(entry%ncid, entry%dimname(j), entry%dimID(j)), __LINE__)
     end do
     !___Associate time related dimensions_______________________________________
-    call assert_nf( nf_inq_dimid (entry%ncid, 'time', entry%recID), __LINE__)
-    call assert_nf( nf_inq_dimlen(entry%ncid, entry%recID, entry%rec_count), __LINE__)
+    call assert_nf( nf90_inq_dimid(entry%ncid, 'time', entry%recID), __LINE__)
+    call assert_nf( nf90_inquire_dimension(entry%ncid, entry%recID, len=entry%rec_count), __LINE__)
     !___Associate the time and iteration variables______________________________
-    call assert_nf( nf_inq_varid(entry%ncid, 'time', entry%tID), __LINE__)
+    call assert_nf( nf90_inq_varid(entry%ncid, 'time', entry%tID), __LINE__)
     !___Associate physical variables____________________________________________
-    call assert_nf( nf_inq_varid(entry%ncid, entry%name, entry%varID), __LINE__)
+    call assert_nf( nf90_inq_varid(entry%ncid, entry%name, entry%varID), __LINE__)
 end subroutine
 !
 !
@@ -1717,7 +1718,7 @@ subroutine write_mean(entry, entry_index)
     ! write new time index ctime_copy to file --> expand time array in nc file
     if (entry%p_partit%mype==entry%root_rank) then
         write(*,*) 'writing mean record for ', trim(entry%name), '; rec. count = ', entry%rec_count
-        call assert_nf( nf_put_vara_double(entry%ncid, entry%Tid, entry%rec_count, 1, entry%ctime_copy, 1), __LINE__)
+        call assert_nf( nf90_put_var(entry%ncid, entry%Tid, entry%ctime_copy), __LINE__)
     end if
   
     !_______writing 2D and 3D fields____________________________________________
@@ -1762,9 +1763,9 @@ subroutine write_mean(entry, entry_index)
             ! variables into specific layer position lev
             if (entry%p_partit%mype==entry%root_rank) then
                 if (entry%ndim==1) then
-                    call assert_nf( nf_put_vara_double(entry%ncid, entry%varID, (/1, entry%rec_count/), (/size2, 1/), entry%aux_r8, 1), __LINE__)
+                    call assert_nf( nf90_put_var(entry%ncid, entry%varID, entry%aux_r8, start=(/1, entry%rec_count/), count=(/size2, 1/)), __LINE__)
                 elseif (entry%ndim==2) then
-                    call assert_nf( nf_put_vara_double(entry%ncid, entry%varID, (/1, lev, entry%rec_count/), (/size2, 1, 1/), entry%aux_r8, 1), __LINE__)
+                    call assert_nf( nf90_put_var(entry%ncid, entry%varID, entry%aux_r8, start=(/1, lev, entry%rec_count/), count=(/size2, 1, 1/)), __LINE__)
                 end if
             end if
         end do ! --> do lev=1, size1
@@ -1807,13 +1808,13 @@ subroutine write_mean(entry, entry_index)
             ! variables into specific layer position lev
             if (entry%p_partit%mype==entry%root_rank) then
                 if (entry%ndim==1) then
-                    call assert_nf( nf_put_vara_real(entry%ncid, entry%varID, (/1, entry%rec_count/), (/size2, 1/), entry%aux_r4, 1), __LINE__)
+                    call assert_nf( nf90_put_var(entry%ncid, entry%varID, entry%aux_r4, start=(/1, entry%rec_count/), count=(/size2, 1/)), __LINE__)
                     !PS t1=MPI_Wtime()  
-                    !PS if (entry%p_partit%flag_debug)  print *, achar(27)//'[31m'//' -I/O-> after nf_put_vara_real'//achar(27)//'[0m', entry%p_partit%mype, t1-t0
+                    !PS if (entry%p_partit%flag_debug)  print *, achar(27)//'[31m'//' -I/O-> after nf90_put_var'//achar(27)//'[0m', entry%p_partit%mype, t1-t0
                 elseif (entry%ndim==2) then
-                    call assert_nf( nf_put_vara_real(entry%ncid, entry%varID, (/1, lev, entry%rec_count/), (/size2, 1, 1/), entry%aux_r4, 1), __LINE__)
+                    call assert_nf( nf90_put_var(entry%ncid, entry%varID, entry%aux_r4, start=(/1, lev, entry%rec_count/), count=(/size2, 1, 1/)), __LINE__)
                     !PS t1=MPI_Wtime()  
-                    !PS if (entry%p_partit%flag_debug)  print *, achar(27)//'[31m'//' -I/O-> after nf_put_vara_real'//achar(27)//'[0m', entry%p_partit%mype, lev, t1-t0
+                    !PS if (entry%p_partit%flag_debug)  print *, achar(27)//'[31m'//' -I/O-> after nf90_put_var'//achar(27)//'[0m', entry%p_partit%mype, lev, t1-t0
                 end if
             end if
         end do ! --> do lev=1, size1
@@ -1996,16 +1997,16 @@ ctime=timeold+(dayold-1.)*86400
                 !_______________________________________________________________
                 ! create new output file ?!
                 if(filepath /= trim(entry%filename)) then
-                    if("" /= trim(entry%filename)) call assert_nf(nf_close(entry%ncid), __LINE__)   
+                    if("" /= trim(entry%filename)) call assert_nf(nf90_close(entry%ncid), __LINE__)   
                     entry%filename = filepath
                     !___________________________________________________________
                     ! use any existing file with this name or create a new one
-                    if( nf_open(entry%filename, nf_write, entry%ncid) /= nf_noerr ) then
+                    if( nf90_open(entry%filename, nf90_write, entry%ncid) /= nf90_noerr ) then
                         !PS if (partit%flag_debug)  print *, achar(27)//'[33m'//' -I/O-> call create_new_file'//achar(27)//'[0m'  
                         call create_new_file(entry, ice, dynamics, partit, mesh)
                         
                         !PS if (partit%flag_debug)  print *, achar(27)//'[33m'//' -I/O-> call assert_nf A'//achar(27)//'[0m'//',  k=',k, ', rootpart=', entry%root_rank    
-                        call assert_nf( nf_open(entry%filename, nf_write, entry%ncid), __LINE__)
+                        call assert_nf( nf90_open(entry%filename, nf90_write, entry%ncid), __LINE__)
                     end if
                     
                     !___________________________________________________________
@@ -2022,7 +2023,7 @@ ctime=timeold+(dayold-1.)*86400
                 do k=entry%rec_count, 1, -1
                     !PS if (partit%flag_debug)  print *, achar(27)//'[33m'//' -I/O-> call assert_nf B'//achar(27)//'[0m'//',  k=',k, ', rootpart=', entry%root_rank  
                     ! determine rtime from exiting file
-                    call assert_nf( nf_get_vara_double(entry%ncid, entry%tID, k, 1, rtime, 1), __LINE__)
+                    call assert_nf( nf90_get_var(entry%ncid, entry%tID, rtime), __LINE__)
                     if (ctime > rtime) then
                         entry%rec_count=k+1
                         exit ! a proper rec_count detected, exit the loop
@@ -2123,7 +2124,7 @@ subroutine do_output_callback(entry_index)
     ! available to other processes for reading immediately after it is written. 
     if(entry%p_partit%mype == entry%root_rank) then 
         !PS if (entry%p_partit%flag_debug)  print *, achar(27)//'[31m'//' -I/O-> call nf_sync'//achar(27)//'[0m', entry%p_partit%mype
-        call assert_nf( nf_sync(entry%ncid), __LINE__ ) ! flush the file to disk after each write
+        call assert_nf( nf90_sync(entry%ncid), __LINE__ ) ! flush the file to disk after each write
     end if   
     
 end subroutine
@@ -2430,9 +2431,8 @@ subroutine assert_nf(status, line)
     integer, intent(in) :: status
     integer, intent(in) :: line
     ! EO args
-    include "netcdf.inc" ! old netcdf fortran interface required?
-    if(status /= NF_NOERR) then
-        print *, "error in line ",line, __FILE__, ' ', trim(nf_strerror(status))
+    if(status /= nf90_noerr) then
+        print *, "error in line ",line, __FILE__, ' ', trim(nf90_strerror(status))
         stop 1
     end if   
 end subroutine

--- a/src/io_mesh_info.F90
+++ b/src/io_mesh_info.F90
@@ -6,8 +6,8 @@ use g_config
 use g_comm_auto
 use o_PARAM
 
+use netcdf
 implicit none
-#include "netcdf.inc"
 private
 public :: write_mesh_info
 INTERFACE my_put_vara
@@ -63,7 +63,7 @@ implicit none
   call MPI_AllREDUCE(maxval(nod_in_elem2D_num), N_max, 1, MPI_INTEGER, MPI_MAX, MPI_COMM_FESOM, MPIerr)
 
   filename=trim(ResultPath)//trim(runid)//'.mesh.diag.nc'
-  call my_create(filename, IOR(NF_CLOBBER,IOR(NF_NETCDF4,NF_CLASSIC_MODEL)), ncid, partit)
+  call my_create(filename, IOR(NF90_CLOBBER,IOR(NF90_NETCDF4,NF90_CLASSIC_MODEL)), ncid, partit)
 
   ! NOTE(PG): For naming conventions of node, edge, face, please see here:
   ! https://tinyurl.com/43z4m6cd
@@ -85,7 +85,7 @@ implicit none
   ! 1D
   call my_def_var(ncid,                                &  ! NetCDF Variable File Handle ID
     'nz',                                              &  ! Short Name
-    NF_DOUBLE,                                         &  ! Variable Type
+    NF90_DOUBLE,                                         &  ! Variable Type
     1,                                                 &  ! Variable Dimensionality
     (/nl_id /),                                        &  ! Dimension IDs
     zbar_id,                                           &  ! ID
@@ -99,12 +99,12 @@ implicit none
   !
   ! Note that the sign (negative in normal FESOM code) is inverted during the saving process.
   if (partit%mype==0) then
-    status = nf_put_att_text(ncid, zbar_id, 'positive', len_trim("down"), trim("down"));
+    status = nf90_put_att(ncid, zbar_id, 'positive', "down");
   end if
 
   call my_def_var(ncid,                                &  ! NetCDF Variable File Handle ID
     'nz1',                                             &  ! Short Name
-    NF_DOUBLE,                                         &  ! Variable Type
+    NF90_DOUBLE,                                         &  ! Variable Type
     1,                                                 &  ! Variable Dimensionality
     (/nl1_id/),                                        &  ! Dimension IDs
     z_id,                                              &  ! ID
@@ -116,12 +116,12 @@ implicit none
   !
   ! Note that the sign (negative in normal FESOM code) is inverted during the saving process.
   if (partit%mype==0) then
-    status = nf_put_att_text(ncid, z_id, 'positive', len_trim("down"), trim("down"));
+    status = nf90_put_att(ncid, z_id, 'positive', "down");
   end if
 
   call my_def_var(ncid,                                       &  ! NetCDF Variable File Handle ID
     'elem_area',                                              &  ! Short Name
-    NF_DOUBLE,                                                &  ! Variable Type
+    NF90_DOUBLE,                                                &  ! Variable Type
     1,                                                        &  ! Variable Dimensionality
     (/elem_n_id/),                                            &  ! Dimension IDs
     elem_area_id,                                             &  ! ID
@@ -131,7 +131,7 @@ implicit none
 
   call my_def_var(ncid,                                       &  ! NetCDF Variable File Handle ID
     'nlevels_nod2D',                                          &  ! Short Name
-    NF_INT,                                                   &  ! Variable Type
+    NF90_INT,                                                   &  ! Variable Type
     1,                                                        &  ! Variable Dimensionality
     (/nod_n_id/),                                             &  ! Dimension IDs
     nlevels_nod2D_id,                                         &  ! ID
@@ -141,7 +141,7 @@ implicit none
 
   call my_def_var(ncid,                                       &  ! NetCDF Variable File Handle ID
     'nlevels',                                                &  ! Short Name
-    NF_INT,                                                   &  ! Variable Type
+    NF90_INT,                                                   &  ! Variable Type
     1,                                                        &  ! Variable Dimensionality
     (/elem_n_id/),                                            &  ! Dimension IDs
     nlevels_id,                                               &  ! ID
@@ -151,7 +151,7 @@ implicit none
 
   call my_def_var(ncid,                                       &  ! NetCDF Variable File Handle ID
     'nod_in_elem2D_num',                                      &  ! Short Name
-    NF_INT,                                                   &  ! Variable Type
+    NF90_INT,                                                   &  ! Variable Type
     1,                                                        &  ! Variable Dimensionality
     (/nod_n_id/),                                             &  ! Dimension IDs
     nod_in_elem2D_num_id,                                     &  ! ID
@@ -161,7 +161,7 @@ implicit none
 
   call my_def_var(ncid,                                       &  ! NetCDF Variable File Handle ID
     'nod_part',                                               &  ! Short Name
-    NF_INT,                                                   &  ! Variable Type
+    NF90_INT,                                                   &  ! Variable Type
     1,                                                        &  ! Variable Dimensionality
     (/nod_n_id/),                                             &  ! Dimension IDs
     nod_part_id,                                              &  ! ID
@@ -171,7 +171,7 @@ implicit none
 
   call my_def_var(ncid,                                       &  ! NetCDF Variable File Handle ID
     'elem_part',                                              &  ! Short Name
-    NF_INT,                                                   &  ! Variable Type
+    NF90_INT,                                                   &  ! Variable Type
     1,                                                        &  ! Variable Dimensionality
     (/elem_n_id/),                                            &  ! Dimension IDs
     elem_part_id,                                             &  ! ID
@@ -181,7 +181,7 @@ implicit none
 
   call my_def_var(ncid,                                       &  ! NetCDF Variable File Handle ID
     'zbar_e_bottom',                                          &  ! Short Name
-    NF_DOUBLE,                                                &  ! Variable Type
+    NF90_DOUBLE,                                                &  ! Variable Type
     1,                                                        &  ! Variable Dimensionality
     (/elem_n_id/),                                            &  ! Dimension IDs
     zbar_e_bot_id,                                            &  ! ID
@@ -191,7 +191,7 @@ implicit none
 
   call my_def_var(ncid,                                       &  ! NetCDF Variable File Handle ID
     'zbar_n_bottom',                                          &  ! Short Name
-    NF_DOUBLE,                                                &  ! Variable Type
+    NF90_DOUBLE,                                                &  ! Variable Type
     1,                                                        &  ! Variable Dimensionality
     (/nod_n_id/),                                             &  ! Dimension IDs
     zbar_n_bot_id,                                            &  ! ID
@@ -201,7 +201,7 @@ implicit none
 
   call my_def_var(ncid,                                       &  ! NetCDF Variable File Handle ID
     'lon',                                                    &  ! Short Name
-    NF_DOUBLE,                                                &  ! Variable Type
+    NF90_DOUBLE,                                                &  ! Variable Type
     1,                                                        &  ! Variable Dimensionality
     (/nod_n_id/),                                             &  ! Dimension IDs
     lon_id,                                                   &  ! ID
@@ -214,7 +214,7 @@ implicit none
 
   call my_def_var(ncid,                                       &  ! NetCDF Variable File Handle ID
     'lat',                                                    &  ! Short Name
-    NF_DOUBLE,                                                &  ! Variable Type
+    NF90_DOUBLE,                                                &  ! Variable Type
     1,                                                        &  ! Variable Dimensionality
     (/nod_n_id/),                                             &  ! Dimension IDs
     lat_id,                                                   &  ! ID
@@ -225,16 +225,16 @@ implicit none
     "degrees_north"                                           &
   )
   if (use_cavity) then
-    call my_def_var(ncid, 'ulevels_nod2D',     NF_INT,    1, (/nod_n_id/),  ulevels_nod2D_id,     'number of levels above nodes',           partit)
-    call my_def_var(ncid, 'ulevels',           NF_INT,    1, (/elem_n_id/), ulevels_id,           'number of levels above elements',        partit)
-    call my_def_var(ncid, 'zbar_e_surface',    NF_DOUBLE, 1, (/elem_n_id/), zbar_e_srf_id,        'element surface depth',                  partit)
-    call my_def_var(ncid, 'zbar_n_surface',    NF_DOUBLE, 1, (/nod_n_id/) , zbar_n_srf_id,        'nodal surface depth',                    partit)
+    call my_def_var(ncid, 'ulevels_nod2D',     NF90_INT,    1, (/nod_n_id/),  ulevels_nod2D_id,     'number of levels above nodes',           partit)
+    call my_def_var(ncid, 'ulevels',           NF90_INT,    1, (/elem_n_id/), ulevels_id,           'number of levels above elements',        partit)
+    call my_def_var(ncid, 'zbar_e_surface',    NF90_DOUBLE, 1, (/elem_n_id/), zbar_e_srf_id,        'element surface depth',                  partit)
+    call my_def_var(ncid, 'zbar_n_surface',    NF90_DOUBLE, 1, (/nod_n_id/) , zbar_n_srf_id,        'nodal surface depth',                    partit)
   endif
 
   ! 2D
   call my_def_var(ncid,                                       &  ! NetCDF Variable File Handle ID
     'nod_area',                                               &  ! Short Name
-    NF_DOUBLE,                                                &  ! Variable Type
+    NF90_DOUBLE,                                                &  ! Variable Type
     2,                                                        &  ! Variable Dimensionality
     (/nod_n_id, nl_id/),                                      &  ! Dimension IDs
     nod_area_id,                                              &  ! ID
@@ -244,7 +244,7 @@ implicit none
 
   call my_def_var(ncid,                                       &  ! NetCDF Variable File Handle ID
     'face_nodes',                                             &  ! Short Name
-    NF_INT,                                                   &  ! Variable Type
+    NF90_INT,                                                   &  ! Variable Type
     2,                                                        &  ! Variable Dimensionality
     (/elem_n_id, id_3/),                                      &  ! Dimension IDs
     face_node_id,                                             &  ! ID
@@ -257,12 +257,12 @@ implicit none
     start_index = 1                                           &  ! Start index
   )
   if (partit%mype==0) then
-    status = nf_put_att_text(ncid, face_node_id, 'location', len_trim("face"), trim("face"));
+    status = nf90_put_att(ncid, face_node_id, 'location', "face");
   end if
 
   call my_def_var(ncid,                                       &  ! NetCDF Variable File Handle ID
   "edge_nodes",                                               &  ! Short Name
-  NF_INT,                                                     &  ! Variable Type
+  NF90_INT,                                                     &  ! Variable Type
   2,                                                          &  ! Variable Dimensionality
   (/edge_n_id, id_2/),                                        &  ! Dimension IDs
   edge_nodes_id,                                              &  ! ID
@@ -277,7 +277,7 @@ implicit none
 
   call my_def_var(ncid,                                       &  ! NetCDF Variable File Handle ID
   'face_edges',                                               &  ! Short Name
-  NF_INT,                                                     &  ! Variable Type
+  NF90_INT,                                                     &  ! Variable Type
   2,                                                          &  ! Variable Dimensionality
   (/elem_n_id, id_3/),                                        &  ! Dimension IDs
   face_edges_id,                                              &  ! ID
@@ -291,7 +291,7 @@ implicit none
 
 call my_def_var(ncid,                                         &  ! NetCDF Variable File Handle ID
   "face_links",                                               &  ! Short Name
-  NF_INT,                                                     &  ! Variable Type
+  NF90_INT,                                                     &  ! Variable Type
   2,                                                          &  ! Variable Dimensionality
   (/elem_n_id, id_3/),                                        &  ! Dimension IDs
   face_links_id,                                              &  ! ID
@@ -307,7 +307,7 @@ call my_def_var(ncid,                                         &  ! NetCDF Variab
 
 call my_def_var(ncid,                                         &  ! NetCDF Variable File Handle ID
   "edge_face_links",                                          &  ! Short Name
-  NF_INT,                                                     &  ! Variable Type
+  NF90_INT,                                                     &  ! Variable Type
   2,                                                          &  ! Variable Dimensionality
   (/edge_n_id,  id_2/),                                       &  ! Dimension IDs
   edge_face_links_id,                                         &  ! ID
@@ -321,13 +321,13 @@ call my_def_var(ncid,                                         &  ! NetCDF Variab
   1                                                           &  ! Start index
   )
 
-  call my_def_var(ncid, 'nod_in_elem2D',     NF_INT,    2, (/nod_n_id, id_N/),  nod_in_elem2D_id,   'elements containing the node', partit)
-  call my_def_var(ncid, 'edge_cross_dxdy',   NF_DOUBLE, 2, (/edge_n_id, id_4/), edge_cross_dxdy_id, 'edge cross distancess',        partit)
-  call my_def_var(ncid, 'gradient_sca_x',    NF_DOUBLE, 2, (/elem_n_id, id_3/), gradient_sca_x_id,  'x component of a gradient at nodes of an element', partit)
-  call my_def_var(ncid, 'gradient_sca_y',    NF_DOUBLE, 2, (/elem_n_id, id_3/), gradient_sca_y_id,  'y component of a gradient at nodes of an element', partit)
-  call my_def_var(ncid, 'gradient_vec_x',    NF_DOUBLE, 2, (/elem_n_id, id_3/), gradient_vec_x_id,  'x component of a gradient at elements of an element', partit)
-  call my_def_var(ncid, 'gradient_vec_y',    NF_DOUBLE, 2, (/elem_n_id, id_3/), gradient_vec_y_id,  'y component of a gradient at elements of an element', partit)
-  call my_nf_enddef(ncid, partit)
+  call my_def_var(ncid, 'nod_in_elem2D',     NF90_INT,    2, (/nod_n_id, id_N/),  nod_in_elem2D_id,   'elements containing the node', partit)
+  call my_def_var(ncid, 'edge_cross_dxdy',   NF90_DOUBLE, 2, (/edge_n_id, id_4/), edge_cross_dxdy_id, 'edge cross distancess',        partit)
+  call my_def_var(ncid, 'gradient_sca_x',    NF90_DOUBLE, 2, (/elem_n_id, id_3/), gradient_sca_x_id,  'x component of a gradient at nodes of an element', partit)
+  call my_def_var(ncid, 'gradient_sca_y',    NF90_DOUBLE, 2, (/elem_n_id, id_3/), gradient_sca_y_id,  'y component of a gradient at nodes of an element', partit)
+  call my_def_var(ncid, 'gradient_vec_x',    NF90_DOUBLE, 2, (/elem_n_id, id_3/), gradient_vec_x_id,  'x component of a gradient at elements of an element', partit)
+  call my_def_var(ncid, 'gradient_vec_y',    NF90_DOUBLE, 2, (/elem_n_id, id_3/), gradient_vec_y_id,  'y component of a gradient at elements of an element', partit)
+  call my_nf90_enddef(ncid, partit)
 
   ! NOTE(PG): Same order as definition!
   ! NOTE(PG): We invert the sign of ``zbar`` here to conform with CF-Conventions
@@ -609,11 +609,11 @@ integer,        intent(inout) :: id
 integer                       :: ierror, status
 
 if (partit%mype==0) then
-   status =  nf_def_dim(ncid, trim(short_name), value, id)
+   status =  nf90_def_dim(ncid, trim(short_name), value, id)
 end if
 
 call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-if (status .ne. nf_noerr) call handle_err(status, partit)
+if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 end subroutine my_def_dim
 !
@@ -633,10 +633,10 @@ integer                       :: ierror, status
 
 ! NOTE(PG): Adds global Conventions attribute
 if (partit%mype==0) then
-   status = nf_put_att_text(ncid, NF_GLOBAL, 'Conventions', len_trim('UGRID-1.0'), 'UGRID-1.0')
+   status = nf90_put_att(ncid, NF90_GLOBAL, 'Conventions', 'UGRID-1.0')
 end if
 call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-if (status .ne. nf_noerr) call handle_err(status, partit)
+if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 
 
@@ -644,80 +644,80 @@ if (status .ne. nf_noerr) call handle_err(status, partit)
 
 call my_def_dim(ncid, "info", 1, info_id, partit)
 if (partit%mype==0) then
-   status = nf_def_var(ncid, 'fesom_mesh', NF_INT, 0, info_id, fesom_mesh_id)
+   status = nf90_def_var(ncid, 'fesom_mesh', NF90_INT, varid=fesom_mesh_id)
 end if
 call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-if (status .ne. nf_noerr) call handle_err(status, partit)
+if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 if (partit%mype==0) then
-  status = nf_put_att_text(ncid, fesom_mesh_id, 'cf_role', len_trim('mesh_topology'), trim('mesh_topology'));
+  status = nf90_put_att(ncid, fesom_mesh_id, 'cf_role', "mesh_topology");
 end if
 call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-if (status .ne. nf_noerr) call handle_err(status, partit)
+if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 if (partit%mype==0) then
-  status = nf_put_att_text(ncid, fesom_mesh_id, 'long_name', len_trim('Topology data of 2D unstructured mesh'), trim('Topology data of 2D unstructured mesh'));
+  status = nf90_put_att(ncid, fesom_mesh_id, 'long_name', "Topology data of 2D unstructured mesh");
 end if
 call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-if (status .ne. nf_noerr) call handle_err(status, partit)
+if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 if (partit%mype==0) then
-  status = nf_put_att_int(ncid, fesom_mesh_id, 'topology_dimension', NF_INT, 1, 2);
+  status = nf90_put_att(ncid, fesom_mesh_id, 'topology_dimension', 2);
 end if
 call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-if (status .ne. nf_noerr) call handle_err(status, partit)
+if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 if (partit%mype==0) then
-  status = nf_put_att_text(ncid, fesom_mesh_id, 'node_coordinates', len_trim('lon lat'), trim('lon lat'));
+  status = nf90_put_att(ncid, fesom_mesh_id, 'node_coordinates', "lon lat");
 end if
 call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-if (status .ne. nf_noerr) call handle_err(status, partit)
+if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 if (partit%mype==0) then
-  status = nf_put_att_text(ncid, fesom_mesh_id, 'face_node_connectivity', len_trim('face_nodes'), trim('face_nodes'));
+  status = nf90_put_att(ncid, fesom_mesh_id, 'face_node_connectivity', "face_nodes");
 end if
 call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-if (status .ne. nf_noerr) call handle_err(status, partit)
+if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 if (partit%mype==0) then
-  status = nf_put_att_text(ncid, fesom_mesh_id, 'face_dimension', len_trim('elem') , trim('elem'));
+  status = nf90_put_att(ncid, fesom_mesh_id, 'face_dimension', 'elem');
 end if
 call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-if (status .ne. nf_noerr) call handle_err(status, partit)
+if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 if (partit%mype==0) then
-  status = nf_put_att_text(ncid, fesom_mesh_id, 'edge_node_connectivity', len_trim('edge_nodes'), trim('edge_nodes'));
+  status = nf90_put_att(ncid, fesom_mesh_id, 'edge_node_connectivity', 'edge_nodes');
 end if
 call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-if (status .ne. nf_noerr) call handle_err(status, partit)
+if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 if (partit%mype==0) then
-  status = nf_put_att_text(ncid, fesom_mesh_id, 'edge_dimension', len_trim('edg_n'), trim('edg_n'));
+  status = nf90_put_att(ncid, fesom_mesh_id, 'edge_dimension', 'edg_n');
 end if
 call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-if (status .ne. nf_noerr) call handle_err(status, partit)
+if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 !FIXME(PG): edge coordinates missing
 !Mesh2:edge_coordinates = "Mesh2_edge_x Mesh2_edge_y" ; // optional attribute (requires edge_node_connectivity)
 !FIXME(PG): face coordinates missing
 !Mesh2:face_coordinates = "Mesh2_face_x Mesh2_face_y" ; // optional attribute
 if (partit%mype==0) then
-  status = nf_put_att_text(ncid, fesom_mesh_id, 'face_edge_connectivity', len_trim('face_edges'), trim('face_edges'));
+  status = nf90_put_att(ncid, fesom_mesh_id, 'face_edge_connectivity', 'face_edges');
 end if
 call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-if (status .ne. nf_noerr) call handle_err(status, partit)
+if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 if (partit%mype==0) then
-  status = nf_put_att_text(ncid, fesom_mesh_id, 'face_face_connectivity', len_trim('face_links'), trim('face_links'));
+  status = nf90_put_att(ncid, fesom_mesh_id, 'face_face_connectivity', 'face_links');
 end if
 call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-if (status .ne. nf_noerr) call handle_err(status, partit)
+if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 if (partit%mype==0) then
-  status = nf_put_att_text(ncid, fesom_mesh_id, 'edge_face_connectivity', len_trim('edge_face_links'), trim('edge_face_links'));
+  status = nf90_put_att(ncid, fesom_mesh_id, 'edge_face_connectivity', 'edge_face_links');
 end if
 call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-if (status .ne. nf_noerr) call handle_err(status, partit)
+if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 end subroutine add_fesom_ugrid_info
 !============================================================================
@@ -741,54 +741,54 @@ integer,      intent(in), optional :: start_index
 
 
 if (partit%mype==0) then
-   status = nf_def_var(ncid, trim(short_name), vtype, dsize, dids, id)
+   status = nf90_def_var(ncid, trim(short_name), vtype, dimids=dids, varid=id)
 end if
 
 if (partit%mype==0) then
-   status = nf_put_att_text(ncid, id, 'long_name', len_trim(att_text), trim(att_text));
+   status = nf90_put_att(ncid, id, 'long_name', trim(att_text))
 end if
 
 if (partit%mype==0) then
   if (present(standard_name)) then
-      status = nf_put_att_text(ncid, id, 'standard_name', len_trim(standard_name), trim(standard_name))
+      status = nf90_put_att(ncid, id, 'standard_name', trim(standard_name))
     endif
 endif
 
 if (partit%mype==0) then
   if (present(units)) then
-     status = nf_put_att_text(ncid, id, 'units', len_trim(units), trim(units));
+     status = nf90_put_att(ncid, id, 'units', trim(units));
   endif
 endif
 
 if (partit%mype==0) then
   if (present(cf_role)) then
-     status = nf_put_att_text(ncid, id, 'cf_role', len_trim(cf_role), trim(cf_role));
+     status = nf90_put_att(ncid, id, 'cf_role', trim(cf_role));
   endif
 endif
 
 if (partit%mype==0) then
   if (present(comment)) then
-      status = nf_put_att_text(ncid, id, 'comment', len_trim(comment), trim(comment));
+      status = nf90_put_att(ncid, id, 'comment', trim(comment));
   endif
 endif
 
 
 if (partit%mype==0) then
   if (present(missing_value)) then
-      status = nf_put_att_int(ncid, id, '_FillValue', NF_INT, 1, missing_value);
+      status = nf90_put_att(ncid, id, '_FillValue', missing_value);
   endif
 endif
 
 if (partit%mype==0) then
   if (present(start_index)) then
-    status = nf_put_att_int(ncid, id, 'start_index', NF_INT, 1, start_index);
+    status = nf90_put_att(ncid, id, 'start_index', start_index);
   endif
 end if
 call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-if (status .ne. nf_noerr) call handle_err(status, partit)
+if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-if (status .ne. nf_noerr) call handle_err(status, partit)
+if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 
 
@@ -798,19 +798,19 @@ end subroutine my_def_var
 !
 !============================================================================
 !
-subroutine my_nf_enddef(ncid, partit)
+subroutine my_nf90_enddef(ncid, partit)
 IMPLICIT NONE
 type(t_partit), intent(inout) :: partit
 integer, intent(in)           :: ncid
 integer                       :: ierror, status
 
 if (partit%mype==0) then
-   status = nf_enddef(ncid)
+   status = nf90_enddef(ncid)
 end if
 
 call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-if (status .ne. nf_noerr) call handle_err(status, partit)
-end subroutine my_nf_enddef
+if (status .ne. nf90_noerr) call handle_err(status, partit)
+end subroutine my_nf90_enddef
 !
 !============================================================================
 !
@@ -821,9 +821,9 @@ integer, intent(in)           :: ncid, varid, start, N
 real(kind=WP)                 :: var(:)
 integer                       :: ierror, status
 
-  if (partit%mype==0) status=nf_put_vara_double(ncid, varid, start, N, var)
+  if (partit%mype==0) status=nf90_put_var(ncid, varid, var, start=(/start/), count=(/N/))
   call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 end subroutine my_put_vara_double_1D
 !
@@ -836,9 +836,9 @@ integer, intent(in)           :: ncid, varid, start(:), N(:)
 real(kind=WP)                 :: var(:)
 integer                       :: ierror, status
 
-  if (partit%mype==0) status=nf_put_vara_double(ncid, varid, start, N, var)
+  if (partit%mype==0) status=nf90_put_var(ncid, varid, var, start=start, count=N)
   call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 end subroutine my_put_vara_double_2D
 !
@@ -851,9 +851,9 @@ integer,        intent(in)    :: ncid, varid, start, N
 integer                       :: var(:)
 integer                       :: ierror, status
 
-  if (partit%mype==0) status=nf_put_vara_int(ncid, varid, start, N, var)
+  if (partit%mype==0) status=nf90_put_var(ncid, varid, var, start=(/start/), count=(/N/))
   call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 end subroutine my_put_vara_int_1D
 !
@@ -867,9 +867,9 @@ integer,        intent(in)    :: ncid, varid, start(:), N(:)
 integer                       :: var(:)
 integer                       :: ierror, status
 
-  if (partit%mype==0) status=nf_put_vara_int(ncid, varid, start, N, var)
+  if (partit%mype==0) status=nf90_put_var(ncid, varid, var, start=start, count=N)
   call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 
 end subroutine my_put_vara_int_2D
 !
@@ -878,16 +878,17 @@ end subroutine my_put_vara_int_2D
 subroutine my_create(filename, opt, ncid, partit)
 IMPLICIT NONE
 type(t_partit), intent(inout):: partit
-integer,        intent(in)   :: opt, ncid
+integer,        intent(in)   :: opt
+integer,        intent(out)  :: ncid
 character(*),   intent(in)   :: filename
 integer                      :: ierror, status
   if (partit%mype==0) then  ! create a file
      ! create a file
-     status = nf_create(filename, opt, ncid)
-     if (status.ne.nf_noerr) call handle_err(status, partit)
+     status = nf90_create(filename, opt, ncid)
+     if (status.ne.nf90_noerr) call handle_err(status, partit)
   end if
   call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-  if (status .ne. nf_noerr) call handle_err(status, partit)
+  if (status .ne. nf90_noerr) call handle_err(status, partit)
 end subroutine my_create
 !
 !============================================================================
@@ -898,9 +899,9 @@ type(t_partit), intent(inout) :: partit
 integer,        intent(in)    :: ncid
 integer                       :: ierror, status
 
-if (partit%mype==0) status = nf_close(ncid)
+if (partit%mype==0) status = nf90_close(ncid)
 
 call MPI_BCast(status, 1, MPI_INTEGER, 0, partit%MPI_COMM_FESOM, ierror)
-if (status .ne. nf_noerr) call handle_err(status, partit)
+if (status .ne. nf90_noerr) call handle_err(status, partit)
 end subroutine my_close
 end module io_mesh_info


### PR DESCRIPTION
use fortran interfaces (and specifically fortran90 interfaces).  use of these interfaces means netcdf does data conversions and calls to writing data and attributes are simpler. For instance, use of netcdf interfaces how data variables is defined eliminating need for our own interfaces for writing like for real4 and real8. Additionally we need this for netcdf parallel io and for mixed/single prec mode otherwise we need to keep writing needless new interfaces. 

**viola! and all the compiler warnings for netcdf are gone!**   

Todo later: we have too many custom netcdf interfaces defined at many places need to consolidate them at one place, restart writing needs also a overhaul to use netcdf90 interfaces.  