### PR TITLE
Write error/warning messages to stderr and flush before MPI exit

### DIFF
--- a/src/gen_modules_partitioning.F90
+++ b/src/gen_modules_partitioning.F90
@@ -85,6 +85,7 @@ subroutine par_init(partit)    ! initializes MPI
 end subroutine par_init
 !=================================================================
 subroutine par_ex(COMM, mype, abort)       ! finalizes MPI
+  use iso_fortran_env, only: output_unit, error_unit
   use MOD_PARTIT
 
 ! In case we are letting oasis orchestrate MPI, we need to shut down through
@@ -107,7 +108,10 @@ subroutine par_ex(COMM, mype, abort)       ! finalizes MPI
   integer, optional, intent(in)   :: abort
   integer                         :: error
 
- 
+  ! flush stdout and stderr so that error messages are visible before MPI_ABORT
+  flush(output_unit)
+  flush(error_unit)
+
 ! For standalone runs we
 ! when there is error par_ex should be called with abort argument to abort abruptly,
 ! in all other cases model will be finalized here, call the MPI_barrier and MPI_finalize

--- a/src/gen_surface_forcing.F90
+++ b/src/gen_surface_forcing.F90
@@ -33,6 +33,7 @@ MODULE g_sbf
    !!   sbc_ini  -- initialization atmpospheric forcing
    !!   sbc_do   -- provide a sbc (surface boundary conditions) each time step
    !!
+   USE iso_fortran_env, only: error_unit
    USE MOD_MESH
    USE MOD_PARTIT
    USE MOD_PARSUP
@@ -414,17 +415,17 @@ CONTAINS
             (trim(flf%calendar).eq.'noleap') .or. &
             (trim(flf%calendar).eq.'365_days')) then
             if (include_fleapyear .eqv. .true.) then
-                print *, achar(27)//'[33m'
-                write(*,*) '____________________________________________________________'
-                write(*,*) ' WARNING: It looks like you want to use CORE forcing, Right?'
-                write(*,*) '          but setted include_fleapyear=.true.. CORE forcing '
-                write(*,*) '          does not contain any leap years or particular '
-                write(*,*) '          calender option (julian, gregorian). So if im right,'
-                write(*,*) '          please go to namelist.config and set '
-                write(*,*) '          include_fleapyear=.false. otherwise comment this '
-                write(*,*) '          message block in gen_surface_forcing.F90.'
-                write(*,*) '____________________________________________________________'
-                print *, achar(27)//'[0m'
+                write(error_unit,*) achar(27)//'[33m'
+                write(error_unit,*) '____________________________________________________________'
+                write(error_unit,*) ' WARNING: It looks like you want to use CORE forcing, Right?'
+                write(error_unit,*) '          but setted include_fleapyear=.true.. CORE forcing '
+                write(error_unit,*) '          does not contain any leap years or particular '
+                write(error_unit,*) '          calender option (julian, gregorian). So if im right,'
+                write(error_unit,*) '          please go to namelist.config and set '
+                write(error_unit,*) '          include_fleapyear=.false. otherwise comment this '
+                write(error_unit,*) '          message block in gen_surface_forcing.F90.'
+                write(error_unit,*) '____________________________________________________________'
+                write(error_unit,*) achar(27)//'[0m'
                 call par_ex(partit%MPI_COMM_FESOM, partit%mype, 0)
             end if
         elseif ((trim(flf%calendar).eq.'julian')    .or. &
@@ -432,39 +433,39 @@ CONTAINS
                 (trim(flf%calendar).eq.'proleptic_gregorian') .or. &
                 (trim(flf%calendar).eq.'standard')) then
             if (include_fleapyear .eqv. .false.) then
-                print *, achar(27)//'[33m'
-                write(*,*) '____________________________________________________________'
-                write(*,*) ' WARNING: It looks like you want to use either JRA55, ERA,'
-                write(*,*) '          NCEP or a similar forcing, Right?, but setted '
-                write(*,*) '          include_fleapyear=.false. JRA55, ERA or NCEP contain'
-                write(*,*) '          all fleapyears and use a specific calendar option '
-                write(*,*) '          (julian, gregorian). So that the calendars in FESOM2.0'
-                write(*,*) '          work properly, when using these forcings '
-                write(*,*) '          include_fleapyear must be true. So if im right, please go'
-                write(*,*) '          to namelist.config and set include_fleapyear=.true. '
-                write(*,*) '          otherwise comment this message block in'
-                write(*,*) '          gen_surface_forcing.F90'
-                write(*,*) '____________________________________________________________'
-                print *, achar(27)//'[0m'
+                write(error_unit,*) achar(27)//'[33m'
+                write(error_unit,*) '____________________________________________________________'
+                write(error_unit,*) ' WARNING: It looks like you want to use either JRA55, ERA,'
+                write(error_unit,*) '          NCEP or a similar forcing, Right?, but setted '
+                write(error_unit,*) '          include_fleapyear=.false. JRA55, ERA or NCEP contain'
+                write(error_unit,*) '          all fleapyears and use a specific calendar option '
+                write(error_unit,*) '          (julian, gregorian). So that the calendars in FESOM2.0'
+                write(error_unit,*) '          work properly, when using these forcings '
+                write(error_unit,*) '          include_fleapyear must be true. So if im right, please go'
+                write(error_unit,*) '          to namelist.config and set include_fleapyear=.true. '
+                write(error_unit,*) '          otherwise comment this message block in'
+                write(error_unit,*) '          gen_surface_forcing.F90'
+                write(error_unit,*) '____________________________________________________________'
+                write(error_unit,*) achar(27)//'[0m'
                 call par_ex(partit%MPI_COMM_FESOM, partit%mype, 0)
             end if 
         else
-            print *, achar(27)//'[31m'
-            write(*,*) '____________________________________________________________'
-            write(*,*) ' ERROR: I am not familiar with the found calendar option,'
-            write(*,*) '        dont know what to do. Either talk to the FESOM2 developers'
-            write(*,*) '        or add the calendar option by your self in ...'
-            write(*,*) '        gen_surface_forcing.F90, line:364-367'
-            write(*,*) '                                                            '
-            write(*,*) '        elseif ((trim(flf%calendar).eq."julian")      .or. &'
-            write(*,*) '                (trim(flf%calendar).eq."gregorian")   .or. &'
-            write(*,*) '                (trim(flf%calendar).eq."NEW_CALENDAR").or. &'
-            write(*,*) '                (trim(flf%calendar).eq."standard")) then    '
-            write(*,*) '                                                            '
-            write(*,*) '        The time axis calendar attribute can be checked for '
-            write(*,*) '        example with ncdump -h forcing_file.nc '
-            write(*,*) '____________________________________________________________'
-            print *, achar(27)//'[0m'
+            write(error_unit,*) achar(27)//'[31m'
+            write(error_unit,*) '____________________________________________________________'
+            write(error_unit,*) ' ERROR: I am not familiar with the found calendar option,'
+            write(error_unit,*) '        dont know what to do. Either talk to the FESOM2 developers'
+            write(error_unit,*) '        or add the calendar option by your self in ...'
+            write(error_unit,*) '        gen_surface_forcing.F90, line:364-367'
+            write(error_unit,*) '                                                            '
+            write(error_unit,*) '        elseif ((trim(flf%calendar).eq."julian")      .or. &'
+            write(error_unit,*) '                (trim(flf%calendar).eq."gregorian")   .or. &'
+            write(error_unit,*) '                (trim(flf%calendar).eq."NEW_CALENDAR").or. &'
+            write(error_unit,*) '                (trim(flf%calendar).eq."standard")) then    '
+            write(error_unit,*) '                                                            '
+            write(error_unit,*) '        The time axis calendar attribute can be checked for '
+            write(error_unit,*) '        example with ncdump -h forcing_file.nc '
+            write(error_unit,*) '____________________________________________________________'
+            write(error_unit,*) achar(27)//'[0m'
             call par_ex(partit%MPI_COMM_FESOM, partit%mype, 0)
         end if ! --> if ((trim(flf%calendar).eq.'none')   .or. & ...
     end if !--> if (partit%mype==0 .and. use_flpyrcheck) then
@@ -826,18 +827,20 @@ CONTAINS
          t_indx_p1 = t_indx
          delta_t = 1.0_wp
          if (mype==0) then
-            write(*,*) 'WARNING: no temporal extrapolation into future (nearest neighbour is used): ', trim(var_name), ' !'
-            write(*,*) trim(file_name)
-            write(*,*) nc_time(1), nc_time(nc_Ntime), now_date
+            write(error_unit,*) 'WARNING: no temporal extrapolation into future (nearest neighbour is used): ', trim(var_name), ' !'
+            write(error_unit,*) trim(file_name)
+            write(error_unit,*) nc_time(1), nc_time(nc_Ntime), now_date
+            flush(error_unit)
          end if
       elseif (t_indx < 1) then ! NO extrapolation back in time
          t_indx = 1
          t_indx_p1 = t_indx
          delta_t = 1.0_wp
          if (mype==0) then 
-            write(*,*) 'WARNING: no temporal extrapolation back in time (nearest neighbour is used): ', trim(var_name), ' !'
-            write(*,*) trim(file_name)
-            write(*,*) nc_time(1), nc_time(nc_Ntime), now_date
+            write(error_unit,*) 'WARNING: no temporal extrapolation back in time (nearest neighbour is used): ', trim(var_name), ' !'
+            write(error_unit,*) trim(file_name)
+            write(error_unit,*) nc_time(1), nc_time(nc_Ntime), now_date
+            flush(error_unit)
          end if
       end if
 
@@ -1063,7 +1066,7 @@ CONTAINS
       if (iost == 0) then
          if (mype==0) WRITE(*,*) '     file   : ', 'namelist.forcing',' open ok'
       else
-         if (mype==0) WRITE(*,*) 'ERROR: --> bad opening file   : ', 'namelist.forcing',' ; iostat=',iost
+         if (mype==0) WRITE(error_unit,*) 'ERROR: --> bad opening file   : ', 'namelist.forcing',' ; iostat=',iost
          call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
       endif
       READ( nm_sbc_unit, nml=nam_sbc, iostat=iost )
@@ -1221,38 +1224,38 @@ CONTAINS
             inquire(file=make_full_path(nm_sss_data_file), exist=file_exist) 
             if ( .not. file_exist) then   
                 if (mype==0) then
-                    write(*,*)
-                    print *, achar(27)//'[33m'
-                    write(*,*) '____________________________________________________________________'
-                    write(*,*) ' ERROR: file not found: ', trim(make_full_path(nm_sss_data_file))
-                    write(*,*) '        --> check your namelist.focing'
-                    write(*,*) '            ...'
-                    write(*,*) '            nm_sss_data_file    =...'
-                    write(*,*) '            ...'
-                    write(*,*) '____________________________________________________________________'
-                    print *, achar(27)//'[0m'
-                    write(*,*)
+                    write(error_unit,*)
+                    write(error_unit,*) achar(27)//'[33m'
+                    write(error_unit,*) '____________________________________________________________________'
+                    write(error_unit,*) ' ERROR: file not found: ', trim(make_full_path(nm_sss_data_file))
+                    write(error_unit,*) '        --> check your namelist.focing'
+                    write(error_unit,*) '            ...'
+                    write(error_unit,*) '            nm_sss_data_file    =...'
+                    write(error_unit,*) '            ...'
+                    write(error_unit,*) '____________________________________________________________________'
+                    write(error_unit,*) achar(27)//'[0m'
+                    write(error_unit,*)
                 end if
                 call par_ex(partit%MPI_COMM_FESOM, partit%mype, 0)
             end if
             
         else
             if (mype==0) then
-            write(*,*)
-                print *, achar(27)//'[33m'
-                write(*,*) '____________________________________________________________________'
-                write(*,*) ' ERROR: you choose an unknown sss_data_source ! '
-                write(*,*) '        currently supported is only sss_data_soure=:'
-                write(*,*) '        - ''CORE1'' or ''CORE2'': for monthly SSS climatology'
-                write(*,*) ''
-                write(*,*) '        --> please check your namelist.forcing'
-                write(*,*) '            ...'
-                write(*,*) '            sss_data_source=...'
-                write(*,*) '            nm_sss_file    =...'
-                write(*,*) '            ...'
-                write(*,*) '____________________________________________________________________'
-                print *, achar(27)//'[0m'
-                write(*,*)
+            write(error_unit,*)
+                write(error_unit,*) achar(27)//'[33m'
+                write(error_unit,*) '____________________________________________________________________'
+                write(error_unit,*) ' ERROR: you choose an unknown sss_data_source ! '
+                write(error_unit,*) '        currently supported is only sss_data_soure=:'
+                write(error_unit,*) '        - ''CORE1'' or ''CORE2'': for monthly SSS climatology'
+                write(error_unit,*) ''
+                write(error_unit,*) '        --> please check your namelist.forcing'
+                write(error_unit,*) '            ...'
+                write(error_unit,*) '            sss_data_source=...'
+                write(error_unit,*) '            nm_sss_file    =...'
+                write(error_unit,*) '            ...'
+                write(error_unit,*) '____________________________________________________________________'
+                write(error_unit,*) achar(27)//'[0m'
+                write(error_unit,*)
             end if
             call par_ex(partit%MPI_COMM_FESOM, partit%mype, 0)
         
@@ -1282,22 +1285,22 @@ CONTAINS
             
         else
             if (mype==0) then
-                write(*,*)
-                print *, achar(27)//'[31m'
-                write(*,*) '____________________________________________________________________'
-                write(*,*) ' ERROR: file not found: ', trim(make_full_path(nm_runoff_file))
-                write(*,*) '        --> check your namelist.focing'
-                write(*,*) '            ...'
-                write(*,*) '            nm_runoff_file    =...'
-                write(*,*) '            ...'
-                write(*,*) '____________________________________________________________________'
-                print *, achar(27)//'[0m'
-                write(*,*)
+                write(error_unit,*)
+                write(error_unit,*) achar(27)//'[31m'
+                write(error_unit,*) '____________________________________________________________________'
+                write(error_unit,*) ' ERROR: file not found: ', trim(make_full_path(nm_runoff_file))
+                write(error_unit,*) '        --> check your namelist.focing'
+                write(error_unit,*) '            ...'
+                write(error_unit,*) '            nm_runoff_file    =...'
+                write(error_unit,*) '            ...'
+                write(error_unit,*) '____________________________________________________________________'
+                write(error_unit,*) achar(27)//'[0m'
+                write(error_unit,*)
             end if
             call par_ex(partit%MPI_COMM_FESOM, partit%mype, 0)
-                            
+
         end if
-        
+
     elseif (runoff_data_source=='Dai09' .or. runoff_data_source=='JRA55') then 
         if (mype==0) then 
             write(*,*) ' --> using monthly runoff climatology (12 time slices) '
@@ -1314,46 +1317,46 @@ CONTAINS
         inquire(file=make_full_path(nm_runoff_file), exist=file_exist) 
         if ( .not. file_exist .and. runoff_climatology) then   
             if (mype==0) then
-                write(*,*)
-                print *, achar(27)//'[31m'
-                write(*,*) '____________________________________________________________________'
-                write(*,*) ' ERROR: file not found: ', trim(make_full_path(nm_runoff_file))
-                write(*,*) '        --> check your namelist.focing'
-                write(*,*) '            ...'
-                write(*,*) '            nm_runoff_file    =...'
-                write(*,*) '            ...'
-                write(*,*) '____________________________________________________________________'
-                print *, achar(27)//'[0m'
-                write(*,*)
+                write(error_unit,*)
+                write(error_unit,*) achar(27)//'[31m'
+                write(error_unit,*) '____________________________________________________________________'
+                write(error_unit,*) ' ERROR: file not found: ', trim(make_full_path(nm_runoff_file))
+                write(error_unit,*) '        --> check your namelist.focing'
+                write(error_unit,*) '            ...'
+                write(error_unit,*) '            nm_runoff_file    =...'
+                write(error_unit,*) '            ...'
+                write(error_unit,*) '____________________________________________________________________'
+                write(error_unit,*) achar(27)//'[0m'
+                write(error_unit,*)
             end if
             call par_ex(partit%MPI_COMM_FESOM, partit%mype, 0)
-                            
+
         end if
-        
+
     else
         if (mype==0) then
-            write(*,*)
-            print *, achar(27)//'[31m'
-            write(*,*) '____________________________________________________________________'
-            write(*,*) ' ERROR: you choose an unknown runoff_data_source ! '
-            write(*,*) '        supported is only runoff_data_soure=:'
-            write(*,*) '        - ''CORE1'' or ''CORE2'': for longterm climatology (only one timeslice for the entire simulation)  '
-            write(*,*) '        - ''JRA55'' or ''Dai09'': for monthly climatology (each month has a different runoff timeslice,    ' 
-            write(*,*) '                                  this can be done as a monthly climatology (runoff_climatology=.true.) or '
-            write(*,*) '                                  as a transient monthly climatology (runoff_climatology=.false.) than each'
-            write(*,*) '                                  month and each year have differnt runoff'
-            write(*,*) ''
-            write(*,*) '        --> please check your namelist.forcing'
-            write(*,*) '            ...'
-            write(*,*) '            runoff_data_source=...'
-            write(*,*) '            nm_runoff_file    =...'
-            write(*,*) '            ...'
-            write(*,*) '____________________________________________________________________'
-            print *, achar(27)//'[0m'
-            write(*,*)
+            write(error_unit,*)
+            write(error_unit,*) achar(27)//'[31m'
+            write(error_unit,*) '____________________________________________________________________'
+            write(error_unit,*) ' ERROR: you choose an unknown runoff_data_source ! '
+            write(error_unit,*) '        supported is only runoff_data_soure=:'
+            write(error_unit,*) '        - ''CORE1'' or ''CORE2'': for longterm climatology (only one timeslice for the entire simulation)  '
+            write(error_unit,*) '        - ''JRA55'' or ''Dai09'': for monthly climatology (each month has a different runoff timeslice,    '
+            write(error_unit,*) '                                  this can be done as a monthly climatology (runoff_climatology=.true.) or '
+            write(error_unit,*) '                                  as a transient monthly climatology (runoff_climatology=.false.) than each'
+            write(error_unit,*) '                                  month and each year have differnt runoff'
+            write(error_unit,*) ''
+            write(error_unit,*) '        --> please check your namelist.forcing'
+            write(error_unit,*) '            ...'
+            write(error_unit,*) '            runoff_data_source=...'
+            write(error_unit,*) '            nm_runoff_file    =...'
+            write(error_unit,*) '            ...'
+            write(error_unit,*) '____________________________________________________________________'
+            write(error_unit,*) achar(27)//'[0m'
+            write(error_unit,*)
         end if
         call par_ex(partit%MPI_COMM_FESOM, partit%mype, 0)
-        
+
     end if   
     
     !___________________________________________________________________________
@@ -1373,50 +1376,51 @@ CONTAINS
                 end if    
             else 
                 if (mype==0) then
-                    write(*,*)
-                    print *, achar(27)//'[31m'
-                    write(*,*) '____________________________________________________________________'
-                    write(*,*) ' ERROR: file not found: ', make_full_path(nm_chl_data_file)
-                    write(*,*) '        --> check your namelist.focing'
-                    write(*,*) '            ...'
-                    write(*,*) '            chl_data_source  =...'
-                    write(*,*) '            nm_chl_data_file =...'
-                    write(*,*) '            ...'
-                    write(*,*) '____________________________________________________________________'
-                    print *, achar(27)//'[0m'
-                    write(*,*)
+                    write(error_unit,*)
+                    write(error_unit,*) achar(27)//'[31m'
+                    write(error_unit,*) '____________________________________________________________________'
+                    write(error_unit,*) ' ERROR: file not found: ', make_full_path(nm_chl_data_file)
+                    write(error_unit,*) '        --> check your namelist.focing'
+                    write(error_unit,*) '            ...'
+                    write(error_unit,*) '            chl_data_source  =...'
+                    write(error_unit,*) '            nm_chl_data_file =...'
+                    write(error_unit,*) '            ...'
+                    write(error_unit,*) '____________________________________________________________________'
+                    write(error_unit,*) achar(27)//'[0m'
+                    write(error_unit,*)
                 end if
                 call par_ex(partit%MPI_COMM_FESOM, partit%mype, 0)
                 
             end if 
         elseif (chl_data_source == 'Const.' .or. chl_data_source == 'None') then
             if (mype==0) then 
-                print *, achar(27)//'[33m'
-                write(*,*) ' --> you will use short-wave penetration with constant chlorophyll concentration: ', chl_const
-                write(*,*) '     Are you sure about this??? Usually the shortwave penetration will run better with Sweeney'
-                write(*,*) '     heterogenous chlorophyl climatology. So set chl_data_source=''Sweeney'' and nm_chl_data_file=... '
-                write(*,*) '     chl_data_source =', trim(chl_data_source)
-                print *, achar(27)//'[0m'
+                write(error_unit,*) achar(27)//'[33m'
+                write(error_unit,*) ' --> you will use short-wave penetration with constant chlorophyll concentration: ', chl_const
+                write(error_unit,*) '     Are you sure about this??? Usually the shortwave penetration will run better with Sweeney'
+                write(error_unit,*) '     heterogenous chlorophyl climatology. So set chl_data_source=''Sweeney'' and nm_chl_data_file=... '
+                write(error_unit,*) '     chl_data_source =', trim(chl_data_source)
+                write(error_unit,*) achar(27)//'[0m'
+                flush(error_unit)
             end if     
             chl=chl_const
             
         else
             if (mype==0) then
-                write(*,*)
-                print *, achar(27)//'[31m'
-                write(*,*) '____________________________________________________________________'
-                write(*,*) ' ERROR: you choose an unknown chl_data_source ! '
-                write(*,*) '        supported is only chl_data_source=:'
-                write(*,*) '        - ''Sweeney''            : use Sweeney chlorophyl climatology'
-                write(*,*) '        - ''Const.'' or ''None'' : use constant chlorophyl value of chl_const=',chl_const
-                write(*,*) ''
-                write(*,*) '        --> please check your namelist.forcing'
-                write(*,*) '            ...'
-                write(*,*) '            chl_data_source=...'
-                write(*,*) '            ...'
-                write(*,*) '____________________________________________________________________'
-                print *, achar(27)//'[0m'
-                write(*,*)
+                write(error_unit,*)
+                write(error_unit,*) achar(27)//'[31m'
+                write(error_unit,*) '____________________________________________________________________'
+                write(error_unit,*) ' ERROR: you choose an unknown chl_data_source ! '
+                write(error_unit,*) '        supported is only chl_data_source=:'
+                write(error_unit,*) '        - ''Sweeney''            : use Sweeney chlorophyl climatology'
+                write(error_unit,*) '        - ''Const.'' or ''None'' : use constant chlorophyl value of chl_const=',chl_const
+                write(error_unit,*) ''
+                write(error_unit,*) '        --> please check your namelist.forcing'
+                write(error_unit,*) '            ...'
+                write(error_unit,*) '            chl_data_source=...'
+                write(error_unit,*) '            ...'
+                write(error_unit,*) '____________________________________________________________________'
+                write(error_unit,*) achar(27)//'[0m'
+                write(error_unit,*)
             end if
             call par_ex(partit%MPI_COMM_FESOM, partit%mype, 0)
             
@@ -1433,7 +1437,7 @@ CONTAINS
         if (iost == 0) then
             if (mype==0) WRITE(*,*) '     file   : ', 'namelist.recom for sbc',' open ok'
         else
-            if (mype==0) WRITE(*,*) 'ERROR: --> bad opening file   : ', 'namelist.recom for sbc',' ; iostat=',iost
+            if (mype==0) WRITE(error_unit,*) 'ERROR: --> bad opening file   : ', 'namelist.recom for sbc',' ; iostat=',iost
             call par_ex(partit%MPI_COMM_FESOM, partit%mype)
             stop
         endif
@@ -1634,18 +1638,18 @@ CONTAINS
                 inquire(file=filename, exist=file_exist) 
                 if (.not. file_exist) then   
                     if (mype==0) then
-                        write(*,*)
-                        print *, achar(27)//'[31m'
-                        write(*,*) '____________________________________________________________________'
-                        write(*,*) ' ERROR: file not found: ',trim(filename)
-                        write(*,*) '        --> check your namelist.focing'
-                        write(*,*) '            ...'
-                        write(*,*) '            nm_runoff_file    =...'
-                        write(*,*) '            ...'
-                        write(*,*) '____________________________________________________________________'
-                        print *, achar(27)//'[0m'
-                        write(*,*)
-                    end if 
+                        write(error_unit,*)
+                        write(error_unit,*) achar(27)//'[31m'
+                        write(error_unit,*) '____________________________________________________________________'
+                        write(error_unit,*) ' ERROR: file not found: ',trim(filename)
+                        write(error_unit,*) '        --> check your namelist.focing'
+                        write(error_unit,*) '            ...'
+                        write(error_unit,*) '            nm_runoff_file    =...'
+                        write(error_unit,*) '            ...'
+                        write(error_unit,*) '____________________________________________________________________'
+                        write(error_unit,*) achar(27)//'[0m'
+                        write(error_unit,*)
+                    end if
                     call par_ex(partit%MPI_COMM_FESOM, partit%mype, 0)
                 end if 
             
@@ -1714,8 +1718,8 @@ if (recom_debug .and. mype==0) print *, achar(27)//'[36m'//'     --> Atm_input'/
             ! open file
             status=nf90_open(filename, nf90_nowrite, ncid)
             if (status.ne.nf90_noerr)then
-                print*,'ERROR: CANNOT READ CO2 FILE CORRECTLY !!!!!'
-                print*,'Error in opening netcdf file '//filename
+                write(error_unit,*) 'ERROR: CANNOT READ CO2 FILE CORRECTLY !!!!!'
+                write(error_unit,*) 'Error in opening netcdf file '//filename
                 call par_ex(MPI_COMM_FESOM, mype)
                 stop
             endif
@@ -2225,7 +2229,7 @@ if (recom_debug .and. mype==0) print *, achar(27)//'[36m'//'     --> Atm_input'/
       integer, intent(in)                            :: iost
 
       if (iost .ne. NF90_NOERR) then
-         write(*,*) 'ERROR: I/O status= "',trim(nf90_strerror(iost)),'";',iost,' file= ',fname
+         write(error_unit,*) 'ERROR: I/O status= "',trim(nf90_strerror(iost)),'";',iost,' file= ',fname
          call par_ex(partit%MPI_COMM_FESOM, partit%mype)
          stop
       endif
@@ -3149,12 +3153,12 @@ subroutine read_runoff_mapper(file, vari, R, partit, mesh)
  
    call MPI_BCast(status, 1, MPI_INTEGER, 0, MPI_COMM_FESOM, ierror)
    if (status.ne.nf90_noerr)then
-      print*,'ERROR: CANNOT READ 2D netCDF FILE CORRECTLY !!!!!'
-      print*,'Error in opening netcdf file '//file
+      write(error_unit,*) 'ERROR: CANNOT READ 2D netCDF FILE CORRECTLY !!!!!'
+      write(error_unit,*) 'Error in opening netcdf file '//file
       call par_ex(partit%MPI_COMM_FESOM, partit%mype)
       stop
    endif
- 
+
    if (mype==0) then
       ! lat
       status=nf90_inq_dimid(ncid, 'lat', latid)
@@ -3270,8 +3274,8 @@ subroutine read_runoff_mapper(file, vari, R, partit, mesh)
 
    if (status/=number_arrival_points) then
       if (mype==0) then
-         write(*,*) 'RUNOFF MAPPER ERROR: total number of arrival points does not sum up among partitions: ', status, number_arrival_points
-         write(*,*) 'two different grid points have same distance to a target point!'
+         write(error_unit,*) 'RUNOFF MAPPER ERROR: total number of arrival points does not sum up among partitions: ', status, number_arrival_points
+         write(error_unit,*) 'two different grid points have same distance to a target point!'
       end if
       call par_ex(partit%MPI_COMM_FESOM, partit%mype)
       STOP
@@ -3300,8 +3304,8 @@ subroutine read_runoff_mapper(file, vari, R, partit, mesh)
          j=data_sparse(i)
          if ((j<0) .OR. (j>drain_num)) then
             if (mype==0) then
-               write(*,*) 'RUNOFF MAPPER ERROR: arrival point has an index outside of permitted range', j, drain_num
-               write(*,*) 'two different grid points have same distance to a target point!'
+               write(error_unit,*) 'RUNOFF MAPPER ERROR: arrival point has an index outside of permitted range', j, drain_num
+               write(error_unit,*) 'two different grid points have same distance to a target point!'
             end if
             call par_ex(partit%MPI_COMM_FESOM, partit%mype)
             STOP


### PR DESCRIPTION
Error messages written to stdout were lost when par_ex called MPI_ABORT before the output buffer was flushed. With this we write all ERROR/WARNING messages in `gen_surface_forcing.F90` to stderr    instead of stdout (stderror is not buffered). And also, add flushing of both stdout and stderr at the top of par_ex so that all pending output is visible regardless of which stream was used. 
This was a problem on LUMI with cray compiler, with intel is has not been a problem so far. I'd like also the other error messages to go to stderr and not stdout, but for now it's only in `gen_surface_forcing.F90`.