### PR TITLE
Re-established some albedo IO-optimizations from #400

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,12 @@ else()
    set(FESOM_PLATFORM_STRATEGY "notset" CACHE STRING "switch to platform specific compile settings, this is usually determined via the env.sh script")
 endif()
 
+if(DEFINED ENV{ENABLE_ALBEDO_INTELMPI_WORKAROUNDS}) # be able to set the initial cache value from our env settings for albedo, not only via cmake command
+   option(ALBEDO_INTELMPI_WORKAROUNDS "workaround for performance issues on albedo" ON)
+else()
+   option(ALBEDO_INTELMPI_WORKAROUNDS "workaround for performance issues on albedo" OFF)
+endif()
+
 # Cray compiler specific optimizations
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Cray")
    # Use alternative cray-mpich library, about 5% faster with cray-mpich/7.7.3
@@ -36,6 +42,11 @@ if(DEFINED DISABLE_MULTITHREADING)
 endif()
 
 #TODO: these machine specific block can easyly go in cmake toolchain.
+if(ALBEDO_INTELMPI_WORKAROUNDS)
+   add_compile_options(-DENABLE_ALBEDO_INTELMPI_WORKAROUNDS)
+   #SH add_compile_options(-DDISABLE_PARALLEL_RESTART_READ)
+endif()
+
 if    (${FESOM_PLATFORM_STRATEGY} STREQUAL levante.dkrz.de )
    option(ASYNCHRONOUS_IO_THREADS "enable asynchronous I/O threads" OFF)
 elseif(${FESOM_PLATFORM_STRATEGY} STREQUAL leo-dcgp )

--- a/src/info_module.F90
+++ b/src/info_module.F90
@@ -76,7 +76,14 @@ contains
       print '(g0)', 'VERBOSE is ON'
 #else
       print '(g0)', 'VERBOSE is OFF'
-#endif  
+#endif
+
+#ifdef ENABLE_ALBEDO_INTELMPI_WORKAROUNDS
+      print '(g0)', 'ENABLE_ALBEDO_INTELMPI_WORKAROUNDS is ON'
+#else
+      print '(g0)', 'ENABLE_ALBEDO_INTELMPI_WORKAROUNDS is OFF'
+#endif
+      
 #ifdef ENABLE_NVHPC_WORKAROUNDS
       print '(g0)', 'ENABLE_NVHPC_WORKAROUNDS is ON'
 #else

--- a/src/io_fesom_file.F90
+++ b/src/io_fesom_file.F90
@@ -221,6 +221,11 @@ contains
       end if
 
       do lvl=1, nlvl
+
+#ifdef ENABLE_ALBEDO_INTELMPI_WORKAROUNDS
+        call MPI_Barrier(this%comm, mpierr)
+#endif
+
         if(this%is_iorank()) then
           t_start = MPI_Wtime()
           if(is_2d) then
@@ -313,6 +318,11 @@ contains
       end if
 
       do lvl=1, nlvl
+
+#ifdef ENABLE_ALBEDO_INTELMPI_WORKAROUNDS
+        call MPI_Barrier(this%comm, mpierr)        
+#endif
+
         ! the data from our pointer is not contiguous (if it is 3D data), so we can not pass the pointer directly to MPI
         laux = var%local_data_copy(lvl,:) ! todo: remove this buffer and pass the data directly to MPI (change order of data layout to be levelwise or do not gather levelwise but by columns)
 

--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -3990,6 +3990,11 @@ subroutine write_mean(entry, entry_index)
         ! loop over vertical layers --> do gather 3d variables layerwise in 2d
         ! slices
         do lev=1, size1
+
+#ifdef ENABLE_ALBEDO_INTELMPI_WORKAROUNDS     
+            call MPI_Barrier(entry%comm, mpierr)
+#endif
+
             !___________________________________________________________________
             ! local output variables are gahtered in 2d shaped entry%aux_r8 
             ! either for vertices or elements
@@ -4026,6 +4031,11 @@ subroutine write_mean(entry, entry_index)
         ! loop over vertical layers --> do gather 3d variables layerwise in 2d
         ! slices
         do lev=1, size1
+
+#ifdef ENABLE_ALBEDO_INTELMPI_WORKAROUNDS     
+            call MPI_Barrier(entry%comm, mpierr)
+#endif
+
             !PS if (entry%p_partit%mype==entry%root_rank) t0=MPI_Wtime()  
             !___________________________________________________________________
             ! local output variables are gahtered in 2d shaped entry%aux_r8 


### PR DESCRIPTION
This PR does re-establish some of the changes dealing with IO issues on albedo that were included in the branch refactoring_albedo_env, see #400.

These entries are not present in Fesom 2.7, however, experiments on albedo show much more regular behavior across the cores in the output phases of the model if Intel compiler and Intel MPI are used (Settings in env/albedo/shell). Especially the MPI_Barriers in the source code io_meandata.F90 seem to be relevant in this respect

As an example here the output timings for an experiment on 2592 cores on albedo:

Original:
___MODEL RUNTIME per task [seconds]_____mean____________min____________max_

  runtime output:                     15.7956         0.6689      3588.7000
  runtime restart:                    42.7859         0.0435      6165.9058

 ================ BENCHMARK RUNTIME ===================
    Number of cores :                       2592
    Runtime for all timesteps :        6181.1978 sec


After re-establishing the entries for ENABLE_ALBEDO_INTELMPI_WORKAROUNDS:

___MODEL RUNTIME per task [seconds]_____mean____________min____________max_

  runtime output:                    456.7661       456.5835       457.6900
  runtime restart:                    30.9291        30.0464        30.9496

 ================ BENCHMARK RUNTIME ===================
    Number of cores :                       2592
    Runtime for all timesteps :         502.2796 sec


This behavior was tested in several experiments and was so far reproducible, however not yet with other compilers or OpenMPI. We suggest to consider to re-insert the flags in other branches. Path to the experiments:
/albedo/work/user/sharig/f27_r31_dev/config/bin_fesom2.7_lrg/

@mandresm 