### PR TITLE
Melt pond parameterization for IFS/OIFS coupled runs

### DIFF
--- a/config/namelist.io
+++ b/config/namelist.io
@@ -37,6 +37,9 @@ io_list =  'sst       ',1, 'm', 4,
            'a_ice     ',1, 'm', 4,
            'm_ice     ',1, 'm', 4,
            'm_snow    ',1, 'm', 4,
+           'apnd      ',1, 'm', 4, ! melt pond area fraction (requires use_meltponds=.true.)
+           'hpnd      ',1, 'm', 4, ! melt pond depth (requires use_meltponds=.true.)
+           'ipnd      ',1, 'm', 4, ! pond ice lid thickness (requires use_meltponds=.true.)
            'MLD1      ',1, 'm', 4,
            'MLD2      ',1, 'm', 4,
            'MLD3      ',1, 'm', 4,

--- a/config/namelist.io
+++ b/config/namelist.io
@@ -37,9 +37,10 @@ io_list =  'sst       ',1, 'm', 4,
            'a_ice     ',1, 'm', 4,
            'm_ice     ',1, 'm', 4,
            'm_snow    ',1, 'm', 4,
-           'apnd      ',1, 'm', 4, ! melt pond area fraction (requires use_meltponds=.true.)
-           'hpnd      ',1, 'm', 4, ! melt pond depth (requires use_meltponds=.true.)
-           'ipnd      ',1, 'm', 4, ! pond ice lid thickness (requires use_meltponds=.true.)
+           'apnd      ',1, 'm', 4, ! melt pond area fraction (only active for use_meltponds=.true.)
+           'hpnd      ',1, 'm', 4, ! melt pond depth (only active for use_meltponds=.true.)
+           'ipnd      ',1, 'm', 4, ! pond ice lid thickness (only active for use_meltponds=.true.)
+           'alb       ',1, 'm', 4, ! ice albedo (only active for oifs and ifs coupled)
            'MLD1      ',1, 'm', 4,
            'MLD2      ',1, 'm', 4,
            'MLD3      ',1, 'm', 4,

--- a/src/MOD_ICE.F90
+++ b/src/MOD_ICE.F90
@@ -573,12 +573,12 @@ subroutine ice_init(ice, partit, mesh)
     namelist /ice_dyn/ whichEVP, Pstar, ellipse, c_pressure, delta_min, evp_rheol_steps, &
                        Cd_oce_ice, ice_gamma_fct, ice_diff, theta_io, ice_ave_steps, &
                        alpha_evp, beta_evp, c_aevp
-    logical        :: snowdist, new_iclasses
+    logical        :: snowdist, new_iclasses, use_meltponds
     integer        :: open_water_albedo, iclasses
     real(kind=WP)  :: Sice, h0, h0_s, emiss_ice, emiss_wat, albsn, albsnm, albi, &
                       albim, albw, con, consn, hmin, armin, c_melt, h_cutoff
     namelist /ice_therm/ Sice, iclasses, h0, h0_s, hmin, armin,  emiss_ice, emiss_wat, albsn, albsnm, albi, &
-                         albim, albw, con, consn,  snowdist, new_iclasses, open_water_albedo, c_melt, h_cutoff
+                         albim, albw, con, consn,  snowdist, new_iclasses, open_water_albedo, use_meltponds, c_melt, h_cutoff
     !___________________________________________________________________________
     ! pointer on necessary derived types
 #include "associate_part_def.h"
@@ -636,6 +636,7 @@ subroutine ice_init(ice, partit, mesh)
     ice%thermo%snowdist = snowdist
     ice%thermo%new_iclasses=new_iclasses
     ice%thermo%open_water_albedo=open_water_albedo
+    ice%thermo%use_meltponds = use_meltponds
     ice%thermo%c_melt   = c_melt
     ice%thermo%h_cutoff = h_cutoff    
     ice%thermo%cc       =ice%thermo%rhowat*4190.0  ! Volumetr. heat cap. of water [J/m**3/K](cc = rhowat*cp_water)

--- a/src/MOD_ICE.F90
+++ b/src/MOD_ICE.F90
@@ -46,6 +46,8 @@ END TYPE T_ICE_WORK
 TYPE T_ICE_THERMO
     !___________________________________________________________________________
     real(kind=WP), allocatable, dimension(:)    :: t_skin, thdgr, thdgrsn, thdgr_old, ustar
+    ! melt pond variables
+    real(kind=WP), allocatable, dimension(:)    :: apnd, hpnd, ipnd  ! pond area fraction, depth, ice thickness
     !___________________________________________________________________________
     real(kind=WP) :: rhoair=1.3  , inv_rhoair=1./1.3  ! Air density & inverse ,  LY2004 !1.3 AOMIP
     real(kind=WP) :: rhowat=1025., inv_rhowat=1./1025.! Water density & inverse
@@ -86,6 +88,8 @@ TYPE T_ICE_THERMO
     logical       :: new_iclasses=.false. ! ice thickness distribution based on EM observations (Castro-Morales et al., JGR, 2013)
     integer       :: open_water_albedo=0  ! 0=standard; 1=taylor; 2=briegleb        
     REAL(kind=WP) :: c_melt=0.5        ! constant in concentration equation for melting conditions
+    ! --- melt pond parameters
+    logical       :: use_meltponds=.false. ! enable melt pond parameterization
     REAL(kind=WP) :: h_cutoff=3.0      ! cutoff thickness of thickness pdf
     REAL(kind=WP), DIMENSION(15) :: hpdf = (/ 0.066745491, 0.1462317, 0.17769822, 0.13131106, &
          0.11518432, 0.08514193, 0.06871303, 0.05592151, 0.04428673, 0.03584652, 0.02970195, 0.02469673, &
@@ -316,6 +320,10 @@ subroutine WRITE_T_ICE_THERMO(ttherm, unit)
     call write_bin_array(ttherm%thdgrsn,      unit, iostat, iomsg)
     call write_bin_array(ttherm%thdgr_old,    unit, iostat, iomsg)
     call write_bin_array(ttherm%ustar,        unit, iostat, iomsg)
+    ! melt pond variables
+    call write_bin_array(ttherm%apnd,         unit, iostat, iomsg)
+    call write_bin_array(ttherm%hpnd,         unit, iostat, iomsg)
+    call write_bin_array(ttherm%ipnd,         unit, iostat, iomsg)
 end subroutine WRITE_T_ICE_THERMO
 
 ! Unformatted reading for T_ICE_WORK
@@ -330,6 +338,10 @@ subroutine READ_T_ICE_THERMO(ttherm, unit)
     call read_bin_array(ttherm%thdgrsn,      unit, iostat, iomsg)
     call read_bin_array(ttherm%thdgr_old,    unit, iostat, iomsg)
     call read_bin_array(ttherm%ustar,        unit, iostat, iomsg)
+    ! melt pond variables
+    call read_bin_array(ttherm%apnd,         unit, iostat, iomsg)
+    call read_bin_array(ttherm%hpnd,         unit, iostat, iomsg)
+    call read_bin_array(ttherm%ipnd,         unit, iostat, iomsg)
 end subroutine READ_T_ICE_THERMO
 !
 !

--- a/src/MOD_ICE.F90
+++ b/src/MOD_ICE.F90
@@ -769,11 +769,19 @@ subroutine ice_init(ice, partit, mesh)
     allocate(ice%thermo%thdgr(         node_size))
     allocate(ice%thermo%thdgrsn(       node_size))
     allocate(ice%thermo%thdgr_old(     node_size))
+    ! melt pond arrays
+    allocate(ice%thermo%apnd(          node_size))
+    allocate(ice%thermo%hpnd(          node_size))
+    allocate(ice%thermo%ipnd(          node_size))
     ice%thermo%ustar     = 0.0_WP
     ice%thermo%t_skin    = 0.0_WP
     ice%thermo%thdgr     = 0.0_WP
     ice%thermo%thdgrsn   = 0.0_WP
     ice%thermo%thdgr_old = 0.0_WP
+    ! initialize melt pond arrays
+    ice%thermo%apnd      = 0.0_WP
+    ice%thermo%hpnd      = 0.0_WP
+    ice%thermo%ipnd      = 0.0_WP
 
     !___________________________________________________________________________
     ! initialse coupling array of ice derived type

--- a/src/ice_meltponds.F90
+++ b/src/ice_meltponds.F90
@@ -1,0 +1,217 @@
+!===============================================================================
+! FESOM-2.6 Melt Pond Parameterization Module
+! 
+! Based on CESM melt pond scheme from ICEPACK
+! Adapted for use with ice_thermo_cpl.F90
+!
+! Author: Extracted from ICEPACK for FESOM-2.6 coupled simulations
+! Date: 2024
+!===============================================================================
+
+module ice_meltponds
+    use o_param, only: WP
+    implicit none
+    
+    private
+    public :: meltpond_area, meltpond_albedo, init_meltponds
+    
+    ! Melt pond parameters (similar to ICEPACK ponds_nml)
+    real(kind=WP), parameter :: hp1 = 0.01_WP        ! Critical pond depth [m]
+    real(kind=WP), parameter :: hs0 = 0.0_WP         ! Snow depth controlling drainage [m] 
+    real(kind=WP), parameter :: hs1 = 0.03_WP        ! Snow depth threshold [m]
+    real(kind=WP), parameter :: rfracmin = 0.15_WP   ! Minimum retained melt fraction
+    real(kind=WP), parameter :: rfracmax = 1.0_WP    ! Maximum retained melt fraction
+    real(kind=WP), parameter :: pndaspect = 0.8_WP   ! Pond aspect ratio
+    real(kind=WP), parameter :: dpscale = 1.e-3_WP   ! Drainage timescale parameter
+    
+    ! Pond albedo parameters
+    real(kind=WP), parameter :: albpnd = 0.2_WP      ! Pond albedo (open water-like)
+    real(kind=WP), parameter :: albpnd_frz = 0.36_WP ! Frozen pond albedo
+    
+    ! Physical constants
+    real(kind=WP), parameter :: puny = 1.e-11_WP     ! Small number
+    real(kind=WP), parameter :: c0 = 0.0_WP
+    real(kind=WP), parameter :: c1 = 1.0_WP
+    
+    contains
+    
+    !===========================================================================
+    ! Initialize melt pond variables
+    !===========================================================================
+    subroutine init_meltponds()
+        implicit none
+        ! Currently no initialization needed - parameters are set above
+        ! This routine is available for future extensions
+    end subroutine init_meltponds
+    
+    !===========================================================================
+    ! Calculate melt pond area fraction
+    ! 
+    ! Based on CESM melt pond scheme from ICEPACK
+    !===========================================================================
+    subroutine meltpond_area(aice, hice, hsno, meltt, melts, dt, &
+                            apnd, hpnd, ipnd, fpond)
+        implicit none
+        
+        ! Input variables
+        real(kind=WP), intent(in) :: aice     ! Ice concentration
+        real(kind=WP), intent(in) :: hice     ! Ice thickness [m]
+        real(kind=WP), intent(in) :: hsno     ! Snow thickness [m]  
+        real(kind=WP), intent(in) :: meltt    ! Top melt rate [m/s]
+        real(kind=WP), intent(in) :: melts    ! Snow melt rate [m/s]
+        real(kind=WP), intent(in) :: dt       ! Time step [s]
+        
+        ! Input/Output variables
+        real(kind=WP), intent(inout) :: apnd  ! Pond area fraction
+        real(kind=WP), intent(inout) :: hpnd  ! Pond depth [m]
+        real(kind=WP), intent(inout) :: ipnd  ! Pond ice thickness [m]
+        
+        ! Output variables
+        real(kind=WP), intent(out) :: fpond   ! Pond fresh water flux [m/s]
+        
+        ! Local variables
+        real(kind=WP) :: volpnd               ! Pond volume per unit area [m]
+        real(kind=WP) :: volpnd_init          ! Initial pond volume
+        real(kind=WP) :: hi_min               ! Minimum ice thickness for ponds
+        real(kind=WP) :: rfrac                ! Retained fraction of melt water
+        real(kind=WP) :: dvolpnd              ! Change in pond volume
+        real(kind=WP) :: armor                ! Armor parameter
+        real(kind=WP) :: pp                   ! Pond parameter
+        real(kind=WP) :: apondn               ! New pond area
+        real(kind=WP) :: hpondn               ! New pond depth
+        
+        ! Initialize
+        fpond = c0
+        hi_min = 0.1_WP  ! Minimum ice thickness for pond formation
+        
+        ! No ponds on thin ice or high snow cover
+        if (aice < puny .or. hice < hi_min .or. hsno > hs1) then
+            apnd = c0
+            hpnd = c0 
+            ipnd = c0
+            return
+        endif
+        
+        ! Calculate retained fraction of melt water
+        ! More melt water retained on thicker ice
+        armor = min(c1, hice / 0.5_WP)  ! Armor based on ice thickness
+        rfrac = rfracmin + (rfracmax - rfracmin) * armor
+        
+        ! Current pond volume per unit area
+        volpnd_init = apnd * hpnd
+        
+        ! Add melt water (both surface and snow melt)
+        dvolpnd = rfrac * (meltt + melts) * dt
+        volpnd = volpnd_init + dvolpnd
+        
+        ! Pond drainage - simple exponential decay when snow is thin
+        if (hsno < hs0 .and. volpnd > puny) then
+            volpnd = volpnd * exp(-dt * dpscale)
+        endif
+        
+        ! Calculate new pond geometry
+        if (volpnd > puny) then
+            ! CESM pond area calculation
+            pp = 0.5_WP * pndaspect * aice
+            apondn = (-c1 + sqrt(c1 + 4.0_WP * pp * volpnd / hp1)) / (2.0_WP * pp)
+            apondn = max(puny, min(aice * 0.9_WP, apondn))
+            
+            if (apondn > puny) then
+                hpondn = volpnd / apondn
+                hpondn = max(puny, min(c1, hpondn))  ! Limit pond depth
+            else
+                apondn = c0
+                hpondn = c0
+            endif
+        else
+            apondn = c0
+            hpondn = c0
+            volpnd = c0
+        endif
+        
+        ! Update pond variables
+        apnd = apondn
+        hpnd = hpondn
+        
+        ! Calculate fresh water flux (pond volume change)
+        fpond = (volpnd - volpnd_init) / dt
+        
+        ! Simple pond ice formation/melting (frozen lid)
+        if (meltt < c0 .and. apnd > puny) then
+            ! Freezing conditions - form/thicken pond ice
+            ipnd = ipnd - meltt * dt  ! meltt is negative for freezing
+            ipnd = max(c0, ipnd)
+        else
+            ! Melting conditions - melt pond ice
+            ipnd = max(c0, ipnd + meltt * dt)
+        endif
+        
+    end subroutine meltpond_area
+    
+    !===========================================================================
+    ! Calculate effective albedo including melt pond effects
+    !===========================================================================
+    subroutine meltpond_albedo(aice, hsno, apnd, ipnd, t_sfc, &
+                              albi_dry, albsn_dry, albedo_eff)
+        implicit none
+        
+        ! Input variables
+        real(kind=WP), intent(in) :: aice       ! Ice concentration
+        real(kind=WP), intent(in) :: hsno       ! Snow thickness [m]
+        real(kind=WP), intent(in) :: apnd       ! Pond area fraction
+        real(kind=WP), intent(in) :: ipnd       ! Pond ice thickness [m]
+        real(kind=WP), intent(in) :: t_sfc      ! Surface temperature [K]
+        real(kind=WP), intent(in) :: albi_dry   ! Dry ice albedo
+        real(kind=WP), intent(in) :: albsn_dry  ! Snow albedo
+        
+        ! Output
+        real(kind=WP), intent(out) :: albedo_eff ! Effective albedo
+        
+        ! Local variables
+        real(kind=WP) :: albedo_ice              ! Ice surface albedo
+        real(kind=WP) :: albedo_pond             ! Pond albedo
+        real(kind=WP) :: frac_ice                ! Fraction of ice not covered by ponds
+        real(kind=WP) :: frac_pond               ! Effective pond fraction
+        real(kind=WP) :: frac_open               ! Open water fraction
+        real(kind=WP) :: albw                    ! Open water albedo
+        
+        ! Initialize
+        albw = 0.066_WP  ! Open water albedo
+        
+        if (aice < puny) then
+            albedo_eff = albw
+            return
+        endif
+        
+        ! Determine ice surface albedo (ice or snow)
+        if (hsno > 0.001_WP) then
+            albedo_ice = albsn_dry  ! Snow-covered ice
+        else
+            albedo_ice = albi_dry   ! Bare ice
+        endif
+        
+        ! Determine pond albedo based on pond ice thickness
+        if (ipnd > 0.01_WP) then
+            ! Thick pond ice - use frozen pond albedo
+            albedo_pond = albpnd_frz
+        else
+            ! Thin or no pond ice - use open pond albedo
+            albedo_pond = albpnd
+        endif
+        
+        ! Calculate area fractions
+        frac_pond = min(apnd, aice)  ! Ponds only exist on ice
+        frac_ice = aice - frac_pond   ! Ice not covered by ponds
+        frac_open = c1 - aice         ! Open water
+        
+        ! Weight albedos by area fractions
+        albedo_eff = frac_ice * albedo_ice + &
+                     frac_pond * albedo_pond + &
+                     frac_open * albw
+        
+        ! Ensure reasonable bounds
+        albedo_eff = max(albw, min(0.9_WP, albedo_eff))
+        
+    end subroutine meltpond_albedo
+    
+end module ice_meltponds

--- a/src/ice_thermo_cpl.F90
+++ b/src/ice_thermo_cpl.F90
@@ -175,7 +175,7 @@ subroutine thermodynamics(ice, partit, mesh)
         ! Freezing temp of saltwater in K
         ice_temp(inod) = -0.0575_WP*S_oc_array(inod) + 1.7105e-3_WP*sqrt(S_oc_array(inod)**3) -2.155e-4_WP*(S_oc_array(inod)**2)+273.15_WP        
      endif
-     call ice_albedo(ice%thermo, h, hsn, t, alb)
+     call ice_albedo(ice%thermo, h, hsn, t, apnd(inod), ipnd(inod), alb)
      ice_alb(inod)       = alb
      ice_heat_qres(inod) = qres
      ice_heat_qcon(inod) = qcon
@@ -578,11 +578,13 @@ contains
 ! t=min(273.15_WP,t)
  end subroutine ice_surftemp
 
- subroutine ice_albedo(ithermp, h, hsn, t, alb)
+ subroutine ice_albedo(ithermp, h, hsn, t, apnd_node, ipnd_node, alb)
   ! INPUT:
   ! h      - ice thickness [m]
   ! hsn    - snow thickness [m]
   ! t      - temperature of snow/ice surface [C]
+  ! apnd_node - melt pond area fraction at this node
+  ! ipnd_node - pond ice lid thickness at this node
   ! 
   ! OUTPUT:
   ! alb    - selected broadband albedo (modified for melt ponds)
@@ -591,6 +593,7 @@ contains
   real(kind=WP) :: h
   real(kind=WP) :: hsn    
   real(kind=WP) :: t    
+  real(kind=WP) :: apnd_node, ipnd_node
   real(kind=WP) :: alb
   real(kind=WP) :: geolat
   real(kind=WP), pointer :: albsn, albi, albsnm, albim
@@ -621,8 +624,8 @@ contains
    endif
    
    ! Apply melt pond albedo modification if enabled
-   if (ice%thermo%use_meltponds .and. h > 0.0_WP) then
-       call meltpond_albedo(1.0_WP, hsn, apnd(inod), ipnd(inod), t, &
+   if (ithermp%use_meltponds .and. h > 0.0_WP) then
+       call meltpond_albedo(1.0_WP, hsn, apnd_node, ipnd_node, t, &
                            alb_noponds, alb_noponds, alb)
    else
        alb = alb_noponds

--- a/src/ice_thermo_cpl.F90
+++ b/src/ice_thermo_cpl.F90
@@ -25,6 +25,7 @@ subroutine thermodynamics(ice, partit, mesh)
   use g_forcing_arrays
   use g_comm_auto
   use g_rotate_grid
+  use ice_meltponds
   implicit none
   type(t_ice)   , intent(inout), target :: ice
   type(t_partit), intent(inout), target :: partit
@@ -47,6 +48,8 @@ subroutine thermodynamics(ice, partit, mesh)
   real(kind=WP)  :: rsss
   !---- output variables (computed in `ice_growth')
   real(kind=WP)  :: ehf, fw, rsf, dhgrowth, dhsngrowth, dhflice
+  !---- melt pond variables
+  real(kind=WP)  :: fpond, meltt_rate, melts_rate
 
   !---- geographical coordinates
   real(kind=WP)  :: geolon, geolat
@@ -63,7 +66,9 @@ subroutine thermodynamics(ice, partit, mesh)
   real(kind=WP), dimension(:)  , pointer :: u_ice, v_ice
   real(kind=WP), dimension(:)  , pointer :: a_ice, m_ice, m_snow
   real(kind=WP), dimension(:)  , pointer :: thdgr, thdgrsn
-  real(kind=WP), dimension(:)  , pointer :: a_ice_old, m_ice_old, m_snow_old, thdgr_old 
+  real(kind=WP), dimension(:)  , pointer :: a_ice_old, m_ice_old, m_snow_old, thdgr_old
+  ! melt pond pointers
+  real(kind=WP), dimension(:)  , pointer :: apnd, hpnd, ipnd 
   real(kind=WP), dimension(:)  , pointer :: S_oc_array, T_oc_array, u_w, v_w
   real(kind=WP), dimension(:)  , pointer :: fresh_wa_flux, net_heat_flux
 #if defined (__oifs) || defined (__ifsinterface)
@@ -116,6 +121,10 @@ subroutine thermodynamics(ice, partit, mesh)
   consn         => ice%thermo%consn
   con           => ice%thermo%con
   rhoice        => ice%thermo%rhoice
+  ! melt pond pointer assignments
+  apnd          => ice%thermo%apnd(:)
+  hpnd          => ice%thermo%hpnd(:) 
+  ipnd          => ice%thermo%ipnd(:)
   !_____________________________________________________________________________  
   rsss = ref_sss
 
@@ -458,6 +467,22 @@ contains
     !---- NOTE: ehf = -ohf (in case of no cut-off)
     ehf = -ahf + cl*(dhgrowth + dhsngrowth*rhosno/rhoice) 
 
+    !---- melt pond calculations (if enabled)
+    fpond = 0._WP
+    if (ice%thermo%use_meltponds .and. A > Aimin) then
+        ! Calculate melt rates for pond formation
+        meltt_rate = max(0._WP, -dhgrowth)  ! Top melt rate (negative dhgrowth is melting)
+        melts_rate = max(0._WP, -dhsngrowth) ! Snow melt rate
+        
+        ! Update melt pond area and depth
+        call meltpond_area(A, h, hsn, meltt_rate, melts_rate, dt, &
+                          apnd(inod), hpnd(inod), ipnd(inod), fpond)
+    else
+        apnd(inod) = 0._WP
+        hpnd(inod) = 0._WP
+        ipnd(inod) = 0._WP
+    endif
+
     !---- store ice thickness before flooding (snow to ice conversion)
     htmp = h
 
@@ -560,7 +585,7 @@ contains
   ! t      - temperature of snow/ice surface [C]
   ! 
   ! OUTPUT:
-  ! alb    - selected broadband albedo
+  ! alb    - selected broadband albedo (modified for melt ponds)
   implicit none
   type(t_ice_thermo), intent(in), target :: ithermp
   real(kind=WP) :: h
@@ -569,30 +594,40 @@ contains
   real(kind=WP) :: alb
   real(kind=WP) :: geolat
   real(kind=WP), pointer :: albsn, albi, albsnm, albim
+  real(kind=WP) :: alb_noponds  ! albedo without pond effects
+  
   albsn  => ice%thermo%albsn
   albi   => ice%thermo%albi
   albsnm => ice%thermo%albsnm
   albim  => ice%thermo%albim
   
-  ! set albedo
-  ! ice and snow, freezing and melting conditions are distinguished
+  ! Calculate standard albedo first (without pond effects)
   if (h>0.0_WP) then
      if (t<273.15_WP) then         ! freezing condition    
         if (hsn.gt.0.001_WP) then !   snow cover present  
-           alb=albsn       
+           alb_noponds=albsn       
         else                    !   no snow cover       
-           alb=albi           
+           alb_noponds=albi           
         endif
      else                               ! melting condition     
         if (hsn.gt.0.001_WP) then !   snow cover present  
-           alb=albsnm          
+           alb_noponds=albsnm          
         else                    !   no snow cover       
-           alb=albim
+           alb_noponds=albim
         endif
      endif
    else
-      alb=0.066_WP            !  ocean albedo
+      alb_noponds=0.066_WP            !  ocean albedo
    endif
+   
+   ! Apply melt pond albedo modification if enabled
+   if (ice%thermo%use_meltponds .and. h > 0.0_WP) then
+       call meltpond_albedo(1.0_WP, hsn, apnd(inod), ipnd(inod), t, &
+                           alb_noponds, alb_noponds, alb)
+   else
+       alb = alb_noponds
+   endif
+   
  end subroutine ice_albedo
 
 end subroutine thermodynamics

--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -280,6 +280,19 @@ CASE ('h_ice ')
 CASE ('h_snow    ')
     if (use_ice) then
     call def_stream(nod2D, myDim_nod2D, 'h_snow',   'snow thickness over ice-covered fraction',  'm',     ice%h_snow(1:myDim_nod2D), io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
+    end if
+! Melt pond variables
+CASE ('apnd      ')
+    if (use_ice .and. ice%thermo%use_meltponds) then
+    call def_stream(nod2D, myDim_nod2D, 'apnd',     'melt pond area fraction',                  'frac',  ice%thermo%apnd(1:myDim_nod2D), io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
+    end if
+CASE ('hpnd      ')
+    if (use_ice .and. ice%thermo%use_meltponds) then
+    call def_stream(nod2D, myDim_nod2D, 'hpnd',     'melt pond depth',                          'm',     ice%thermo%hpnd(1:myDim_nod2D), io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
+    end if
+CASE ('ipnd      ')
+    if (use_ice .and. ice%thermo%use_meltponds) then
+    call def_stream(nod2D, myDim_nod2D, 'ipnd',     'melt pond ice lid thickness',              'm',     ice%thermo%ipnd(1:myDim_nod2D), io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
     end if    
 ! Debug ice variables    
 CASE ('strength_ice')


### PR DESCRIPTION
Getting desperate with the NH / SH, cold / warm dipol bias here. 

I decided to try and lift the meltpond scheme from icepack and use it in ice_thermo_cpl. The idea is, that NH should have more meltponds than SH, due to thicker multi year ice and less snow cover. Then I can increase base sea ice albedo values cooling SH and let the meltponds take care of lowering these back down for NH. My hope is that this reduces both issues.

First evaluation from a 4 year long coupled pi spinup run:
<img width="4467" height="2951" alt="monthly_apnd_nh_sh" src="https://github.com/user-attachments/assets/145eb65c-5ba5-4a35-9e4f-a971cb01abf8" />
NH fraction reaches realistic and higher values than SH fraction.
<img width="4467" height="2951" alt="monthly_hpnd_nh_sh" src="https://github.com/user-attachments/assets/5d1bb5d4-89e2-4956-acad-b47b73a3409b" />
Meltpool depth also looks ok.
<img width="4467" height="2951" alt="monthly_ipnd_nh_sh" src="https://github.com/user-attachments/assets/bb871f74-37a1-4a52-a506-3f676968780c" />
Peak at 4m ice lid is a bit much for freezing in one winter imo. But mean values look fine.


Next I will do some longer runs with sea ice albedo output. Also checking the climate impact.