### PR TITLE
Update oce_setup_step.F90

### DIFF
--- a/src/oce_setup_step.F90
+++ b/src/oce_setup_step.F90
@@ -1018,7 +1018,7 @@ SUBROUTINE oce_initial_state(tracers, partit, mesh)
     use recom_ciso
 #endif
     ! for additional (transient) tracers:
-    use mod_transit, only: id_r14c, id_r39ar, id_f12, id_sf6
+    use mod_transit, only: id_r14c, id_r39ar, id_if11, id_f12, id_sf6
     implicit none
     type(t_tracer), intent(inout), target :: tracers
     type(t_partit), intent(inout), target :: partit


### PR DESCRIPTION
Bugfix for missing CFC-11 tracer ID which affects all tagged versions >= 2.6