### PR TITLE
Reproducibility bug fix for IFS runs with frequent restarts

### DIFF
--- a/src/io_restart.F90
+++ b/src/io_restart.F90
@@ -252,7 +252,7 @@ subroutine ini_ice_io(ice, partit, mesh)
   call ice_files%def_node_var('hsnow', 'effective snow thickness',  'm',   ice%data(3)%values(:), mesh, partit)
   call ice_files%def_node_var('uice', 'zonal velocity',             'm/s', ice%uice, mesh, partit)
   call ice_files%def_node_var('vice', 'meridional velocity',        'm',   ice%vice, mesh, partit)
-#if defined (__oifs)
+#if defined (__oifs) || defined (__ifsinterface)
   call ice_files%def_node_var_optional('ice_albedo', 'ice albedo',    '-',   ice%atmcoupl%ice_alb, mesh, partit)
   call ice_files%def_node_var_optional('ice_temp', 'ice surface temperature',  'K',   ice%data(4)%values, mesh, partit)
 #endif /* (__oifs) */


### PR DESCRIPTION
Sea-ice surface temperature (and, less importantly, sea-ice albedo) were not properly restarted and were instead initialized with default values (265.15 K for the SIT). Each subsequent restart introduced an additional perturbation, which cumulatively resulted in an artificial cooling trend.

You can continue using your old run, as the new variables are declared optional. Just restart using NetCDF.