### PR TITLE
make bundle.yml use fesom main as #743 is merged

### DIFF
--- a/bundle.yml
+++ b/bundle.yml
@@ -14,7 +14,7 @@ projects :
 
     - fesom :
         git     : https://github.com/FESOM/fesom2.git
-        version : add_ecbundle_support
+        version : main
         cmake   : >
             ENABLE_IFS_INTERFACE=OFF
             DISABLE_MULTITHREADING=ON


### PR DESCRIPTION
it had to be done this way as bundle could not be tested otherwise in #743. and ec_bundle_support branch is deleted.