### PR TITLE
Meshdiag tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(BUILD_TESTING "Build tests" OFF)
 
 # Tools
 option(BUILD_MESHPARTITIONER "Build mesh partitioning tools (fesom_meshpart executable)" OFF)
+option(BUILD_MESHDIAG "Build mesh diagnostics utility (fesom_meshdiag executable)" OFF)
 
 #add_subdirectory(oasis3-mct/lib/psmile)
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -441,15 +441,34 @@ target_link_libraries(${PROJECT_NAME} PRIVATE ${YAXT_Fortran_LIBRARIES} ${YAXTC_
 #target_link_libraries(${PROJECT_NAME} PRIVATE ${PROJECT_NAME}_C ${YAXT_Fortran_LIBRARIES} ${YAXTC_Fortran_LIBRARIES})
 
    
-# fesom.x executable
+# fesom.x executable
 add_executable(${PROJECT_NAME}.x ${src_home}/fesom_main.F90)
 target_link_libraries(${PROJECT_NAME}.x PUBLIC ${PROJECT_NAME})
+
+# fesom_meshdiag executable (optional)
+if(BUILD_MESHDIAG)
+    add_executable(fesom_meshdiag ${src_home}/fesom_meshdiag.F90)
+    target_link_libraries(fesom_meshdiag PUBLIC ${PROJECT_NAME})
+    target_link_libraries(fesom_meshdiag PRIVATE MPI::MPI_Fortran)
+    
+    # Install the mesh diagnostics utility
+    install(TARGETS fesom_meshdiag
+            RUNTIME DESTINATION bin
+            COMPONENT tools)
+    
+    message(STATUS "Mesh diagnostics utility will be built as fesom_meshdiag")
+endif()
 
 
 get_target_property(FLAGS ${PROJECT_NAME} COMPILE_OPTIONS)
 message(STATUS " --> Final Compile options for ${PROJECT_NAME}: ${FLAGS}")
 
 
-### Export and installation
+### Export and installation
+
+# Add meshdiag to additional targets if built
+if(BUILD_MESHDIAG)
+    set(additional_targets ${additional_targets} fesom_meshdiag)
+endif()
 
 fesom_export(TARGETS ${PROJECT_NAME} fesom.x ${additional_targets})

--- a/src/fesom_meshdiag.F90
+++ b/src/fesom_meshdiag.F90
@@ -1,0 +1,98 @@
+!=============================================================================!
+!
+!                 Finite Volume Sea-ice Ocean Model
+!                     Mesh Diagnostics Utility
+!
+!=============================================================================!
+!  This utility generates mesh diagnostics NetCDF file and exits.
+!  It performs minimal initialization required for mesh diagnostics generation.
+!=============================================================================!    
+
+program fesom_meshdiag
+  use MOD_MESH
+  use MOD_PARTIT
+  use MOD_PARSUP
+  use MOD_DYN
+  use MOD_TRACER
+  use o_PARAM
+  use o_ARRAYS
+  use g_config
+  use g_comm_auto
+  use io_mesh_info
+  use, intrinsic :: iso_fortran_env, only : real32
+
+  implicit none
+  
+  ! Local variables
+  integer           :: provided, MPIerr
+  logical           :: mpi_is_initialized
+  real(kind=WP)     :: t0, t1, t2
+  type(t_mesh)      :: mesh
+  type(t_partit)    :: partit
+  type(t_dyn)       :: dynamics
+  type(t_tracer)    :: tracers
+  
+  ! Initialize MPI (following FESOM2 approach)
+  mpi_is_initialized = .false.
+  call MPI_Initialized(mpi_is_initialized, MPIerr)
+  if(.not. mpi_is_initialized) then
+    call MPI_INIT_THREAD(MPI_THREAD_MULTIPLE, provided, MPIerr)
+  end if
+  
+  ! Set up global pointers
+  call par_init(partit)
+  
+  if (partit%mype == 0) then
+    write(*,*) '=========================================='
+    write(*,*) 'FESOM2 Mesh Diagnostics Utility'
+    write(*,*) '=========================================='
+    t0 = MPI_Wtime()
+  endif
+  
+  ! Setup model (read namelists)
+  if (partit%mype == 0) write(*,*) 'Reading namelists...'
+  call setup_model(partit)
+  
+  ! Setup mesh
+  if (partit%mype == 0) then
+    write(*,*) 'Setting up mesh...'
+    t1 = MPI_Wtime()
+  endif
+  call mesh_setup(partit, mesh)
+  
+  if (partit%mype == 0) then
+    t2 = MPI_Wtime()
+    write(*,*) 'FESOM mesh_setup... complete'
+    write(*,*) 'Mesh setup time: ', real(t2-t1, real32), ' seconds'
+  endif
+  
+  ! Check mesh consistency
+  if (partit%mype == 0) write(*,*) 'Checking mesh consistency...'
+  call check_mesh_consistency(partit, mesh)
+  
+  ! Initialize minimal dynamics and tracers for mesh diagnostics
+  if (partit%mype == 0) write(*,*) 'Initializing dynamics and tracers...'
+  call dynamics_init(dynamics, partit, mesh)
+  call tracer_init(tracers, partit, mesh)
+  call arrays_init(tracers%num_tracers, partit, mesh)
+  
+  ! Complete ocean setup to ensure all arrays are properly initialized
+  if (partit%mype == 0) write(*,*) 'Completing ocean setup...'
+  call ocean_setup(dynamics, tracers, partit, mesh)
+  
+  ! Generate mesh diagnostics NetCDF file
+  if (partit%mype == 0) write(*,*) 'Writing mesh diagnostics...'
+  call write_mesh_info(partit, mesh)
+  
+  if (partit%mype == 0) then
+    write(*,*) 'Mesh diagnostics written successfully!'
+    write(*,*) 'Output file: ', trim(ResultPath)//trim(runid)//'.mesh.diag.nc'
+    write(*,*) 'Total runtime: ', real(MPI_Wtime()-t0, real32), ' seconds'
+    write(*,*) '=========================================='
+  endif
+  
+  ! Finalize MPI
+  call MPI_FINALIZE(MPIerr)
+  
+end program fesom_meshdiag
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -102,3 +102,13 @@ if(ENABLE_MPI_TESTS)
         VERBATIM
     )
 endif()
+
+# Create target to run only meshdiag tests (if BUILD_MESHDIAG is enabled)
+if(BUILD_MESHDIAG)
+    add_custom_target(run_meshdiag_tests
+        COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -R "meshdiag_"
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMENT "Running FESOM2 meshdiag tests"
+        VERBATIM
+    )
+endif()

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -56,3 +56,24 @@ add_test(
 set_tests_properties(integration_test_data_check PROPERTIES
     TIMEOUT 10
 )
+
+# Meshdiag tests (only when BUILD_MESHDIAG is enabled)
+if(BUILD_MESHDIAG AND TARGET fesom_meshdiag)
+    message(STATUS "Adding meshdiag tests...")
+    
+    # Basic meshdiag test with 2 processes (matches integration_full_run_mpi2)
+    add_fesom_meshdiag_test(meshdiag_pi_mpi2
+        NP 2
+        TIMEOUT 120
+    )
+    
+    # Meshdiag test with 8 processes (matches integration_full_run_mpi8)
+    add_fesom_meshdiag_test_with_options(meshdiag_pi_mpi8
+        "pi" "mesh8"
+        NP 8
+        TIMEOUT 120
+    )
+    
+else()
+    message(STATUS "Meshdiag tests disabled. Set BUILD_MESHDIAG=ON to enable them.")
+endif()


### PR DESCRIPTION
Adds a mesh diag tool to fesom `fesom_meshdiag`, it reads namelist.config and generates `fesom.mesh.diag.nc` and exits without time loop, especially relevant for large meshes and IFS-FESOM setup that doesn't generate mesh diag. this eventually allows automatic testing of remote meshes  and #305.

configure/cmake with -DBUILD_MESHDIAG=ON to get `fesom_meshdiag` utility 