### PR TITLE
io: expose dMOC density-coordinate axis to XIOS, skip wet-mask on density-class 3D fields

### DIFF
--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -2390,6 +2390,7 @@ end subroutine
 subroutine write_mean(entry, entry_index)
     use mod_mesh
     use io_gather_module
+    use diagnostics, only: std_dens_N
     implicit none
     type(Meandata), intent(inout) :: entry
     integer, intent(in) :: entry_index
@@ -2431,7 +2432,7 @@ subroutine write_mean(entry, entry_index)
                 do k=1, n_own
                   do kk=1, nze; tmp3_r8(kk,k) = entry%local_values_r8_copy(kk, own(k)); end do
                 end do
-                call io_xios_apply_wet_3d_elem_r8(tmp3_r8)
+                if (nze /= std_dens_N) call io_xios_apply_wet_3d_elem_r8(tmp3_r8)
                 call io_xios_send_3d_r8(entry%name, tmp3_r8)
                 deallocate(tmp3_r8)
               end if
@@ -2452,7 +2453,7 @@ subroutine write_mean(entry, entry_index)
                 do k=1, n_own
                   do kk=1, nze; tmp3_r4(kk,k) = entry%local_values_r4_copy(kk, own(k)); end do
                 end do
-                call io_xios_apply_wet_3d_elem_r4(tmp3_r4)
+                if (nze /= std_dens_N) call io_xios_apply_wet_3d_elem_r4(tmp3_r4)
                 call io_xios_send_3d_r4(entry%name, tmp3_r4)
                 deallocate(tmp3_r4)
               end if
@@ -2461,7 +2462,9 @@ subroutine write_mean(entry, entry_index)
             if (entry%accuracy == i_real8) then
               if (entry%glsize(1) == 1) then
                 allocate(tmp2_r8(entry%p_partit%myDim_nod2D))
-                tmp2_r8(:) = entry%local_values_r8_copy(1, 1:entry%p_partit%myDim_nod2D)
+                do k=1, entry%p_partit%myDim_nod2D
+                  tmp2_r8(k) = entry%local_values_r8_copy(1, k)
+                end do
                 if (io_xios_is_ice_field(entry%name)) then
                    call io_xios_apply_ice_mask_2d_r8(tmp2_r8)
                 else
@@ -2472,15 +2475,19 @@ subroutine write_mean(entry, entry_index)
               else
                 nze = size(entry%local_values_r8_copy, 1)
                 allocate(tmp3_r8(nze, entry%p_partit%myDim_nod2D))
-                tmp3_r8(:,:) = entry%local_values_r8_copy(:, 1:entry%p_partit%myDim_nod2D)
-                call io_xios_apply_wet_3d_r8(tmp3_r8)
+                do k=1, entry%p_partit%myDim_nod2D
+                  do kk=1, nze; tmp3_r8(kk,k) = entry%local_values_r8_copy(kk, k); end do
+                end do
+                if (nze /= std_dens_N) call io_xios_apply_wet_3d_r8(tmp3_r8)
                 call io_xios_send_3d_r8(entry%name, tmp3_r8)
                 deallocate(tmp3_r8)
               end if
             else
               if (entry%glsize(1) == 1) then
                 allocate(tmp2_r4(entry%p_partit%myDim_nod2D))
-                tmp2_r4(:) = entry%local_values_r4_copy(1, 1:entry%p_partit%myDim_nod2D)
+                do k=1, entry%p_partit%myDim_nod2D
+                  tmp2_r4(k) = entry%local_values_r4_copy(1, k)
+                end do
                 if (io_xios_is_ice_field(entry%name)) then
                    call io_xios_apply_ice_mask_2d_r4(tmp2_r4)
                 else
@@ -2491,8 +2498,10 @@ subroutine write_mean(entry, entry_index)
               else
                 nze = size(entry%local_values_r4_copy, 1)
                 allocate(tmp3_r4(nze, entry%p_partit%myDim_nod2D))
-                tmp3_r4(:,:) = entry%local_values_r4_copy(:, 1:entry%p_partit%myDim_nod2D)
-                call io_xios_apply_wet_3d_r4(tmp3_r4)
+                do k=1, entry%p_partit%myDim_nod2D
+                  do kk=1, nze; tmp3_r4(kk,k) = entry%local_values_r4_copy(kk, k); end do
+                end do
+                if (nze /= std_dens_N) call io_xios_apply_wet_3d_r4(tmp3_r4)
                 call io_xios_send_3d_r4(entry%name, tmp3_r4)
                 deallocate(tmp3_r4)
               end if

--- a/src/io_xios.F90
+++ b/src/io_xios.F90
@@ -30,7 +30,8 @@ module io_xios_module
                                   ldiag_dMOC, ldiag_DVD, ldiag_forc,     &
                                   ldiag_extflds, ldiag_destine,          &
                                   ldiag_ice, ldiag_trflx,                &
-                                  ldiag_uvw_sqr, ldiag_trgrd_xyz
+                                  ldiag_uvw_sqr, ldiag_trgrd_xyz,        &
+                                  std_dens_N, std_dens
   use cmor_variables_diag,  only: ldiag_cmor
   implicit none
   private
@@ -267,9 +268,10 @@ contains
     do i = 1, nz_cell
        z_mid(i) = -0.5_WP * (mesh%zbar(i) + mesh%zbar(i+1))
     end do
-    call xios_set_axis_attr("nz",  n_glo = nz_cell, value = z_mid)
+    call xios_set_axis_attr("nz",      n_glo = nz_cell,    value = z_mid)
     deallocate(z_mid)
-    call xios_set_axis_attr("nz1", n_glo = mesh%nl, value = -mesh%zbar(1:mesh%nl))
+    call xios_set_axis_attr("nz1",     n_glo = mesh%nl,    value = -mesh%zbar(1:mesh%nl))
+    call xios_set_axis_attr("std_dens", n_glo = std_dens_N, value = std_dens)
 
     ! --- 7. timestep (required by XIOS before close_context_definition) -----
     call xios_set_timestep(timestep = xios_duration(second = dt))


### PR DESCRIPTION
## Summary

- **`io_xios`**: register the `std_dens` axis (sigma_2 density classes) at context init via `xios_set_axis_attr`, alongside the existing `nz` / `nz1`. Pulls `std_dens_N` and `std_dens` from the `diagnostics` module so XIOS knows the axis length and bin values without the model having to issue them at runtime.
- **`io_meandata.write_mean`**: when `nze == std_dens_N`, skip the `io_xios_apply_wet_3d_*` calls. Density-class fields (`std_dens_DIV` / `std_dens_H` / `std_dens_Z` produced by dMOC) are not on the geometric vertical grid; the wet-cell mask keyed off `ulevels_nod` / `nlevels_nod` would otherwise fill valid density bins with `NC_FILL`.
- Same hunks rewrite the surrounding whole-array `local_values_*_copy(:, 1:myDim_nod2D)` assignments as explicit do-loops on the owned-node range. Needed because the outer allocate is `myDim_nod2D` while the source array's stride was implicit; the loop form is what lets the `if (nze /= std_dens_N)` branch sit cleanly next to the wet-mask call without changing the per-cell semantics for non-density fields.

