### PR TITLE
Changes for XIOS3

### DIFF
--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -166,6 +166,16 @@ contains
         call cpl_yac_init(f%partit%MPI_COMM_FESOM)
 #endif
 
+#if defined (__XIOS)
+        ! NEMO pattern: xios_initialize immediately after OASIS init, BEFORE
+        ! par_init / mesh setup. Only xios_initialize here; xios_context_initialize
+        ! (and domain/axis defs) run later in io_xios_init once the mesh is ready.
+        block
+          integer :: xios_client_comm_early
+          call io_xios_init_client(f%partit%MPI_COMM_FESOM, xios_client_comm_early)
+        end block
+#endif
+
         f%t1 = MPI_Wtime()
 
         ! Initialize enhanced profiler
@@ -943,17 +953,6 @@ contains
     mean_rtime(1:14) = mean_rtime(1:14) / real(f%npes,real32)
     call MPI_AllREDUCE(MPI_IN_PLACE, max_rtime,  14, MPI_REAL, MPI_MAX, f%MPI_COMM_FESOM, f%MPIerr)
     call MPI_AllREDUCE(MPI_IN_PLACE, min_rtime,  14, MPI_REAL, MPI_MIN, f%MPI_COMM_FESOM, f%MPIerr)
-    
-#if defined (__XIOS)
-   ! Must finalize XIOS BEFORE MPI/OASIS teardown so server2 receives
-   ! the client-finalize signal on MPI_COMM_WORLD (matches NEMO/OIFS).
-   call io_xios_close()
-#endif
-
-#if defined (__oifs)
-    ! OpenIFS coupled version has to call oasis_terminate through par_ex
-    call par_ex(f%partit%MPI_COMM_FESOM, f%partit%mype)
-#endif
 
 #if defined(__MULTIO) && !defined(__ifsinterface) && !defined(__oasis)
    call mpp_stop
@@ -965,7 +964,12 @@ contains
         ! Note: Do NOT call fesom_profiler_finalize here as it would duplicate the report
 #endif
     
-    if(f%fesom_did_mpi_init) call par_ex(f%partit%MPI_COMM_FESOM, f%partit%mype) ! finalize MPI before FESOM prints its stats block, otherwise there is sometimes output from other processes from an earlier time in the programm AFTER the starts block (with parastationMPI)
+#if !defined(__oifs)
+    ! Standalone / ECHAM coupling: finalize MPI before stats printing to avoid
+    ! interleaved output from other processes with parastationMPI. For __oifs we
+    ! defer MPI teardown to the very end (matches NEMO's cpl_finalize pattern).
+    if(f%fesom_did_mpi_init) call par_ex(f%partit%MPI_COMM_FESOM, f%partit%mype)
+#endif
     if (f%mype==0) then
         41 format (a35,a10,2a15) !Format for table heading
         42 format (a30,3f15.4)   !Format for table content
@@ -1003,9 +1007,24 @@ contains
         print 45, '    Runtime for all timesteps :  ',f%runtime_alltimesteps,' sec'
         write(*,*) '======================================================'
         write(*,*)
-    end if    
-!   call clock_finish  
-    
+    end if
+!   call clock_finish
+
+#if defined (__oifs)
+    ! OpenIFS coupled: tear down XIOS and OASIS/MPI as the LAST things in the
+    ! subroutine. Matches NEMO's nemogcm.F90 pattern where xios_finalize and
+    ! cpl_finalize are the final calls before STOP 0. Avoids post-MPI_Finalize
+    ! work (profiler, Fortran stats printing) from tripping over library
+    ! destructors / pmix shutdown after MPI_COMM_WORLD has been finalized
+    ! through oasis_terminate inside par_ex.
+#if defined (__XIOS)
+    ! XIOS must finalize BEFORE oasis_terminate so server2 receives the
+    ! client-finalize signal on MPI_COMM_WORLD.
+    call io_xios_close()
+#endif
+    call par_ex(f%partit%MPI_COMM_FESOM, f%partit%mype)
+#endif
+
     ! Enhanced profiler is already finalized above before MPI finalization
   end subroutine fesom_finalize
 

--- a/src/io_xios.F90
+++ b/src/io_xios.F90
@@ -35,7 +35,7 @@ module io_xios_module
   implicit none
   private
 
-  public :: io_xios_init, io_xios_close
+  public :: io_xios_init_client, io_xios_init, io_xios_close
   public :: io_xios_update_calendar
   public :: io_xios_send_2d_r8, io_xios_send_3d_r8
   public :: io_xios_send_2d_r4, io_xios_send_3d_r4
@@ -104,7 +104,27 @@ contains
   end function
 
 
-  !> Initialise the XIOS client side.
+  !> First stage of XIOS client init: just xios_initialize.
+  !> Must be called immediately after OASIS init (cpl_oasis3mct_init), before
+  !> par_init / mesh setup. Matches NEMO's nemogcm.F90 pattern:
+  !>   CALL cpl_init("oceanx", ilocal_comm)
+  !>   CALL xios_initialize("oceanx", local_comm=ilocal_comm)  ! right away
+  !>   CALL mpp_start(ilocal_comm)                             ! par_init equiv
+  !>   ... (lots of init) ...
+  !>   CALL iom_init(...)                                      ! calls xios_context_initialize
+  !> Splitting xios_initialize from xios_context_initialize (which is still in
+  !> io_xios_init below) lets the XIOS server complete its own client-side
+  !> registration before the context leader announcements. Running them
+  !> back-to-back caused a deadlock on the EC-Earth v4.1.7 XIOS snapshot.
+  subroutine io_xios_init_client(parent_comm, client_comm)
+    integer, intent(in)  :: parent_comm
+    integer, intent(out) :: client_comm
+
+    call xios_initialize("fesom", local_comm=parent_comm)
+    client_comm = parent_comm    ! OASIS already split; keep API compat
+  end subroutine io_xios_init_client
+
+  !> Second stage of XIOS client init: context + domain/axis setup.
   !> parent_comm:  the FESOM OASIS local communicator (partit%MPI_COMM_FESOM).
   !> client_comm:  returned equal to parent_comm (kept for API compat; OASIS
   !>               has already done the world split, so no further split here).
@@ -137,7 +157,13 @@ contains
     end block
     init_call_count = init_call_count + 1
 
-    call xios_initialize("fesom", local_comm=parent_comm)
+    ! xios_initialize is now done earlier via io_xios_init_client (called right
+    ! after cpl_oasis3mct_init, matching NEMO's nemogcm.F90 pattern where
+    ! xios_initialize fires immediately after cpl_init, before mpp_start /
+    ! mesh setup). Calling xios_initialize and xios_context_initialize
+    ! back-to-back here caused the XIOS server to hang in
+    ! createServerContextIntercomm on the EC-Earth v4.1.7 XIOS (dd74653e)
+    ! snapshot, which doesn't tolerate the rapid sequence.
     client_comm = parent_comm    ! OASIS already split; keep API compat
 
     ! --- 2. open the context on the FESOM communicator -----------------------


### PR DESCRIPTION
Split xios_initialize (new io_xios_init_client) from xios_context_initialize and call the client stage right after OASIS init (NEMO pattern). Running both back-to-back deadlocked the XIOS server in createServerContextIntercomm on the EC-Earth v4.1.7 XIOS (dd74653e); interleaving par_init / mesh setup lets the server finish registering first.

Under __oifs, move io_xios_close + par_ex to the very end of fesom_finalize so no Fortran stats / profiler work runs after oasis_terminate finalizes MPI_COMM_WORLD. Non-__oifs ordering unchanged.