### PR TITLE
Fix blowup not exiting in coupled runs

### DIFF
--- a/src/write_step_info.F90
+++ b/src/write_step_info.F90
@@ -679,7 +679,7 @@ subroutine check_blowup(istep, ice, dynamics, tracers, partit, mesh)
         end if
         call blowup(istep, ice, dynamics, tracers, partit, mesh)
         if (mype==0) write(*,*) ' --> finished writing blow up file'
-        call par_ex(partit%MPI_COMM_FESOM, partit%mype)
+        call par_ex(partit%MPI_COMM_FESOM, partit%mype, abort=1)
     endif 
 end subroutine check_blowup
 !===============================================================================


### PR DESCRIPTION
par_ex() was called without the abort argument after blowup detection. In coupled runs (__oifs), this calls oasis_terminate() which hangs waiting for other model components that don't know FESOM has blown up.

Adding abort=1 forces MPI_ABORT for immediate termination with a non-zero exit code.

Run that hung: /work/bb1469/a270089/runtime/awiesm3-v3.4.1/failed_runs/run_13580101-13591231