### PR TITLE
Fix icepack compilation by adding parameter

### DIFF
--- a/src/io_restart.F90
+++ b/src/io_restart.F90
@@ -335,7 +335,7 @@ subroutine read_initial_conditions(which_readr, ice, dynamics, tracers, partit, 
   call ini_ocean_io(dynamics, tracers, partit, mesh)
   if (use_ice) then
 #if defined(__icepack)    
-      call ini_icepack_io(partit, mesh)
+      call ini_icepack_io(yearold, partit, mesh)
 #else
       call ini_ice_io  (ice, partit, mesh)
 #endif        


### PR DESCRIPTION
Compilation of the latest FESOM with Icepack 'on' was broken due to this missing parameter. I have tested that the software compiles and a simulation can be run and restarted with Icepack.