### PR TITLE
Fix restart written every coupling step under __ifsinterface

### DIFF
--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -788,7 +788,14 @@ contains
 #if defined (FESOM_PROFILING)
         call fesom_profiler_start("restart")
 #endif
-        call write_initial_conditions(n, nstart, ntotal, f%which_readr, f%ice, f%dynamics, f%tracers, f%partit, f%mesh)
+        ! Pass f%total_nsteps (namelist run length) as the segment-end marker
+        ! rather than the runloop-chunk end (ntotal). In standalone FESOM they
+        ! are identical (fesom_runloop is called once with all steps), so the
+        ! year-boundary fix from PR #880 still fires. Under __ifsinterface,
+        ! fesom_runloop is called per IFS coupling step with a small chunk, so
+        ! ntotal == istep on every call; using it as the segment-end marker
+        ! would force a restart every coupling timestep.
+        call write_initial_conditions(n, nstart, f%total_nsteps, f%which_readr, f%ice, f%dynamics, f%tracers, f%partit, f%mesh)
 #if defined (FESOM_PROFILING)
         call fesom_profiler_end("restart")
 #endif


### PR DESCRIPTION
PR #880 (commit 28e51ddf) changed write_initial_conditions's segment-end marker from f%total_nsteps to the runloop-chunk end (ntotal). In standalone FESOM the two are identical (fesom_runloop is called once with all steps and from_nstep=1), so the year-boundary fallback from that PR still fires. But under __ifsinterface, fesom_runloop is called per IFS coupling step with a small substeps chunk, so ntotal == istep at the end of every call, forcing a restart write every coupling timestep.

Pass f%total_nsteps again so the (istep==ntotal) fallback only fires at the namelist-defined segment end. Standalone behavior is unchanged; under __ifsinterface FESOM never organically reaches f%total_nsteps (IFS drives the loop), so the fallback correctly stays silent and restarts revert to pure is_due cadence.

Preserves the fix for #879.