### PR TITLE
Fix fesom.clock not updating when short segments cross year boundaries

### DIFF
--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -768,7 +768,7 @@ contains
 #if defined (FESOM_PROFILING)
         call fesom_profiler_start("restart")
 #endif
-        call write_initial_conditions(n, nstart, f%total_nsteps, f%which_readr, f%ice, f%dynamics, f%tracers, f%partit, f%mesh)
+        call write_initial_conditions(n, nstart, ntotal, f%which_readr, f%ice, f%dynamics, f%tracers, f%partit, f%mesh)
 #if defined (FESOM_PROFILING)
         call fesom_profiler_end("restart")
 #endif

--- a/src/io_restart.F90
+++ b/src/io_restart.F90
@@ -515,24 +515,23 @@ subroutine write_initial_conditions(istep, nstart, ntotal, which_readr, ice, dyn
   ctime = timeold + (dayold - 1.0_WP) * 86400.0_WP
   
   ! Check whether restart will be written
-  is_portable_restart_write = is_due(trim(restart_length_unit), restart_length, istep)
-  
+  ! Always force a restart at the end of the run segment (istep==ntotal) to ensure
+  ! the clock file and restart files are up to date for the next segment, even when
+  ! short segments cross year boundaries without aligning with the restart schedule.
+  is_portable_restart_write = is_due(trim(restart_length_unit), restart_length, istep) .OR. (istep==ntotal)
+
   ! Should write core dump restart?
   if(is_portable_restart_write .and. (raw_restart_length_unit /= "off")) then
     is_raw_restart_write = .true. ! always write a raw restart together with the portable restart
   else
-#if !defined __ifsinterface
-    is_raw_restart_write = is_due(trim(raw_restart_length_unit), raw_restart_length, istep)
-#else
     is_raw_restart_write = is_due(trim(raw_restart_length_unit), raw_restart_length, istep) .OR. (istep==ntotal)
-#endif
   end if
-  
+
   ! Should write derived type binary restart?
   if(is_portable_restart_write .and. (bin_restart_length_unit /= "off")) then
     is_bin_restart_write = .true. ! always write a binary restart together with the portable restart
   else
-    is_bin_restart_write = is_due(trim(bin_restart_length_unit), bin_restart_length, istep)
+    is_bin_restart_write = is_due(trim(bin_restart_length_unit), bin_restart_length, istep) .OR. (istep==ntotal)
   end if
 
   ! Write restart files


### PR DESCRIPTION
Always write restart files and update the clock at the end of each run segment by adding (istep==ntotal) fallback to all restart type checks in write_initial_conditions. Previously only raw restarts under __ifsinterface had this safeguard, so yearly restart schedules with sub-yearly segments would leave the clock and restart files stale when the segment ended mid-year after crossing a year boundary.

Also pass the actual segment end step (ntotal) from fesom_runloop instead of f%total_nsteps, so the end-of-segment detection is correct for coupled setups where fesom_runloop is called multiple times.

Fixes #879