### PR TITLE
 bugfix makes sure that the time vector is properly filled up again 

### DIFF
--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -1718,7 +1718,7 @@ subroutine write_mean(entry, entry_index)
     ! write new time index ctime_copy to file --> expand time array in nc file
     if (entry%p_partit%mype==entry%root_rank) then
         write(*,*) 'writing mean record for ', trim(entry%name), '; rec. count = ', entry%rec_count
-        call assert_nf( nf90_put_var(entry%ncid, entry%Tid, entry%ctime_copy), __LINE__)
+        call assert_nf( nf90_put_var(entry%ncid, entry%Tid, entry%ctime_copy, start = (/entry%rec_count/) ), __LINE__)
     end if
   
     !_______writing 2D and 3D fields____________________________________________


### PR DESCRIPTION
- bugfix makes sure that the time vector is properly filled up in the io_meandata files
```
ncdump -v time sst.fesom.1958.nc
netcdf sst.fesom.1958 {
dimensions:
        nod2 = 126858 ;
        time = UNLIMITED ; // (30 currently)
variables:
        double time(time) ;
                time:long_name = "time" ;
                time:standard_name = "time" ;
                time:units = "seconds since 1958-01-01 0:0:0" ;
                time:axis = "T" ;
                time:stored_direction = "increasing" ;
        float sst(time, nod2) ;
                sst:description = "sea surface temperature" ;
                sst:long_name = "sea surface temperature" ;
                sst:units = "C" ;
                sst:location = "node" ;
                sst:mesh = "fesom_mesh" ;
... 
```

- with bug:
```
time = 2589300, _, _, _, _, _, _, _, 
    _, _, _, _, _, _, _, _, 
    _, _, _, _, _, _, _, _, 
    _, _, _, _, _, _ ;
}
```

- without bug: 
```
 time = 83700, 170100, 256500, 342900, 429300, 515700, 602100, 688500, 
    774900, 861300, 947700, 1034100, 1120500, 1206900, 1293300, 1379700, 
    1466100, 1552500, 1638900, 1725300, 1811700, 1898100, 1984500, 2070900, 
    2157300, 2243700, 2330100, 2416500, 2502900, 2589300 ;
}
```