### PR TITLE
small fix in the description of the namelist.oce

### DIFF
--- a/config/namelist.oce
+++ b/config/namelist.oce
@@ -64,7 +64,7 @@ Redi_Kmin          = 100.0   ! minimum Redi difusivity thats left when Redi_Ktap
 
 ! --- Vertical Mixing Scheme ---
 visc_sh_limit      = 5.0e-3  ! maximum viscosity due to shear instability [m²/s] (for KPP)
-mix_scheme         = 'KPP'   ! vertical mixing scheme: 'KPP' (K-Profile Parameterization), 'PP' (Pacanowski-Philander), or 'TKE' (Turbulent Kinetic Energy)
+mix_scheme         = 'KPP'   ! vertical mixing scheme: 'KPP' (K-Profile Parameterization), 'PP' (Pacanowski-Philander), or 'cvmix_TKE' (Turbulent Kinetic Energy). For complete list of available shemes look at the oce_setup_step.F90. 
 
 ! --- Convection Parameters ---
 Ricr               = 0.3     ! critical bulk Richardson number (for convection onset)


### PR DESCRIPTION
Just "TKE" was misleading, it is not valid mixing scheme. Available ones are:

```fortran
    select case (trim(mix_scheme))
        case ('KPP'                   ) ; mix_scheme_nmb = 1
        case ('PP'                    ) ; mix_scheme_nmb = 2
#if defined (__cvmix)
        case ('cvmix_KPP'             ) ; mix_scheme_nmb = 3
        case ('cvmix_PP'              ) ; mix_scheme_nmb = 4
        case ('cvmix_TKE'             ) ; mix_scheme_nmb = 5
        case ('cvmix_IDEMIX'          ) ; mix_scheme_nmb = 6
        case ('cvmix_TIDAL'           ) ; mix_scheme_nmb = 7
        case ('KPP+cvmix_TIDAL'       ) ; mix_scheme_nmb = 17
        case ('PP+cvmix_TIDAL'        ) ; mix_scheme_nmb = 27
        case ('cvmix_KPP+cvmix_TIDAL' ) ; mix_scheme_nmb = 37
        case ('cvmix_PP+cvmix_TIDAL'  ) ; mix_scheme_nmb = 47
        case ('cvmix_TKE+cvmix_IDEMIX') ; mix_scheme_nmb = 56
```
But it is too much to put to the namelist description, so I decide to reference the source file instead.