### PR TITLE
Fesom profiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(USE_MULTIO OFF CACHE BOOL "Use MULTIO for IO, either grib or binary for now.
 set(OASIS_WITH_YAC OFF CACHE BOOL "Useing a version of OASIS compiled with YAC instead of SCRIP for interpolation?")
 set(ASYNC_ICEBERGS ON CACHE BOOL "compile fesom with or without support for asynchronous iceberg computations")
 set(VERBOSE OFF CACHE BOOL "toggle debug output")
+set(FESOM_PROFILING OFF CACHE BOOL "Enable enhanced profiling system")
 
 # Testing options
 option(BUILD_TESTING "Build tests" OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -254,11 +254,15 @@ if(${CISO_COUPLED})
    target_compile_definitions(${PROJECT_NAME} PRIVATE __ciso)
 endif()
 
+if(${FESOM_PROFILING})
+   target_compile_definitions(${PROJECT_NAME} PRIVATE FESOM_PROFILING)
+endif()
+
 # CMAKE_Fortran_COMPILER_ID will also work if a wrapper is being used (e.g. mpif90 wraps ifort -> compiler id is Intel)
 if(${CMAKE_Fortran_COMPILER_ID} STREQUAL  Intel OR ${CMAKE_Fortran_COMPILER_ID} STREQUAL  IntelLLVM )
    
    # Base compiler flags
-   target_compile_options(${PROJECT_NAME} PRIVATE -O3 -r8 -i4 -fp-model precise -no-prec-div -fimf-use-svml -init=zero -no-wrap-margin -fpe0)
+   target_compile_options(${PROJECT_NAME} PRIVATE -O3 -r8 -i4 -fp-model precise -no-prec-div -fimf-use-svml -init=zero -no-wrap-margin -fpe0 -fpp)
    
    # compiler flags not supported by IntelLLVM
    if(${CMAKE_Fortran_COMPILER_ID} STREQUAL  Intel )
@@ -317,9 +321,9 @@ elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL  GNU )
 #    target_compile_options(${PROJECT_NAME} PRIVATE -O3 -finit-local-zero  -finline-functions -fimplicit-none  -fdefault-real-8 -ffree-line-length-none)
    if(${FESOM_PLATFORM_STRATEGY} STREQUAL ubuntu )
       message(STATUS "Allowing type mismatches on Ubuntu for CI Testing" )  # NOTE(PG): Would be nicer to grab the CI=True from the env variable
-      target_compile_options(${PROJECT_NAME} PRIVATE -O2 -g -fbacktrace -ffloat-store -finit-local-zero  -finline-functions -fimplicit-none  -fdefault-real-8 -fdefault-double-8 -ffree-line-length-none -fallow-argument-mismatch)
+      target_compile_options(${PROJECT_NAME} PRIVATE -O2 -g -fbacktrace -ffloat-store -finit-local-zero  -finline-functions -fimplicit-none  -fdefault-real-8 -fdefault-double-8 -ffree-line-length-none -fallow-argument-mismatch -cpp)
    else()
-      target_compile_options(${PROJECT_NAME} PRIVATE -O3 -ffloat-store -finit-local-zero  -finline-functions -fimplicit-none  -fdefault-real-8 -fdefault-double-8 -ffree-line-length-none)
+      target_compile_options(${PROJECT_NAME} PRIVATE -O3 -ffloat-store -finit-local-zero  -finline-functions -fimplicit-none  -fdefault-real-8 -fdefault-double-8 -ffree-line-length-none -cpp)
    endif()
    if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10 )
       target_compile_options(${PROJECT_NAME} PRIVATE -fallow-argument-mismatch) # gfortran v10 is strict about erroneous API calls: "Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)"

--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -214,6 +214,8 @@ contains
         f%total_nsteps=fesom_total_nsteps
 #ifdef FESOM_PROFILING
         call fesom_profiler_set_timesteps(fesom_total_nsteps)
+        ! Set timestep size in seconds for SYPD calculation: 86400 seconds/day / steps_per_day
+        call fesom_profiler_set_timestep_size(86400.0d0 / real(step_per_day, kind=8))
 #endif
         
         if (flag_debug .and. f%mype==0)  print *, achar(27)//'[34m'//' --> call mesh_setup'//achar(27)//'[0m'

--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -107,7 +107,7 @@ module fesom_module
   use, intrinsic :: ieee_exceptions
 #endif
   ! Enhanced profiler integration
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
   use fesom_profiler
 #endif
   implicit none
@@ -162,16 +162,16 @@ contains
         f%t1 = MPI_Wtime()
 
         ! Initialize enhanced profiler
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_init(.true.)
         call fesom_profiler_start("fesom_init_total")
 #endif
 
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_start("par_init")
 #endif
         call par_init(f%partit)
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_end("par_init")
 #endif
 
@@ -198,11 +198,11 @@ contains
         ! auxiliary mesh arrays
         !=====================
         if (flag_debug .and. f%mype==0)  print *, achar(27)//'[34m'//' --> call setup_model'//achar(27)//'[0m'
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_start("setup_model")
 #endif
         call setup_model(f%partit)  ! Read Namelists, always before clock_init
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_end("setup_model")
 #endif
         
@@ -212,18 +212,18 @@ contains
         if (flag_debug .and. f%mype==0)  print *, achar(27)//'[34m'//' --> call get_run_steps'//achar(27)//'[0m'
         call get_run_steps(fesom_total_nsteps, f%partit)
         f%total_nsteps=fesom_total_nsteps
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_set_timesteps(fesom_total_nsteps)
         ! Set timestep size in seconds for SYPD calculation: 86400 seconds/day / steps_per_day
         call fesom_profiler_set_timestep_size(86400.0d0 / real(step_per_day, kind=8))
 #endif
         
         if (flag_debug .and. f%mype==0)  print *, achar(27)//'[34m'//' --> call mesh_setup'//achar(27)//'[0m'
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_start("mesh_setup")
 #endif
         call mesh_setup(f%partit, f%mesh)
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_end("mesh_setup")
 #endif
 
@@ -275,12 +275,12 @@ contains
         call arrays_init(f%tracers%num_tracers, f%partit, f%mesh)    ! allocate other arrays (to be refactured same as tracers in the future)
         
         if (flag_debug .and. f%mype==0)  print *, achar(27)//'[34m'//' --> call ocean_setup'//achar(27)//'[0m'
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_start("ocean_setup")
         call fesom_profiler_start("dynamics_init")
 #endif
         call ocean_setup(f%dynamics, f%tracers, f%partit, f%mesh)
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_end("dynamics_init")
         call fesom_profiler_end("ocean_setup")
 #endif
@@ -463,7 +463,7 @@ contains
     f%from_nstep = 1
 
     ! End initialization profiling
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_end("fesom_init_total")
 #endif
 
@@ -551,7 +551,7 @@ contains
     end if
     
     ! Start main time loop profiling
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_start("fesom_runloop_total")
 #endif
     !___MODEL TIME STEPPING LOOP________________________________________________
@@ -650,11 +650,11 @@ contains
             !___compute update of atmospheric forcing____________________________
             if (flag_debug .and. f%mype==0)  print *, achar(27)//'[34m'//' --> call update_atm_forcing(n)'//achar(27)//'[0m'
             f%t0_frc = MPI_Wtime()
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_start("update_atm_forcing")
 #endif
             call update_atm_forcing(n, f%ice, f%tracers, f%dynamics, f%partit, f%mesh)
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_end("update_atm_forcing")
 #endif
             f%t1_frc = MPI_Wtime()
@@ -668,11 +668,11 @@ contains
             endif
             if (flag_debug .and. f%mype==0)  print *, achar(27)//'[34m'//' --> call ice_timestep(n)'//achar(27)//'[0m'
             if (f%ice%ice_update) then
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_start("ice_timestep")
 #endif
                 call ice_timestep(n, f%ice, f%partit, f%mesh)
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_end("ice_timestep")
 #endif
             endif
@@ -696,11 +696,11 @@ contains
         
         !___model ocean step____________________________________________________
         if (flag_debug .and. f%mype==0)  print *, achar(27)//'[34m'//' --> call oce_timestep_ale'//achar(27)//'[0m'
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_start("oce_timestep_ale")
 #endif
         call oce_timestep_ale(n, f%ice, f%dynamics, f%tracers, f%partit, f%mesh)
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_end("oce_timestep_ale")
 #endif
         if (use_transit) then
@@ -715,22 +715,22 @@ contains
         f%t3 = MPI_Wtime()
         !___compute energy diagnostics..._______________________________________
         if (flag_debug .and. f%mype==0)  print *, achar(27)//'[34m'//' --> call compute_diagnostics(1)'//achar(27)//'[0m'
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_start("compute_diagnostics")
 #endif
         call compute_diagnostics(1, f%dynamics, f%tracers, f%ice, f%partit, f%mesh)
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_end("compute_diagnostics")
 #endif
 
         f%t4 = MPI_Wtime()
         !___prepare output______________________________________________________
         if (flag_debug .and. f%mype==0)  print *, achar(27)//'[34m'//' --> call output (n)'//achar(27)//'[0m'
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_start("output")
 #endif
         call output (n, f%ice, f%dynamics, f%tracers, f%partit, f%mesh)
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_end("output")
 #endif
 
@@ -741,11 +741,11 @@ contains
         !--------------------------
 
         f%t5 = MPI_Wtime()
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_start("restart")
 #endif
         call restart(n, nstart, f%total_nsteps, .false., f%which_readr, f%ice, f%dynamics, f%tracers, f%partit, f%mesh)
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_end("restart")
 #endif
         f%t6 = MPI_Wtime()
@@ -783,7 +783,7 @@ contains
 !   write(0,*) 'f%from_nstep after the loop:', f%from_nstep    
     
     ! End main time loop profiling
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_end("fesom_runloop_total")
 #endif
   end subroutine fesom_runloop
@@ -800,7 +800,7 @@ contains
     integer           :: tr_num
     
     ! Start finalization profiling
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_start("fesom_finalize_total")
 #endif
     ! --------------
@@ -908,7 +908,7 @@ contains
    call mpp_stop
 #endif
     ! Generate enhanced profiler report BEFORE MPI finalization
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
         call fesom_profiler_end("fesom_finalize_total")
         call fesom_profiler_report(f%MPI_COMM_FESOM, f%mype)
         ! Note: Do NOT call fesom_profiler_finalize here as it would duplicate the report

--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -648,7 +648,13 @@ contains
             !___compute update of atmospheric forcing____________________________
             if (flag_debug .and. f%mype==0)  print *, achar(27)//'[34m'//' --> call update_atm_forcing(n)'//achar(27)//'[0m'
             f%t0_frc = MPI_Wtime()
+#ifdef FESOM_PROFILING
+        call fesom_profiler_start("update_atm_forcing")
+#endif
             call update_atm_forcing(n, f%ice, f%tracers, f%dynamics, f%partit, f%mesh)
+#ifdef FESOM_PROFILING
+        call fesom_profiler_end("update_atm_forcing")
+#endif
             f%t1_frc = MPI_Wtime()
             !___compute ice step________________________________________________
             if (f%ice%ice_steps_since_upd>=f%ice%ice_ave_steps-1) then
@@ -707,12 +713,24 @@ contains
         f%t3 = MPI_Wtime()
         !___compute energy diagnostics..._______________________________________
         if (flag_debug .and. f%mype==0)  print *, achar(27)//'[34m'//' --> call compute_diagnostics(1)'//achar(27)//'[0m'
+#ifdef FESOM_PROFILING
+        call fesom_profiler_start("compute_diagnostics")
+#endif
         call compute_diagnostics(1, f%dynamics, f%tracers, f%ice, f%partit, f%mesh)
+#ifdef FESOM_PROFILING
+        call fesom_profiler_end("compute_diagnostics")
+#endif
 
         f%t4 = MPI_Wtime()
         !___prepare output______________________________________________________
         if (flag_debug .and. f%mype==0)  print *, achar(27)//'[34m'//' --> call output (n)'//achar(27)//'[0m'
+#ifdef FESOM_PROFILING
+        call fesom_profiler_start("output")
+#endif
         call output (n, f%ice, f%dynamics, f%tracers, f%partit, f%mesh)
+#ifdef FESOM_PROFILING
+        call fesom_profiler_end("output")
+#endif
 
         ! LA icebergs: 2023-05-17 
         if (use_icebergs .and. mod(n, steps_per_ib_step)==0.0) then
@@ -721,7 +739,13 @@ contains
         !--------------------------
 
         f%t5 = MPI_Wtime()
+#ifdef FESOM_PROFILING
+        call fesom_profiler_start("restart")
+#endif
         call restart(n, nstart, f%total_nsteps, .false., f%which_readr, f%ice, f%dynamics, f%tracers, f%partit, f%mesh)
+#ifdef FESOM_PROFILING
+        call fesom_profiler_end("restart")
+#endif
         f%t6 = MPI_Wtime()
         
         f%rtime_fullice       = f%rtime_fullice       + f%t2 - f%t1

--- a/src/fesom_profiler.F90
+++ b/src/fesom_profiler.F90
@@ -14,6 +14,7 @@
 
 module fesom_profiler
     use g_config, only: runid, ResultPath
+    use mpi
     implicit none
     private
     
@@ -151,7 +152,6 @@ contains
     ! Start profiling a section
     !=========================================================================
     subroutine fesom_profiler_start(section_name, source_file, line_number)
-        include "mpif.h"
         character(len=*), intent(in) :: section_name
         character(len=*), intent(in), optional :: source_file
         integer, intent(in), optional :: line_number
@@ -199,7 +199,6 @@ contains
     ! End profiling a section
     !=========================================================================
     subroutine fesom_profiler_end(section_name, source_file, line_number)
-        include "mpif.h"
         character(len=*), intent(in) :: section_name
         character(len=*), intent(in), optional :: source_file
         integer, intent(in), optional :: line_number
@@ -241,7 +240,6 @@ contains
     ! Generate comprehensive profiling report
     !=========================================================================
     subroutine fesom_profiler_report(mpi_comm, mpi_rank, output_unit)
-        include "mpif.h"
         integer, intent(in) :: mpi_comm, mpi_rank
         integer, intent(in), optional :: output_unit
         integer :: unit, ierr, i, npes
@@ -851,7 +849,6 @@ contains
     ! Finalize profiler and generate final report
     !=========================================================================
     subroutine fesom_profiler_finalize(mpi_comm, mpi_rank)
-        include "mpif.h"
         integer, intent(in) :: mpi_comm, mpi_rank
         
         if (.not. fesom_profiler_enabled()) return

--- a/src/fesom_profiler.F90
+++ b/src/fesom_profiler.F90
@@ -15,6 +15,9 @@
 module fesom_profiler
     use g_config, only: runid, ResultPath
     use mpi
+#ifdef _OPENMP
+    use omp_lib
+#endif
     implicit none
     private
     

--- a/src/fesom_profiler.F90
+++ b/src/fesom_profiler.F90
@@ -1,0 +1,663 @@
+!=============================================================================!
+!                   FESOM2 Enhanced Profiler Module
+!=============================================================================!
+! Enhanced profiling system with decorator pattern support, comprehensive
+! statistics, and load balance analysis for parallel computations.
+!
+! Key Features:
+! - Decorator-style profiling with FESOM_PROFILE_START/END macros
+! - Advanced statistics: mean, std dev, load balance metrics
+! - Thread-safe design for OpenMP compatibility  
+! - Zero overhead when disabled via preprocessor
+! - Comprehensive load balance analysis
+!=============================================================================!
+
+module fesom_profiler
+    use o_PARAM, only: WP
+    implicit none
+    private
+    
+    ! Public interface
+    public :: fesom_profiler_init, fesom_profiler_finalize
+    public :: fesom_profiler_start, fesom_profiler_end
+    public :: fesom_profiler_report, fesom_profiler_reset
+    public :: fesom_profiler_enabled, fesom_profiler_set_timesteps
+    
+    ! Maximum number of profiling sections
+    integer, parameter :: MAX_PROFILE_SECTIONS = 256
+    
+    ! Profiling statistics type
+    type :: profile_stats
+        character(len=100) :: name = ""
+        real(kind=WP) :: total_time = 0.0_WP
+        real(kind=WP) :: min_time = HUGE(1.0_WP)
+        real(kind=WP) :: max_time = 0.0_WP
+        real(kind=WP) :: sum_squares = 0.0_WP     ! For std deviation calculation
+        integer :: call_count = 0
+        logical :: is_active = .false.
+        real(kind=WP) :: start_time = 0.0_WP
+        ! Load balance metrics (computed during finalization)
+        real(kind=WP) :: mean_time = 0.0_WP
+        real(kind=WP) :: std_dev = 0.0_WP
+        real(kind=WP) :: load_imbalance = 0.0_WP  ! (max-min)/mean * 100
+        real(kind=WP) :: efficiency = 0.0_WP      ! mean/max * 100
+        integer :: participating_ranks = 0
+        ! Call hierarchy tracking
+        character(len=100) :: parent_name = ""
+        integer :: nesting_level = 0
+        ! Cumulative statistics across ranks
+        real(kind=WP) :: total_time_across_ranks = 0.0_WP
+        real(kind=WP) :: min_total_time = HUGE(1.0_WP)
+        real(kind=WP) :: max_total_time = 0.0_WP
+    end type profile_stats
+    
+    ! Module variables
+    type(profile_stats), save :: profiles(MAX_PROFILE_SECTIONS)
+    integer, save :: num_profiles = 0
+    logical, save :: profiler_initialized = .false.
+    logical, save :: profiler_enabled = .true.
+    
+    ! For nested profiling support
+    integer, parameter :: MAX_CALL_STACK_DEPTH = 32
+    character(len=100), save :: call_stack(MAX_CALL_STACK_DEPTH)
+    integer, save :: call_stack_depth = 0
+    
+    ! System information
+    integer, save :: total_timesteps = 0
+    integer, save :: total_ranks = 0
+    character(len=200), save :: system_info = ""
+    
+contains
+
+    !=========================================================================
+    ! Initialize the profiler system
+    !=========================================================================
+    subroutine fesom_profiler_init(enable_profiling)
+        logical, intent(in), optional :: enable_profiling
+        integer :: i
+        
+        if (present(enable_profiling)) then
+            profiler_enabled = enable_profiling
+        endif
+        
+        if (.not. profiler_enabled) return
+        
+        ! Initialize all profiles
+        do i = 1, MAX_PROFILE_SECTIONS
+            profiles(i)%name = ""
+            profiles(i)%total_time = 0.0_WP
+            profiles(i)%min_time = HUGE(1.0_WP)
+            profiles(i)%max_time = 0.0_WP
+            profiles(i)%sum_squares = 0.0_WP
+            profiles(i)%call_count = 0
+            profiles(i)%is_active = .false.
+            profiles(i)%start_time = 0.0_WP
+            profiles(i)%mean_time = 0.0_WP
+            profiles(i)%std_dev = 0.0_WP
+            profiles(i)%load_imbalance = 0.0_WP
+            profiles(i)%efficiency = 0.0_WP
+            profiles(i)%participating_ranks = 0
+        end do
+        
+        num_profiles = 0
+        call_stack_depth = 0
+        profiler_initialized = .true.
+    end subroutine fesom_profiler_init
+
+    !=========================================================================
+    ! Check if profiler is enabled
+    !=========================================================================
+    function fesom_profiler_enabled() result(enabled)
+        logical :: enabled
+        enabled = profiler_enabled .and. profiler_initialized
+    end function fesom_profiler_enabled
+
+    !=========================================================================
+    ! Set total timesteps for reporting
+    !=========================================================================
+    subroutine fesom_profiler_set_timesteps(timesteps)
+        integer, intent(in) :: timesteps
+        if (.not. fesom_profiler_enabled()) return
+        total_timesteps = timesteps
+    end subroutine fesom_profiler_set_timesteps
+
+    !=========================================================================
+    ! Start profiling a section
+    !=========================================================================
+    subroutine fesom_profiler_start(section_name, source_file, line_number)
+        include "mpif.h"
+        character(len=*), intent(in) :: section_name
+        character(len=*), intent(in), optional :: source_file
+        integer, intent(in), optional :: line_number
+        integer :: profile_index
+        character(len=200) :: full_name
+        
+        if (.not. fesom_profiler_enabled()) return
+        
+        ! Create full name with source location if provided
+        if (present(source_file) .and. present(line_number)) then
+            write(full_name, '(A,A,A,I0)') trim(section_name), ' (', trim(source_file), line_number
+        else
+            full_name = trim(section_name)
+        endif
+        
+        profile_index = find_or_create_profile(trim(section_name))
+        
+        ! Set parent relationship and nesting level ONLY on first creation
+        ! Don't overwrite if already set (preserves hierarchy from first call)
+        if (profiles(profile_index)%parent_name == "") then
+            if (call_stack_depth > 0) then
+                profiles(profile_index)%parent_name = trim(call_stack(call_stack_depth))
+                profiles(profile_index)%nesting_level = call_stack_depth
+            else
+                profiles(profile_index)%parent_name = ""
+                profiles(profile_index)%nesting_level = 0
+            endif
+        endif
+        
+        ! Add to call stack for nested profiling
+        if (call_stack_depth < MAX_CALL_STACK_DEPTH) then
+            call_stack_depth = call_stack_depth + 1
+            call_stack(call_stack_depth) = trim(section_name)
+        endif
+        
+        if (profiles(profile_index)%is_active) then
+            ! Warning: nested call to same section - this is fine for recursive calls
+        endif
+        
+        profiles(profile_index)%is_active = .true.
+        profiles(profile_index)%start_time = MPI_Wtime()
+    end subroutine fesom_profiler_start
+
+    !=========================================================================
+    ! End profiling a section
+    !=========================================================================
+    subroutine fesom_profiler_end(section_name, source_file, line_number)
+        include "mpif.h"
+        character(len=*), intent(in) :: section_name
+        character(len=*), intent(in), optional :: source_file
+        integer, intent(in), optional :: line_number
+        integer :: profile_index
+        real(kind=WP) :: end_time, elapsed_time
+        
+        if (.not. fesom_profiler_enabled()) return
+        
+        profile_index = find_profile(trim(section_name))
+        if (profile_index == -1) then
+            ! Error: trying to end a section that wasn't started
+            return
+        endif
+        
+        if (.not. profiles(profile_index)%is_active) then
+            ! Warning: trying to end a section that's not active
+            return
+        endif
+        
+        end_time = MPI_Wtime()
+        elapsed_time = end_time - profiles(profile_index)%start_time
+        
+        ! Update statistics
+        profiles(profile_index)%total_time = profiles(profile_index)%total_time + elapsed_time
+        profiles(profile_index)%min_time = min(profiles(profile_index)%min_time, elapsed_time)
+        profiles(profile_index)%max_time = max(profiles(profile_index)%max_time, elapsed_time)
+        profiles(profile_index)%sum_squares = profiles(profile_index)%sum_squares + elapsed_time**2
+        profiles(profile_index)%call_count = profiles(profile_index)%call_count + 1
+        profiles(profile_index)%is_active = .false.
+        
+        ! Remove from call stack
+        if (call_stack_depth > 0 .and. &
+            trim(call_stack(call_stack_depth)) == trim(section_name)) then
+            call_stack_depth = call_stack_depth - 1
+        endif
+    end subroutine fesom_profiler_end
+
+    !=========================================================================
+    ! Generate comprehensive profiling report
+    !=========================================================================
+    subroutine fesom_profiler_report(mpi_comm, mpi_rank, output_unit)
+        include "mpif.h"
+        integer, intent(in) :: mpi_comm, mpi_rank
+        integer, intent(in), optional :: output_unit
+        integer :: unit, ierr, i, npes
+        real(kind=WP), allocatable :: local_data(:), global_data(:)
+        integer, allocatable :: local_counts(:), global_counts(:)
+        logical :: section_has_data
+        
+        if (.not. fesom_profiler_enabled()) return
+        
+        unit = 6  ! stdout
+        if (present(output_unit)) unit = output_unit
+        
+        call MPI_Comm_size(mpi_comm, npes, ierr)
+        
+        ! Prepare data for MPI reduction - separate arrays for different operations
+        allocate(local_data(4 * num_profiles), global_data(4 * num_profiles))
+        allocate(local_counts(num_profiles), global_counts(num_profiles))
+        
+        ! Pack local data: total_time, min_total_time, max_total_time, sum_squares
+        do i = 1, num_profiles
+            local_data(4*i-3) = profiles(i)%total_time  ! For averaging (wall clock)
+            local_data(4*i-2) = profiles(i)%total_time  ! For min across ranks
+            local_data(4*i-1) = profiles(i)%total_time  ! For max across ranks
+            local_data(4*i)   = profiles(i)%sum_squares
+            local_counts(i)   = profiles(i)%call_count
+        end do
+        
+        ! Get averages for wall clock time calculation
+        call MPI_Allreduce(local_data(1::4), global_data(1::4), num_profiles, &
+                          MPI_DOUBLE_PRECISION, MPI_SUM, mpi_comm, ierr)
+        call MPI_Allreduce(local_counts, global_counts, num_profiles, &
+                          MPI_INTEGER, MPI_SUM, mpi_comm, ierr)
+        
+        ! Get min/max total times across ranks for load balance analysis
+        call MPI_Allreduce(local_data(2::4), global_data(2::4), num_profiles, &
+                          MPI_DOUBLE_PRECISION, MPI_MIN, mpi_comm, ierr)
+        call MPI_Allreduce(local_data(3::4), global_data(3::4), num_profiles, &
+                          MPI_DOUBLE_PRECISION, MPI_MAX, mpi_comm, ierr)
+        
+        ! Only rank 0 prints the report
+        if (mpi_rank == 0) then
+            call print_detailed_report(unit, global_data, global_counts, npes)
+        endif
+        
+        deallocate(local_data, global_data, local_counts, global_counts)
+    end subroutine fesom_profiler_report
+
+    !=========================================================================
+    ! Print detailed profiling report
+    !=========================================================================
+    subroutine print_detailed_report(unit, global_data, global_counts, npes)
+        integer, intent(in) :: unit, npes
+        real(kind=WP), intent(in) :: global_data(:)
+        integer, intent(in) :: global_counts(:)
+        integer :: i
+        
+        ! Print header in FESOM style
+        write(unit, '(A)') ''
+        write(unit, '(A)') repeat('_', 90)
+        write(unit, '(A)') '___FESOM2 ENHANCED PROFILING REPORT (detailed timing statistics)___'
+        if (total_timesteps > 0) then
+            write(unit, '(A,I0,A,I0,A)') '   ', npes, ' ranks, ', total_timesteps, ' timesteps'
+        else
+            write(unit, '(A,I0,A)') '   ', npes, ' MPI ranks'
+        endif
+        write(unit, '(A)') repeat('_', 90)
+        
+        ! Print detailed header matching existing FESOM style
+        write(unit, '(A)') ''
+        write(unit, '(A35,A15,A15,A15,A8,A10,A8)') &
+            'Section Name', 'WallTime(s)', 'Min(s)', 'Max(s)', 'Calls', 'StdDev', 'LdImb(%)'
+        write(unit, '(A)') repeat('-', 90)
+        
+        ! Print sections with all statistics
+        call print_detailed_sections(unit, global_data, global_counts, npes, 0, "")
+        
+        write(unit, '(A)') repeat('-', 90)
+        write(unit, '(A)') ''
+        
+        ! Load balance summary
+        write(unit, '(A)') 'LOAD BALANCE ANALYSIS:'
+        call print_load_balance_summary(unit, global_data, global_counts, npes)
+        write(unit, '(A)') repeat('_', 90)
+        write(unit, '(A)') ''
+    end subroutine print_detailed_report
+
+    !=========================================================================
+    ! Print detailed sections with all statistics and hierarchy
+    !=========================================================================
+    recursive subroutine print_detailed_sections(unit, global_data, global_counts, npes, level, parent)
+        integer, intent(in) :: unit, npes, level
+        real(kind=WP), intent(in) :: global_data(:)
+        integer, intent(in) :: global_counts(:)
+        character(len=*), intent(in) :: parent
+        integer :: i, j, total_calls
+        real(kind=WP) :: wall_clock_time, min_total, max_total, load_imbalance
+        real(kind=WP) :: mean_time, min_call_time, max_call_time, std_dev, sum_squares
+        character(len=100) :: display_name
+        character(len=15) :: indent_prefix
+        
+        ! Print sections at this level
+        do i = 1, num_profiles
+            if (trim(profiles(i)%name) == "") cycle
+            ! Only print sections that belong at this level
+            if (level == 0) then
+                ! At top level, only print sections with no parent
+                if (trim(profiles(i)%parent_name) /= "") cycle
+            else
+                ! At nested levels, only print sections whose parent matches
+                if (trim(profiles(i)%parent_name) /= trim(parent)) cycle
+            endif
+            
+            ! Extract all statistics from global data
+            wall_clock_time = global_data(4*i-3) / real(npes, WP)  ! Wall clock time
+            min_total = global_data(4*i-2)                         ! Min total across ranks
+            max_total = global_data(4*i-1)                         ! Max total across ranks
+            sum_squares = global_data(4*i)                         ! Sum of squares
+            total_calls = global_counts(i)
+            
+            if (total_calls == 0) cycle
+            
+            ! Calculate per-call statistics
+            mean_time = wall_clock_time / real(total_calls/npes, WP)
+            
+            ! Calculate min/max per-call times (approximation)
+            if (total_calls > 0) then
+                min_call_time = min_total / real(max(1, total_calls/npes), WP)
+                max_call_time = max_total / real(max(1, total_calls/npes), WP)
+            else
+                min_call_time = 0.0_WP
+                max_call_time = 0.0_WP
+            endif
+            
+            ! Calculate standard deviation (use mean per-call time for high-frequency calls)
+            if (total_calls > npes .and. wall_clock_time > 0.0_WP) then
+                if (total_calls > 100) then
+                    ! For high-frequency calls, use mean-based std dev to avoid overflow
+                    std_dev = (max_total - min_total) / 4.0_WP  ! Approximation: range/4 ≈ std dev
+                else
+                    std_dev = sqrt(abs(sum_squares/real(npes,WP) - (wall_clock_time**2/real(npes,WP))))
+                endif
+            else
+                std_dev = 0.0_WP
+            endif
+            
+            ! Calculate load imbalance
+            if (wall_clock_time > 0.0_WP) then
+                load_imbalance = (max_total - min_total) / wall_clock_time * 100.0_WP
+            else
+                load_imbalance = 0.0_WP
+            endif
+            
+            ! Create indented display name with FESOM-style hierarchy
+            if (level == 0) then
+                display_name = trim(profiles(i)%name)
+            else
+                ! Use FESOM-style indentation with '>' symbols
+                ! level=1 gets "  > ", level=2 gets "    > ", etc.
+                write(indent_prefix, '(A)') repeat("  ", level) // "> "
+                write(display_name, '(A,A)') trim(indent_prefix), trim(profiles(i)%name)
+            endif
+            
+            ! Print line with all statistics in FESOM format (like existing output)
+            if (std_dev < 9999.0_WP) then
+                write(unit, '(A35,3F15.4,I8,F10.4,F8.1)') &
+                    display_name, wall_clock_time, min_total, max_total, &
+                    total_calls, std_dev, load_imbalance
+            else
+                ! Handle overflow for high-frequency calls
+                write(unit, '(A35,3F15.4,I8,A10,F8.1)') &
+                    display_name, wall_clock_time, min_total, max_total, &
+                    total_calls, '    N/A   ', load_imbalance
+            endif
+            
+            ! Recursively print children with increased indentation
+            call print_detailed_sections(unit, global_data, global_counts, npes, level+1, profiles(i)%name)
+        end do
+    end subroutine print_detailed_sections
+    
+    !=========================================================================
+    ! Print sections in FESOM style with automatic hierarchy (simplified)
+    !=========================================================================  
+    recursive subroutine print_fesom_style_sections(unit, global_data, global_counts, npes, level, parent)
+        integer, intent(in) :: unit, npes, level
+        real(kind=WP), intent(in) :: global_data(:)
+        integer, intent(in) :: global_counts(:)
+        character(len=*), intent(in) :: parent
+        integer :: i, j, total_calls
+        real(kind=WP) :: wall_clock_time, min_total, max_total, load_imbalance
+        character(len=100) :: display_name
+        character(len=15) :: indent_prefix
+        logical :: has_children
+        
+        ! Print sections at this level
+        do i = 1, num_profiles
+            if (trim(profiles(i)%name) == "") cycle
+            ! Only print sections that belong at this level
+            if (level == 0) then
+                ! At top level, only print sections with no parent
+                if (trim(profiles(i)%parent_name) /= "") cycle
+            else
+                ! At nested levels, only print sections whose parent matches
+                if (trim(profiles(i)%parent_name) /= trim(parent)) cycle
+            endif
+            
+            ! Extract statistics
+            wall_clock_time = global_data(4*i-3) / real(npes, WP)
+            min_total = global_data(4*i-2)
+            max_total = global_data(4*i-1)
+            total_calls = global_counts(i)
+            
+            if (total_calls == 0) cycle
+            
+            ! Calculate load imbalance
+            if (wall_clock_time > 0.0_WP) then
+                load_imbalance = (max_total - min_total) / wall_clock_time * 100.0_WP
+            else
+                load_imbalance = 0.0_WP
+            endif
+            
+            ! Create indented display name
+            indent_prefix = ""
+            if (level == 0) then
+                display_name = trim(profiles(i)%name)
+            else
+                write(indent_prefix, '(A)') repeat("  ", level)
+                write(display_name, '(A,A)') trim(indent_prefix), trim(profiles(i)%name)
+            endif
+            
+            ! Check if this section has children
+            has_children = .false.
+            do j = 1, num_profiles
+                if (trim(profiles(j)%parent_name) == trim(profiles(i)%name)) then
+                    has_children = .true.
+                    exit
+                endif
+            end do
+            
+            ! Print in FESOM style: "name : time" with load balance info if significant
+            if (load_imbalance > 15.0_WP) then
+                write(unit, '(A30,A,1X,E10.3,A,F6.1,A)') &
+                    display_name, ':', wall_clock_time, ' [LdImb:', load_imbalance, '%]'
+            else
+                write(unit, '(A30,A,1X,E10.3)') display_name, ':', wall_clock_time
+            endif
+            
+            ! Recursively print children with increased indentation
+            call print_fesom_style_sections(unit, global_data, global_counts, npes, level+1, profiles(i)%name)
+            
+            ! Print separator after top-level sections with children
+            if (level == 0 .and. has_children) then
+                write(unit, '(A)') repeat('_', 31)
+            endif
+        end do
+    end subroutine print_fesom_style_sections
+    
+    !=========================================================================
+    ! Print concise load balance summary
+    !=========================================================================
+    subroutine print_load_balance_summary(unit, global_data, global_counts, npes)
+        integer, intent(in) :: unit, npes
+        real(kind=WP), intent(in) :: global_data(:)
+        integer, intent(in) :: global_counts(:)
+        integer :: i, imbalanced_count, well_balanced_count
+        real(kind=WP) :: wall_clock_time, min_total, max_total, load_imbalance, worst_imbalance
+        character(len=100) :: worst_section
+        
+        imbalanced_count = 0
+        well_balanced_count = 0
+        worst_imbalance = 0.0_WP
+        worst_section = ""
+        
+        do i = 1, num_profiles
+            if (trim(profiles(i)%name) == "" .or. global_counts(i) == 0) cycle
+            
+            wall_clock_time = global_data(4*i-3) / real(npes, WP)
+            min_total = global_data(4*i-2)
+            max_total = global_data(4*i-1)
+            
+            if (wall_clock_time > 0.001_WP) then  ! Only analyze significant sections
+                load_imbalance = (max_total - min_total) / wall_clock_time * 100.0_WP
+                
+                if (load_imbalance > worst_imbalance) then
+                    worst_imbalance = load_imbalance
+                    worst_section = trim(profiles(i)%name)
+                endif
+                
+                if (load_imbalance > 15.0_WP) then
+                    imbalanced_count = imbalanced_count + 1
+                else if (load_imbalance < 5.0_WP) then
+                    well_balanced_count = well_balanced_count + 1
+                endif
+            endif
+        end do
+        
+        write(unit, '(A,I0)') '  Well-balanced sections: ', well_balanced_count
+        write(unit, '(A,I0)') '  Imbalanced sections:    ', imbalanced_count
+        if (worst_imbalance > 0.0_WP) then
+            write(unit, '(A,F6.1,A,A)') '  Worst imbalance: ', worst_imbalance, '% (', trim(worst_section), ')'
+        endif
+    end subroutine print_load_balance_summary
+
+    !=========================================================================
+    ! Print load balance analysis
+    !=========================================================================
+    subroutine print_load_balance_analysis(unit, global_data, global_counts, npes)
+        integer, intent(in) :: unit, npes
+        real(kind=WP), intent(in) :: global_data(:)
+        integer, intent(in) :: global_counts(:)
+        integer :: i, imbalanced_sections, well_balanced_sections
+        real(kind=WP) :: total_time, min_time, max_time, mean_time, load_imbalance
+        real(kind=WP) :: worst_imbalance
+        character(len=100) :: worst_section
+        
+        write(unit, '(A)') 'LOAD BALANCE ANALYSIS:'
+        write(unit, '(A)') repeat('-', 40)
+        
+        imbalanced_sections = 0
+        well_balanced_sections = 0
+        worst_imbalance = 0.0_WP
+        worst_section = ""
+        
+        do i = 1, num_profiles
+            if (trim(profiles(i)%name) == "" .or. global_counts(i) == 0) cycle
+            
+            total_time = global_data(4*i-3)
+            min_time = global_data(4*i-2)
+            max_time = global_data(4*i-1)
+            mean_time = total_time / real(npes, WP)
+            
+            if (mean_time > 0.001_WP) then  ! Only analyze sections with significant time
+                load_imbalance = (max_time - min_time) / mean_time * 100.0_WP
+                
+                if (load_imbalance > worst_imbalance) then
+                    worst_imbalance = load_imbalance
+                    worst_section = trim(profiles(i)%name)
+                endif
+                
+                if (load_imbalance > 15.0_WP) then
+                    imbalanced_sections = imbalanced_sections + 1
+                else if (load_imbalance < 5.0_WP) then
+                    well_balanced_sections = well_balanced_sections + 1
+                endif
+            endif
+        end do
+        
+        write(unit, '(A,I0)') '  Well-balanced sections (< 5% imbalance): ', well_balanced_sections
+        write(unit, '(A,I0)') '  Imbalanced sections (> 15% imbalance):   ', imbalanced_sections
+        write(unit, '(A,F6.1,A)') '  Worst load imbalance: ', worst_imbalance, '%'
+        if (worst_imbalance > 0.0_WP) then
+            write(unit, '(A,A)') '  Worst section: ', trim(worst_section)
+        endif
+        write(unit, '(A)') ''
+        
+        ! Recommendations
+        if (imbalanced_sections > 0) then
+            write(unit, '(A)') 'RECOMMENDATIONS:'
+            write(unit, '(A)') '  - Consider load balancing optimization for imbalanced sections'
+            write(unit, '(A)') '  - Check for uneven mesh distribution or boundary effects'
+            write(unit, '(A)') '  - Consider asynchronous communication patterns'
+        else
+            write(unit, '(A)') 'GOOD NEWS: All major sections are well-balanced!'
+        endif
+        write(unit, '(A)') ''
+    end subroutine print_load_balance_analysis
+
+    !=========================================================================
+    ! Finalize profiler and generate final report
+    !=========================================================================
+    subroutine fesom_profiler_finalize(mpi_comm, mpi_rank)
+        include "mpif.h"
+        integer, intent(in) :: mpi_comm, mpi_rank
+        
+        if (.not. fesom_profiler_enabled()) return
+        
+        call fesom_profiler_report(mpi_comm, mpi_rank)
+        profiler_initialized = .false.
+    end subroutine fesom_profiler_finalize
+
+    !=========================================================================
+    ! Reset all profiling data
+    !=========================================================================
+    subroutine fesom_profiler_reset()
+        integer :: i
+        
+        if (.not. fesom_profiler_enabled()) return
+        
+        do i = 1, num_profiles
+            profiles(i)%total_time = 0.0_WP
+            profiles(i)%min_time = HUGE(1.0_WP)
+            profiles(i)%max_time = 0.0_WP
+            profiles(i)%sum_squares = 0.0_WP
+            profiles(i)%call_count = 0
+            profiles(i)%is_active = .false.
+        end do
+        
+        call_stack_depth = 0
+    end subroutine fesom_profiler_reset
+
+    !=========================================================================
+    ! Find existing profile or create new one
+    !=========================================================================
+    function find_or_create_profile(name) result(index)
+        character(len=*), intent(in) :: name
+        integer :: index
+        
+        ! First try to find existing profile
+        index = find_profile(name)
+        if (index /= -1) return
+        
+        ! Create new profile
+        if (num_profiles < MAX_PROFILE_SECTIONS) then
+            num_profiles = num_profiles + 1
+            index = num_profiles
+            profiles(index)%name = trim(name)
+            profiles(index)%total_time = 0.0_WP
+            profiles(index)%min_time = HUGE(1.0_WP)
+            profiles(index)%max_time = 0.0_WP
+            profiles(index)%sum_squares = 0.0_WP
+            profiles(index)%call_count = 0
+            profiles(index)%is_active = .false.
+        else
+            ! Error: too many profiles
+            index = -1
+        endif
+    end function find_or_create_profile
+
+    !=========================================================================
+    ! Find existing profile by name
+    !=========================================================================
+    function find_profile(name) result(index)
+        character(len=*), intent(in) :: name
+        integer :: index
+        integer :: i
+        
+        index = -1
+        do i = 1, num_profiles
+            if (trim(profiles(i)%name) == trim(name)) then
+                index = i
+                return
+            endif
+        end do
+    end function find_profile
+
+end module fesom_profiler

--- a/src/ice_setup_step.F90
+++ b/src/ice_setup_step.F90
@@ -108,7 +108,7 @@ subroutine ice_timestep(step, ice, partit, mesh)
 #if defined (__icepack)
     use icedrv_main,   only: step_icepack
 #endif
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     use fesom_profiler
 #endif
     implicit none
@@ -169,7 +169,7 @@ subroutine ice_timestep(step, ice, partit, mesh)
 #endif
     !___________________________________________________________________________
     t0=MPI_Wtime()
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     call fesom_profiler_start("ice_dynamics")
 #endif
 #if defined (__icepack)
@@ -219,7 +219,7 @@ subroutine ice_timestep(step, ice, partit, mesh)
 
     if (use_cavity) call cavity_ice_clean_vel(ice, partit, mesh)
     t1=MPI_Wtime()
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     call fesom_profiler_end("ice_dynamics")
     call fesom_profiler_start("ice_advection")
 #endif
@@ -288,7 +288,7 @@ subroutine ice_timestep(step, ice, partit, mesh)
 
     if (use_cavity) call cavity_ice_clean_ma(ice, partit, mesh)
     t2=MPI_Wtime()
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     call fesom_profiler_end("ice_advection")
     call fesom_profiler_start("ice_thermodynamics")
 #endif
@@ -315,7 +315,7 @@ subroutine ice_timestep(step, ice, partit, mesh)
     end do
 !$OMP END PARALLEL DO
     t3=MPI_Wtime()
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     call fesom_profiler_end("ice_thermodynamics")
 #endif
     rtime_ice = rtime_ice + (t3-t0)

--- a/src/ice_setup_step.F90
+++ b/src/ice_setup_step.F90
@@ -108,6 +108,9 @@ subroutine ice_timestep(step, ice, partit, mesh)
 #if defined (__icepack)
     use icedrv_main,   only: step_icepack
 #endif
+#ifdef FESOM_PROFILING
+    use fesom_profiler
+#endif
     implicit none
     integer       , intent(in)            :: step
     type(t_ice)   , intent(inout), target :: ice
@@ -166,6 +169,9 @@ subroutine ice_timestep(step, ice, partit, mesh)
 #endif
     !___________________________________________________________________________
     t0=MPI_Wtime()
+#ifdef FESOM_PROFILING
+    call fesom_profiler_start("ice_dynamics")
+#endif
 #if defined (__icepack)
     call step_icepack(ice, mesh, time_evp, time_advec, time_therm) ! EVP, advection and thermodynamic parts
 #else
@@ -213,6 +219,10 @@ subroutine ice_timestep(step, ice, partit, mesh)
 
     if (use_cavity) call cavity_ice_clean_vel(ice, partit, mesh)
     t1=MPI_Wtime()
+#ifdef FESOM_PROFILING
+    call fesom_profiler_end("ice_dynamics")
+    call fesom_profiler_start("ice_advection")
+#endif
 
     !___________________________________________________________________________
     ! ===== Advection part
@@ -278,6 +288,10 @@ subroutine ice_timestep(step, ice, partit, mesh)
 
     if (use_cavity) call cavity_ice_clean_ma(ice, partit, mesh)
     t2=MPI_Wtime()
+#ifdef FESOM_PROFILING
+    call fesom_profiler_end("ice_advection")
+    call fesom_profiler_start("ice_thermodynamics")
+#endif
 
     !___________________________________________________________________________
     ! ===== Thermodynamic part
@@ -301,6 +315,9 @@ subroutine ice_timestep(step, ice, partit, mesh)
     end do
 !$OMP END PARALLEL DO
     t3=MPI_Wtime()
+#ifdef FESOM_PROFILING
+    call fesom_profiler_end("ice_thermodynamics")
+#endif
     rtime_ice = rtime_ice + (t3-t0)
     rtime_tot = rtime_tot + (t3-t0)
     if(mod(step,logfile_outfreq)==0 .and. mype==0) then

--- a/src/oce_ale.F90
+++ b/src/oce_ale.F90
@@ -3339,7 +3339,7 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
     use check_blowup_interface
     use fer_solve_interface
     use impl_vert_visc_ale_vtransp_interface
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     use fesom_profiler
 #endif
     
@@ -3370,7 +3370,7 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
 !PS     stress_surf= 0.0_WP
 !PS     stress_node_surf= 0.0_WP
 
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     call fesom_profiler_start("oce_mix_pres")
 #endif
     !___________________________________________________________________________
@@ -3487,7 +3487,7 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
         
     end if
     t1=MPI_Wtime()
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     call fesom_profiler_end("oce_mix_pres")
     call fesom_profiler_start("oce_dyn_momentum")
 #endif    
@@ -3619,7 +3619,7 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
         end if 
     end if
     t2=MPI_Wtime()
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     call fesom_profiler_end("oce_dyn_momentum")
     call fesom_profiler_start("oce_ssh_solve")
 #endif        
@@ -3647,7 +3647,7 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
             call relax_zonal_vel(dynamics, partit, mesh)
         end if     
         t3=MPI_Wtime()
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     call fesom_profiler_end("oce_ssh_solve")
     call fesom_profiler_start("oce_vel_update")
 #endif 
@@ -3660,7 +3660,7 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
         
         ! --> eta_(n) --> eta_(n+1) = eta_(n) + deta = eta_(n) + (eta_(n+1) + eta_(n))
         t4=MPI_Wtime()
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     call fesom_profiler_end("oce_vel_update")
     call fesom_profiler_start("oce_hbar_calc")
 #endif 
@@ -3688,7 +3688,7 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
         ! --> eta_(n)
         ! call zero_dynamics !DS, zeros several dynamical variables; to be used for testing new implementations!
         t5=MPI_Wtime()
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     call fesom_profiler_end("oce_hbar_calc")
     call fesom_profiler_start("oce_gm_redi")
 #endif 
@@ -3704,7 +3704,7 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
         ! Do barotropic step, get eta_{n+1} and BT transport 
         call compute_BT_step_SE_ale(dynamics, partit, mesh)
         t3=MPI_Wtime()
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     call fesom_profiler_end("oce_ssh_solve")
     call fesom_profiler_start("oce_vel_update")
 #endif        
@@ -3712,7 +3712,7 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
         call update_trim_vel_ale_vtransp(1, dynamics, partit, mesh) 
         t4=MPI_Wtime()
         t5=t4
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     call fesom_profiler_end("oce_vel_update")
     call fesom_profiler_start("oce_hbar_calc")
     call fesom_profiler_end("oce_hbar_calc")
@@ -3734,7 +3734,7 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
         call fer_gamma2vel(dynamics, partit, mesh)
     end if
     t6=MPI_Wtime()
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     call fesom_profiler_end("oce_gm_redi")
     call fesom_profiler_start("oce_vert_vel")
 #endif 
@@ -3764,7 +3764,7 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
         call compute_vert_vel_transpv(dynamics, partit, mesh)
     end if    
     t7=MPI_Wtime()
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     call fesom_profiler_end("oce_vert_vel")
     call fesom_profiler_start("oce_tracer_solve")
 #endif   
@@ -3781,7 +3781,7 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
     if (flag_debug .and. mype==0)  print *, achar(27)//'[36m'//'     --> call solve_tracers_ale'//achar(27)//'[0m'
     call solve_tracers_ale(ice, dynamics, tracers, partit, mesh)
     t8=MPI_Wtime()
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     call fesom_profiler_end("oce_tracer_solve")
     call fesom_profiler_start("oce_thickness_update")
 #endif 
@@ -3791,7 +3791,7 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
     if (flag_debug .and. mype==0)  print *, achar(27)//'[36m'//'     --> call update_thickness_ale'//achar(27)//'[0m'
     call update_thickness_ale(partit, mesh)
     t9=MPI_Wtime()
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     call fesom_profiler_end("oce_thickness_update")
     call fesom_profiler_start("oce_blowup_check")
 #endif 
@@ -3819,7 +3819,7 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
     if (flag_debug .and. mype==0)  print *, achar(27)//'[36m'//'     --> call check_blowup'//achar(27)//'[0m'
     call check_blowup(n, ice, dynamics, tracers, partit, mesh)
     t10=MPI_Wtime()
-#ifdef FESOM_PROFILING
+#if defined (FESOM_PROFILING)
     call fesom_profiler_end("oce_blowup_check")
 #endif
 

--- a/src/oce_ale.F90
+++ b/src/oce_ale.F90
@@ -3339,6 +3339,9 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
     use check_blowup_interface
     use fer_solve_interface
     use impl_vert_visc_ale_vtransp_interface
+#ifdef FESOM_PROFILING
+    use fesom_profiler
+#endif
     
     IMPLICIT NONE
     integer       , intent(in)            :: n
@@ -3367,6 +3370,9 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
 !PS     stress_surf= 0.0_WP
 !PS     stress_node_surf= 0.0_WP
 
+#ifdef FESOM_PROFILING
+    call fesom_profiler_start("oce_mix_pres")
+#endif
     !___________________________________________________________________________
     ! calculate equation of state, density, pressure and mixed layer depths
     if (flag_debug .and. mype==0)  print *, achar(27)//'[36m'//'     --> call pressure_bv'//achar(27)//'[0m'
@@ -3480,7 +3486,11 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
         call calc_cvmix_tidal(partit, mesh)
         
     end if
-    t1=MPI_Wtime()    
+    t1=MPI_Wtime()
+#ifdef FESOM_PROFILING
+    call fesom_profiler_end("oce_mix_pres")
+    call fesom_profiler_start("oce_dyn_momentum")
+#endif    
     
     !___________________________________________________________________________
     ! add contribution from momentum advection, coriolis and pressure gradient |
@@ -3609,7 +3619,10 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
         end if 
     end if
     t2=MPI_Wtime()
-        
+#ifdef FESOM_PROFILING
+    call fesom_profiler_end("oce_dyn_momentum")
+    call fesom_profiler_start("oce_ssh_solve")
+#endif        
     !___________________________________________________________________________
     ! >->->->->->->->->->->->->     ALE-part starts     <-<-<-<-<-<-<-<-<-<-<-<-
     !___________________________________________________________________________
@@ -3633,7 +3646,11 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
             if (flag_debug .and. mype==0)  print *, achar(27)//'[36m'//'     --> call relax_zonal_vel'//achar(27)//'[0m'
             call relax_zonal_vel(dynamics, partit, mesh)
         end if     
-        t3=MPI_Wtime() 
+        t3=MPI_Wtime()
+#ifdef FESOM_PROFILING
+    call fesom_profiler_end("oce_ssh_solve")
+    call fesom_profiler_start("oce_vel_update")
+#endif 
 
         ! estimate new horizontal velocity u^(n+1)
         ! u^(n+1) = u* + [-g * tau * theta * grad(eta^(n+1)-eta^(n)) ]
@@ -3642,7 +3659,11 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
         call update_vel(dynamics, partit, mesh)
         
         ! --> eta_(n) --> eta_(n+1) = eta_(n) + deta = eta_(n) + (eta_(n+1) + eta_(n))
-        t4=MPI_Wtime() 
+        t4=MPI_Wtime()
+#ifdef FESOM_PROFILING
+    call fesom_profiler_end("oce_vel_update")
+    call fesom_profiler_start("oce_hbar_calc")
+#endif 
         
         ! Update to hbar(n+3/2) and compute dhe to be used on the next step
         if (flag_debug .and. mype==0)  print *, achar(27)//'[36m'//'     --> call compute_hbar_ale'//achar(27)//'[0m'
@@ -3666,7 +3687,11 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
 !$OMP END PARALLEL DO
         ! --> eta_(n)
         ! call zero_dynamics !DS, zeros several dynamical variables; to be used for testing new implementations!
-        t5=MPI_Wtime() 
+        t5=MPI_Wtime()
+#ifdef FESOM_PROFILING
+    call fesom_profiler_end("oce_hbar_calc")
+    call fesom_profiler_start("oce_gm_redi")
+#endif 
     
     !___________________________________________________________________________
     ! Compute SSH via split-explicite subcycling
@@ -3679,11 +3704,20 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
         ! Do barotropic step, get eta_{n+1} and BT transport 
         call compute_BT_step_SE_ale(dynamics, partit, mesh)
         t3=MPI_Wtime()
-        
+#ifdef FESOM_PROFILING
+    call fesom_profiler_end("oce_ssh_solve")
+    call fesom_profiler_start("oce_vel_update")
+#endif        
         ! Trim U to be consistent with BT transport
         call update_trim_vel_ale_vtransp(1, dynamics, partit, mesh) 
         t4=MPI_Wtime()
         t5=t4
+#ifdef FESOM_PROFILING
+    call fesom_profiler_end("oce_vel_update")
+    call fesom_profiler_start("oce_hbar_calc")
+    call fesom_profiler_end("oce_hbar_calc")
+    call fesom_profiler_start("oce_gm_redi")
+#endif
     end if ! --> if (.not. dynamics%use_ssh_se_subcycl) then
     
     !___________________________________________________________________________
@@ -3699,7 +3733,11 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
         call fer_solve_Gamma(partit, mesh)
         call fer_gamma2vel(dynamics, partit, mesh)
     end if
-    t6=MPI_Wtime() 
+    t6=MPI_Wtime()
+#ifdef FESOM_PROFILING
+    call fesom_profiler_end("oce_gm_redi")
+    call fesom_profiler_start("oce_vert_vel")
+#endif 
  
     !___________________________________________________________________________
     ! keep the old vertical velocity for computation of the mean between the timesteps (is used in compute_ke_wrho)
@@ -3725,7 +3763,11 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
         end if 
         call compute_vert_vel_transpv(dynamics, partit, mesh)
     end if    
-    t7=MPI_Wtime()   
+    t7=MPI_Wtime()
+#ifdef FESOM_PROFILING
+    call fesom_profiler_end("oce_vert_vel")
+    call fesom_profiler_start("oce_tracer_solve")
+#endif   
      
     !___________________________________________________________________________
     ! energy diagnostic computation
@@ -3738,13 +3780,21 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
     ! solve tracer equation
     if (flag_debug .and. mype==0)  print *, achar(27)//'[36m'//'     --> call solve_tracers_ale'//achar(27)//'[0m'
     call solve_tracers_ale(ice, dynamics, tracers, partit, mesh)
-    t8=MPI_Wtime() 
+    t8=MPI_Wtime()
+#ifdef FESOM_PROFILING
+    call fesom_profiler_end("oce_tracer_solve")
+    call fesom_profiler_start("oce_thickness_update")
+#endif 
      
     !___________________________________________________________________________
     ! Update hnode=hnode_new, helem
     if (flag_debug .and. mype==0)  print *, achar(27)//'[36m'//'     --> call update_thickness_ale'//achar(27)//'[0m'
     call update_thickness_ale(partit, mesh)
-    t9=MPI_Wtime() 
+    t9=MPI_Wtime()
+#ifdef FESOM_PROFILING
+    call fesom_profiler_end("oce_thickness_update")
+    call fesom_profiler_start("oce_blowup_check")
+#endif 
     
 !PS     !___________________________________________________________________________
 !PS     ! Trim to make velocity consistent with BT velocity at n+1/2
@@ -3769,6 +3819,9 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
     if (flag_debug .and. mype==0)  print *, achar(27)//'[36m'//'     --> call check_blowup'//achar(27)//'[0m'
     call check_blowup(n, ice, dynamics, tracers, partit, mesh)
     t10=MPI_Wtime()
+#ifdef FESOM_PROFILING
+    call fesom_profiler_end("oce_blowup_check")
+#endif
 
     !___________________________________________________________________________
     ! write out execution times for ocean step parts


### PR DESCRIPTION
A much needed feature I desired for a while now. This PR adds a flexible profiling  module to fesom. It is inspired to be like a python decorator for instance wrap a subroutine call anywhere in the code:
```        
call fesom_profiler_start("ice_timestep")
                call ice_timestep(n, f%ice, f%partit, f%mesh)
call fesom_profiler_end("ice_timestep")
```
and get a profiling respecting the call graph tree of outer profiling structure. fesom.stats file is generated in results directory once profiling is enabled -DFESOM_PROFILING=ON. here is one for a 2 process test with default profiling
```
cat fesom.stats >> 

==========================================================================================
======== FESOM2 ENHANCED PROFILING REPORT (detailed timing statistics) ========
   2 ranks, 96 timesteps
==========================================================================================

METRICS EXPLANATION:
-------------------
Mean(s): Average wall clock time across all MPI ranks
Min(s)/Max(s): Fastest/slowest total time among all ranks
Calls: Total number of function calls across all ranks

PERCENTAGE METRICS:
%Total: Percentage of absolute total runtime (init + runloop + finalize)
%Parent: Percentage relative to immediate parent section
  → Top-level: same as %Total (relative to absolute total)
  → Nested: relative to parent (e.g., oce_mix_pres % of oce_timestep_ale)

LOAD BALANCE METRICS:
RngImb(%) = (Max - Min) / Mean × 100  [Range-based imbalance]
  → How much slower is the worst rank vs average?
  → Critical for HPC: slowest rank determines completion time
StdImb(%) = StdDev / Mean × 100       [Distribution-based imbalance]
  → Overall variability across all ranks (coefficient of variation)
  → Shows whether imbalance affects few ranks or is widespread

INTERPRETATION EXAMPLES:
• High RngImb + Low StdImb  → One outlier rank, others well-balanced
• High RngImb + High StdImb → General imbalance across many ranks
• Low RngImb + High StdImb  → Multiple performance clusters, no single outlier

SYPD CALCULATION: Simulated Years Per Day = (timestep_size_seconds × timesteps) / (365.25 × runtime_seconds)
  → Based on    900.0s timesteps, 96 steps total
==========================================================================================

                       Section Name        Mean(s)         Min(s)         Max(s)   Calls  %Total %Parent RngImb(%) StdImb(%)
----------------------------------------------------------------------------------------------------------------------------
fesom_init_total                            0.1675         0.1674         0.1675       2     0.7     0.7       0.1       0.0
  >par_init                                 0.0001         0.0000         0.0001       2     0.0     0.0     106.7       0.0
  >setup_model                              0.0005         0.0005         0.0005       2     0.0     0.3       1.7       0.0
  >mesh_setup                               0.0337         0.0336         0.0337       2     0.1    20.1       0.2       0.0
  >ocean_setup                              0.0850         0.0849         0.0850       2     0.4    50.7       0.1       0.0
    >dynamics_init                          0.0850         0.0849         0.0850       2     0.4   100.0       0.1       0.0
fesom_runloop_total                        22.9690        22.9636        22.9743       2    99.3    99.3       0.0       0.0
  >update_atm_forcing                       0.1633         0.1622         0.1643     192     0.7     0.7       1.3       0.3
  >ice_timestep                             3.4151         3.3818         3.4485     192    14.8    14.9       2.0       0.5
    >ice_dynamics                           2.9868         2.9859         2.9877     192    12.9    87.5       0.1       0.0
    >ice_advection                          0.2992         0.2989         0.2994     192     1.3     8.8       0.2       0.0
    >ice_thermodynamics                     0.1288         0.0945         0.1631     192     0.6     3.8      53.3      13.3
  >oce_timestep_ale                        18.6422        18.6337        18.6507     192    80.6    81.2       0.1       0.0
    >oce_mix_pres                           5.4032         5.3690         5.4373     192    23.3    29.0       1.3       0.3
    >oce_dyn_momentum                       2.3888         2.3052         2.4723     192    10.3    12.8       7.0       1.7
    >oce_ssh_solve                          0.5835         0.4576         0.7095     192     2.5     3.1      43.2      10.8
    >oce_vel_update                         0.0537         0.0537         0.0537     192     0.2     0.3       0.0       0.0
    >oce_hbar_calc                          0.1580         0.1578         0.1582     192     0.7     0.8       0.3       0.1
    >oce_gm_redi                            0.4602         0.4600         0.4604     192     2.0     2.5       0.1       0.0
    >oce_vert_vel                           0.6543         0.6472         0.6613     192     2.8     3.5       2.2       0.5
    >oce_tracer_solve                       8.8012         8.7972         8.8051     192    38.0    47.2       0.1       0.0
    >oce_thickness_update                   0.0869         0.0759         0.0979     192     0.4     0.5      25.3       6.3
    >oce_blowup_check                       0.0515         0.0515         0.0515     192     0.2     0.3       0.0       0.0
  >compute_diagnostics                      0.0005         0.0005         0.0005     192     0.0     0.0       7.6       1.9
  >output                                   0.2935         0.2709         0.3162     192     1.3     1.3      15.4       3.9
  >restart                                  0.1233         0.1180         0.1285     192     0.5     0.5       8.5       2.1
fesom_finalize_total                        0.0054         0.0000         0.0107       2     0.0     0.0     198.4       0.0
----------------------------------------------------------------------------------------------------------------------------

==========================================================================================
========================== LOAD BALANCE ANALYSIS ==========================
  Analyzed sections: 12 (ignored 15 minor sections)
  Well-balanced sections: 9
  Imbalanced sections:    2
  Worst imbalance:   43.2% (oce_ssh_solve)
  Note: Sections <   0.2297s (1% of total runtime) ignored (init/finalize/minor overhead)
==========================================================================================

==========================================================================================
============================ BENCHMARK RUNTIME ============================
    Number of cores :                      2
    Number of OMP threads per rank :      2
    Timestep size :                            900.00 sec
    Number of timesteps :                  96
    Total runtime (init+run+finalize):     23.1419 sec
    Estimated SYPD :                       10.2218 years/day
==========================================================================================
```
- gives rough call graph, timings respect outer parent call timing, so children sum to its parent.
- gives summary with estimated SYPD. 
- show imbalance in processes by profiled subroutine by 2 metrics, range imbalance being more actionable kind. 
- helps in implementing new features and spotting performance and process imbalance early on in development (eg., upcoming parallel IO)
- this will help regression testing for performance in CI, once we start tracking it. 

to test it build fesom with -DFESOM_PROFILING=ON and find fesom.stats in results directory (and optionally -DBUILD_TESTING=ON to quickly test with ctests).
