### PR TITLE
Don't force raw/bin restart at segment end when unit is 'off'

### DIFF
--- a/src/io_restart.F90
+++ b/src/io_restart.F90
@@ -521,17 +521,24 @@ subroutine write_initial_conditions(istep, nstart, ntotal, which_readr, ice, dyn
   is_portable_restart_write = is_due(trim(restart_length_unit), restart_length, istep) .OR. (istep==ntotal)
 
   ! Should write core dump restart?
+  ! Gate the segment-end fallback on the raw restart being configured at all;
+  ! otherwise we trigger a write into a directory that was never mkdir'd
+  ! (the init block is skipped when raw_restart_length_unit == "off").
   if(is_portable_restart_write .and. (raw_restart_length_unit /= "off")) then
     is_raw_restart_write = .true. ! always write a raw restart together with the portable restart
-  else
+  else if(raw_restart_length_unit /= "off") then
     is_raw_restart_write = is_due(trim(raw_restart_length_unit), raw_restart_length, istep) .OR. (istep==ntotal)
+  else
+    is_raw_restart_write = .false.
   end if
 
   ! Should write derived type binary restart?
   if(is_portable_restart_write .and. (bin_restart_length_unit /= "off")) then
     is_bin_restart_write = .true. ! always write a binary restart together with the portable restart
-  else
+  else if(bin_restart_length_unit /= "off") then
     is_bin_restart_write = is_due(trim(bin_restart_length_unit), bin_restart_length, istep) .OR. (istep==ntotal)
+  else
+    is_bin_restart_write = .false.
   end if
 
   ! Write restart files


### PR DESCRIPTION
Fixes a regression introduced in #880 (commit 28e51ddf) that causes `forrtl: No such file or directory` on every FESOM PE rank at the first run-segment end when the user has `raw_restart_length_unit = 'off'` (and/or `bin_restart_length_unit = 'off'`).

## Root cause

`write_initial_conditions` splits restart initialization (mkdir) from the restart-write decision:

```fortran
if(.not. initialized_raw) then
    initialized_raw = .true.
    if(raw_restart_length_unit /= "off") then     ! <-- gated
        if(partit%mype == RAW_RESTART_METADATA_RANK) then
            call mkdir(build_raw_restart_dirpath(RestartOutPath))
            call mkdir(write_raw_dirpath)
        end if
        call MPI_Barrier(partit%MPI_COMM_FESOM, mpierr)
    end if
end if
```

After #880 the segment-end fallback at the top of the routine is not gated:

```fortran
else
    is_raw_restart_write = is_due(trim(raw_restart_length_unit), raw_restart_length, istep) .OR. (istep==ntotal)
end if
```

So with `raw_restart_length_unit = 'off'`:
- the init block skips the mkdir (directory is never created),
- but at `istep==ntotal` the `.OR.` fallback flips `is_raw_restart_write` to `.true.`,
- `write_all_raw_restarts` then opens files under a non-existent directory → `No such file or directory`.

Same shape for `is_bin_restart_write`.

## Fix

Gate the segment-end fallback on the corresponding `*_restart_length_unit /= "off"`, mirroring the mkdir init block. When the unit is `"off"` the restart type is treated as disabled and the segment-end fallback does nothing. Portable (netCDF) restarts are unaffected and still covered by the existing `is_portable_restart_write` fallback.

## Reproducer

On DKRZ Levante, AWI-ESM3 CORE2 setup with a 1-year run segment and:

```
&restart_log
    restart_length = 1
    restart_length_unit = 'y'
    raw_restart_length_unit = 'off'
    bin_restart_length_unit = 'off'
    restartflag = 'last'
/
```

Observed on 768 FESOM ranks: all 15 iorank `mkdir` calls for the NetCDF restart dir succeed, OIFS completes the full year (`STEPO 8760`), XIOS servers are active, and then 743 FESOM ranks simultaneously print `forrtl: No such file or directory` at the first `annual_event TRIGGERED` with `do_output=T`. No other diagnostic is printed; the job is killed by the esm_tools observer shortly after.

A previous 10-year run on the same setup (`cmip7_output_017`, built before 28e51ddf) was not affected — same source, same config otherwise.

