### PR TITLE
 fix bug in writing fesom.mesh.diag.nc

### DIFF
--- a/src/io_mesh_info.F90
+++ b/src/io_mesh_info.F90
@@ -530,7 +530,8 @@ call my_def_var(ncid,                                         &  ! NetCDF Variab
   allocate(rbuffer(elem2D))
   do i=1, 3
      call gather_elem(gradient_sca(i, 1:myDim_elem2D), rbuffer, partit)
-     call my_put_vara(ncid, gradient_sca_x_id, (/1, 4-i/), (/elem2D, 1/), rbuffer, partit) ! (4-i), NETCDF will permute otherwise
+     !!PS call my_put_vara(ncid, gradient_sca_x_id, (/1, 4-i/), (/elem2D, 1/), rbuffer, partit) ! (4-i), NETCDF will permute otherwise
+     call my_put_vara(ncid, gradient_sca_x_id, (/1, i/), (/elem2D, 1/), rbuffer, partit) 
   end do
   deallocate(rbuffer)
 
@@ -539,7 +540,8 @@ call my_def_var(ncid,                                         &  ! NetCDF Variab
   allocate(rbuffer(elem2D))
   do i=1, 3
      call gather_elem(gradient_sca(i+3, 1:myDim_elem2D), rbuffer, partit)
-     call my_put_vara(ncid, gradient_sca_y_id, (/1, 4-i/), (/elem2D, 1/), rbuffer, partit)! (4-i), NETCDF will permute otherwise
+     !!PS call my_put_vara(ncid, gradient_sca_y_id, (/1, 4-i/), (/elem2D, 1/), rbuffer, partit)! (4-i), NETCDF will permute otherwise
+     call my_put_vara(ncid, gradient_sca_y_id, (/1, i/), (/elem2D, 1/), rbuffer, partit)
   end do
   deallocate(rbuffer)
 
@@ -548,7 +550,8 @@ call my_def_var(ncid,                                         &  ! NetCDF Variab
   allocate(rbuffer(elem2D))
   do i=1, 3
      call gather_elem(gradient_vec(i, 1:myDim_elem2D), rbuffer, partit)
-     call my_put_vara(ncid, gradient_vec_x_id, (/1, 4-i/), (/elem2D, 1/), rbuffer, partit) ! (4-i), NETCDF will permute otherwise
+     !!PS call my_put_vara(ncid, gradient_vec_x_id, (/1, 4-i/), (/elem2D, 1/), rbuffer, partit) ! (4-i), NETCDF will permute otherwise
+     call my_put_vara(ncid, gradient_vec_x_id, (/1, i/), (/elem2D, 1/), rbuffer, partit) ! (4-i), NETCDF will permute otherwise
   end do
   deallocate(rbuffer)
 
@@ -557,7 +560,8 @@ call my_def_var(ncid,                                         &  ! NetCDF Variab
   allocate(rbuffer(elem2D))
   do i=1, 3
      call gather_elem(gradient_vec(i+3, 1:myDim_elem2D), rbuffer, partit)
-     call my_put_vara(ncid, gradient_vec_y_id, (/1, 4-i/), (/elem2D, 1/), rbuffer, partit)! (4-i), NETCDF will permute otherwise
+     !!PS call my_put_vara(ncid, gradient_vec_y_id, (/1, 4-i/), (/elem2D, 1/), rbuffer, partit)! (4-i), NETCDF will permute otherwise
+     call my_put_vara(ncid, gradient_vec_y_id, (/1, i/), (/elem2D, 1/), rbuffer, partit)! (4-i), NETCDF will permute otherwise
   end do
   deallocate(rbuffer)
 


### PR DESCRIPTION
- Raika tried to compute the density gradient in the channel sigma_xy in python like its done in fesom by using gradient_sca_x and gradient_sca_y from the fesom.mesh.diag.nc file and stepped into some issues. 

<img width="2284" height="836" alt="grafik" src="https://github.com/user-attachments/assets/e98594da-06a8-4c71-adb9-ef5d470a1be5" />

- We found out that, like the code was written until now it exchanged the indices between gradient_sca_x[1,:] and gradient_sca_x[3,:] as well as gradient_sca_y[1,:] and gradient_sca_y[3,:] when it was written to the fesom.mesh.diag.nc file. The same is also valid for the arrays of gradient_vec_x and gradient_vec_y. 

https://github.com/FESOM/fesom2/blob/354fe9bfcd2337a11d146f34159992e783482d1b/src/io_mesh_info.F90#L531-L534

- its unclear to me why it was written in that way with  (/1, 4-i/) which clearly writes the 3. index into 1st position and the 1. index into 3rd position, only index 2. is correctly located. However there is the comment " ! (4-i), NETCDF will permute otherwise", im not sure if there is here a hidden netcdf version issue or if its just plain wrong! Now with this bug fixed through ... 

```
 do i=1, 3 
    call gather_elem(gradient_sca(i, 1:myDim_elem2D), rbuffer, partit) 
    call my_put_vara(ncid, gradient_sca_x_id, (/1, i/), (/elem2D, 1/), rbuffer, partit) ! (4-i), NETCDF will permute otherwise 
 end do 
...
 ```
... the outcome regarding sigma_xy looks now correct!
 
<img width="2284" height="836" alt="grafik" src="https://github.com/user-attachments/assets/19514686-5217-4475-9184-aeaf16552bac" />



