### PR TITLE
Bugfix/cavity optimization

### DIFF
--- a/src/fvom_init.F90
+++ b/src/fvom_init.F90
@@ -1187,6 +1187,9 @@ subroutine find_levels_cavity(mesh)
                                         end if 
                                     end if 
                                 end do ! --> do i = 1, nneighb
+                                if (nz == 1) then
+                                    write(*,*) 'WARNING: nz = 1 for element ', elem, ' — Cavity element becomes ocean element!'
+                                end if
                                 ulevels(      elems(idx)) = ulevels(elem)
                                 elemreducelvl(elems(idx)) = .True.
                             end if     


### PR DESCRIPTION
I found a small bug regarding computing the shallowest neighbouring cavity level. The loop did not return the shallowest neighboring cavity level but the level of the **last** neighbor (1,2, or 3) that is shallower - regardless of ocean or cavity element. It now only considers cavity elements (additional statement in the if clause) and returns the shallowest of the neighbors shallower than the processed element (nl exchanged for val). 

In addition, related to #811, I added a warning log output when isolated cavity elements can not be deepened anymore and thus neighboring elements are made shallower and thereby accidentally turned to first active layer == 1, which is unwanted. 