### PR TITLE
Set metric_factor to zero as suggested by Qiang.

### DIFF
--- a/src/oce_mesh.F90
+++ b/src/oce_mesh.F90
@@ -2510,7 +2510,7 @@ t0=MPI_Wtime()
  center_x(n)=ax
  center_y(n)=ay
  mesh%elem_cos(n)=cos(ay)
- mesh%metric_factor=tan(ay)/r_earth
+ mesh%metric_factor(n)=0.0_WP                   ! Suggested by Qiang
  END DO
 
  call exchange_elem(mesh%metric_factor, partit)


### PR DESCRIPTION
<p>This improves the Arctic sea ice thickness distribution in AWI-CM3.</p>
 before vs after
<p float="left">
  <img src="https://github.com/user-attachments/assets/43d98605-78c9-4b67-bce0-31974fb5fced" width="45%" />
  <img src="https://github.com/user-attachments/assets/a28ecedc-7f3c-4630-9e83-30626411f150" width="45%" />
  <img src="https://github.com/user-attachments/assets/78485622-0ef3-4aaa-8bf9-c699469d245f" width="45%" />
  <img src="https://github.com/user-attachments/assets/c876c490-eaee-4f5b-8565-0f1f4ef4c901" width="45%" />
</p>

