### PR TITLE
Drive FESOM xios_send_field cadence from XIOS XML via xios_field_is_active

### DIFF
--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -847,7 +847,10 @@ contains
     use mpp_io
 #endif
     ! EO parameters
-    real(kind=real32) :: mean_rtime(15), max_rtime(15), min_rtime(15)
+    ! 1..15 are the existing FESOM timers (ocean components, ice, output, etc.)
+    ! 16..20 are the io_meandata sub-decomposition: update_means, streamloop,
+    ! pack, mask, xsend (see rtime_om_* in io_meandata.F90).
+    real(kind=real32) :: mean_rtime(20), max_rtime(20), min_rtime(20)
     integer           :: tr_num
     
     ! Start finalization profiling
@@ -935,8 +938,21 @@ contains
 #if defined (__recom)
     mean_rtime(15) = f%rtime_compute_recom
 #endif
+    ! Sub-decomposition of rtime_write_means (= mean_rtime(12)):
+    ! (16) update_means accumulator cost (per step, every step)
+    ! (17) per-stream loop in output() (incl. write_mean dispatch)
+    ! (18) Fortran tmp2/tmp3 nested-loop pack from local_values_*_copy
+    ! (19) io_xios_apply_wet_* / apply_ice_mask_* full-array scans
+    ! (20) pure xios_send_field call wall (post-gate, the actual XIOS pipeline)
+    mean_rtime(16) = real(rtime_om_update_means, real32)
+    mean_rtime(17) = real(rtime_om_streamloop,   real32)
+    mean_rtime(18) = real(rtime_om_pack,         real32)
+    mean_rtime(19) = real(rtime_om_mask,         real32)
+    mean_rtime(20) = real(rtime_om_xsend,        real32)
     max_rtime(1:14) = mean_rtime(1:14)
     min_rtime(1:14) = mean_rtime(1:14)
+    max_rtime(16:20) = mean_rtime(16:20)
+    min_rtime(16:20) = mean_rtime(16:20)
 #if defined (__recom)
     max_rtime(15) = mean_rtime(15)
     min_rtime(15) = mean_rtime(15)
@@ -950,7 +966,15 @@ contains
     mean_rtime(1:14) = mean_rtime(1:14) / real(f%npes,real32)
     call MPI_AllREDUCE(MPI_IN_PLACE, max_rtime,  14, MPI_REAL, MPI_MAX, f%MPI_COMM_FESOM, f%MPIerr)
     call MPI_AllREDUCE(MPI_IN_PLACE, min_rtime,  14, MPI_REAL, MPI_MIN, f%MPI_COMM_FESOM, f%MPIerr)
-    
+    ! Sub-decomposition of write_means: indices (16)..(20)
+    call MPI_AllREDUCE(MPI_IN_PLACE, mean_rtime(16), 5, MPI_REAL, MPI_SUM, f%MPI_COMM_FESOM, f%MPIerr)
+    mean_rtime(16:20) = mean_rtime(16:20) / real(f%npes,real32)
+    call MPI_AllREDUCE(MPI_IN_PLACE, max_rtime(16),  5, MPI_REAL, MPI_MAX, f%MPI_COMM_FESOM, f%MPIerr)
+    call MPI_AllREDUCE(MPI_IN_PLACE, min_rtime(16),  5, MPI_REAL, MPI_MIN, f%MPI_COMM_FESOM, f%MPIerr)
+
+    ! Per-stream cumulative cost — printed sorted at finalize from rank 0.
+    call print_per_stream_costs(f%partit%MPI_COMM_FESOM, f%partit%mype, f%npes)
+
 #if defined (__XIOS)
    ! Must finalize XIOS BEFORE MPI/OASIS teardown so server2 receives
    ! the client-finalize signal on MPI_COMM_WORLD (matches NEMO/OIFS).
@@ -989,6 +1013,11 @@ contains
         print 42, '    > runtime ice step :      ',    mean_rtime(8),     min_rtime(8),      max_rtime(8)
         print 42, '  runtime diag:               ',    mean_rtime(11),    min_rtime(11),     max_rtime(11)
         print 42, '  runtime output:             ',    mean_rtime(12),    min_rtime(12),     max_rtime(12)
+        print 42, '    > out: update_means       ',    mean_rtime(16),    min_rtime(16),     max_rtime(16)
+        print 42, '    > out: streamloop         ',    mean_rtime(17),    min_rtime(17),     max_rtime(17)
+        print 42, '    > out:   pack             ',    mean_rtime(18),    min_rtime(18),     max_rtime(18)
+        print 42, '    > out:   mask             ',    mean_rtime(19),    min_rtime(19),     max_rtime(19)
+        print 42, '    > out:   xsend            ',    mean_rtime(20),    min_rtime(20),     max_rtime(20)
         print 42, '  runtime restart:            ',    mean_rtime(13),    min_rtime(13),     max_rtime(13)
         print 42, '  runtime forcing:            ',    mean_rtime(14),    min_rtime(14),     max_rtime(14)
         print 42, '  runtime total (ice+oce):    ',    mean_rtime(9),     min_rtime(9),      max_rtime(9)

--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -28,6 +28,16 @@ module io_MEANDATA
   implicit none
   private
   public :: def_stream, def_stream2D, def_stream3D, def_stream0D, output, finalize_output
+  public :: print_per_stream_costs
+
+  ! Sub-decomposition timers for FESOM `output`. Accumulated per-rank by the
+  ! output() routine; reduced + printed once at finalize from fesom_module.
+  ! Cost is one MPI_Wtime() pair per region per call — negligible.
+  real(WP), public, save :: rtime_om_update_means = 0.0_WP   !< update_means accumulator (every step)
+  real(WP), public, save :: rtime_om_streamloop   = 0.0_WP   !< per-stream loop incl. write_mean dispatch
+  real(WP), public, save :: rtime_om_pack         = 0.0_WP   !< Fortran nested-loop pack from local_values_*_copy → tmp2/tmp3
+  real(WP), public, save :: rtime_om_mask         = 0.0_WP   !< io_xios_apply_wet_* / apply_ice_mask_* full-array scans
+  real(WP), public, save :: rtime_om_xsend        = 0.0_WP   !< pure io_xios_send_* (xios_send_field) call
 !
 !--------------------------------------------------------------------------------------------
 !
@@ -63,6 +73,7 @@ module io_MEANDATA
     integer                                            :: dimID(2), dimvarID(2), varID
     integer                                            :: freq=1
     character                                          :: freq_unit='m'
+    real(kind=WP)                                      :: rtime_per_stream=0._WP   !< cumulative wall in this stream's write_mean dispatch over the run; printed sorted at finalize
     logical                                            :: is_in_use=.false.
     logical :: is_elem_based = .false.
     logical :: flip
@@ -2419,97 +2430,146 @@ subroutine write_mean(entry, entry_index)
           integer, pointer :: own(:)
           real(real64), allocatable :: tmp2_r8(:), tmp3_r8(:,:)
           real(real32), allocatable :: tmp2_r4(:), tmp3_r4(:,:)
+          real(WP) :: tp0, tp1, tm0, tm1, ts0, ts1
           if (entry%is_elem_based) then
             own   => io_xios_owned_elem_local()
             n_own =  io_xios_n_owned_elem()
             if (entry%accuracy == i_real8) then
               if (entry%glsize(1) == 1) then
+                tp0 = MPI_Wtime()
                 allocate(tmp2_r8(n_own))
                 do k=1, n_own; tmp2_r8(k) = entry%local_values_r8_copy(1, own(k)); end do
+                tp1 = MPI_Wtime(); rtime_om_pack = rtime_om_pack + (tp1 - tp0)
+                tm0 = MPI_Wtime()
                 if (io_xios_is_ice_field(entry%name)) then
                    call io_xios_apply_ice_mask_2d_elem_r8(tmp2_r8)
                 else
                    call io_xios_apply_wet_2d_elem_r8(tmp2_r8)
                 end if
+                tm1 = MPI_Wtime(); rtime_om_mask = rtime_om_mask + (tm1 - tm0)
+                ts0 = MPI_Wtime()
                 call io_xios_send_2d_r8(entry%name, tmp2_r8)
+                ts1 = MPI_Wtime(); rtime_om_xsend = rtime_om_xsend + (ts1 - ts0)
                 deallocate(tmp2_r8)
               else
+                tp0 = MPI_Wtime()
                 nze = size(entry%local_values_r8_copy, 1)
                 allocate(tmp3_r8(nze, n_own))
                 do k=1, n_own
                   do kk=1, nze; tmp3_r8(kk,k) = entry%local_values_r8_copy(kk, own(k)); end do
                 end do
+                tp1 = MPI_Wtime(); rtime_om_pack = rtime_om_pack + (tp1 - tp0)
+                tm0 = MPI_Wtime()
                 if (nze /= std_dens_N) call io_xios_apply_wet_3d_elem_r8(tmp3_r8)
+                tm1 = MPI_Wtime(); rtime_om_mask = rtime_om_mask + (tm1 - tm0)
+                ts0 = MPI_Wtime()
                 call io_xios_send_3d_r8(entry%name, tmp3_r8)
+                ts1 = MPI_Wtime(); rtime_om_xsend = rtime_om_xsend + (ts1 - ts0)
                 deallocate(tmp3_r8)
               end if
             else
               if (entry%glsize(1) == 1) then
+                tp0 = MPI_Wtime()
                 allocate(tmp2_r4(n_own))
                 do k=1, n_own; tmp2_r4(k) = entry%local_values_r4_copy(1, own(k)); end do
+                tp1 = MPI_Wtime(); rtime_om_pack = rtime_om_pack + (tp1 - tp0)
+                tm0 = MPI_Wtime()
                 if (io_xios_is_ice_field(entry%name)) then
                    call io_xios_apply_ice_mask_2d_elem_r4(tmp2_r4)
                 else
                    call io_xios_apply_wet_2d_elem_r4(tmp2_r4)
                 end if
+                tm1 = MPI_Wtime(); rtime_om_mask = rtime_om_mask + (tm1 - tm0)
+                ts0 = MPI_Wtime()
                 call io_xios_send_2d_r4(entry%name, tmp2_r4)
+                ts1 = MPI_Wtime(); rtime_om_xsend = rtime_om_xsend + (ts1 - ts0)
                 deallocate(tmp2_r4)
               else
+                tp0 = MPI_Wtime()
                 nze = size(entry%local_values_r4_copy, 1)
                 allocate(tmp3_r4(nze, n_own))
                 do k=1, n_own
                   do kk=1, nze; tmp3_r4(kk,k) = entry%local_values_r4_copy(kk, own(k)); end do
                 end do
+                tp1 = MPI_Wtime(); rtime_om_pack = rtime_om_pack + (tp1 - tp0)
+                tm0 = MPI_Wtime()
                 if (nze /= std_dens_N) call io_xios_apply_wet_3d_elem_r4(tmp3_r4)
+                tm1 = MPI_Wtime(); rtime_om_mask = rtime_om_mask + (tm1 - tm0)
+                ts0 = MPI_Wtime()
                 call io_xios_send_3d_r4(entry%name, tmp3_r4)
+                ts1 = MPI_Wtime(); rtime_om_xsend = rtime_om_xsend + (ts1 - ts0)
                 deallocate(tmp3_r4)
               end if
             end if
           else
             if (entry%accuracy == i_real8) then
               if (entry%glsize(1) == 1) then
+                tp0 = MPI_Wtime()
                 allocate(tmp2_r8(entry%p_partit%myDim_nod2D))
                 do k=1, entry%p_partit%myDim_nod2D
                   tmp2_r8(k) = entry%local_values_r8_copy(1, k)
                 end do
+                tp1 = MPI_Wtime(); rtime_om_pack = rtime_om_pack + (tp1 - tp0)
+                tm0 = MPI_Wtime()
                 if (io_xios_is_ice_field(entry%name)) then
                    call io_xios_apply_ice_mask_2d_r8(tmp2_r8)
                 else
                    call io_xios_apply_wet_2d_r8(tmp2_r8)
                 end if
+                tm1 = MPI_Wtime(); rtime_om_mask = rtime_om_mask + (tm1 - tm0)
+                ts0 = MPI_Wtime()
                 call io_xios_send_2d_r8(entry%name, tmp2_r8)
+                ts1 = MPI_Wtime(); rtime_om_xsend = rtime_om_xsend + (ts1 - ts0)
                 deallocate(tmp2_r8)
               else
+                tp0 = MPI_Wtime()
                 nze = size(entry%local_values_r8_copy, 1)
                 allocate(tmp3_r8(nze, entry%p_partit%myDim_nod2D))
                 do k=1, entry%p_partit%myDim_nod2D
                   do kk=1, nze; tmp3_r8(kk,k) = entry%local_values_r8_copy(kk, k); end do
                 end do
+                tp1 = MPI_Wtime(); rtime_om_pack = rtime_om_pack + (tp1 - tp0)
+                tm0 = MPI_Wtime()
                 if (nze /= std_dens_N) call io_xios_apply_wet_3d_r8(tmp3_r8)
+                tm1 = MPI_Wtime(); rtime_om_mask = rtime_om_mask + (tm1 - tm0)
+                ts0 = MPI_Wtime()
                 call io_xios_send_3d_r8(entry%name, tmp3_r8)
+                ts1 = MPI_Wtime(); rtime_om_xsend = rtime_om_xsend + (ts1 - ts0)
                 deallocate(tmp3_r8)
               end if
             else
               if (entry%glsize(1) == 1) then
+                tp0 = MPI_Wtime()
                 allocate(tmp2_r4(entry%p_partit%myDim_nod2D))
                 do k=1, entry%p_partit%myDim_nod2D
                   tmp2_r4(k) = entry%local_values_r4_copy(1, k)
                 end do
+                tp1 = MPI_Wtime(); rtime_om_pack = rtime_om_pack + (tp1 - tp0)
+                tm0 = MPI_Wtime()
                 if (io_xios_is_ice_field(entry%name)) then
                    call io_xios_apply_ice_mask_2d_r4(tmp2_r4)
                 else
                    call io_xios_apply_wet_2d_r4(tmp2_r4)
                 end if
+                tm1 = MPI_Wtime(); rtime_om_mask = rtime_om_mask + (tm1 - tm0)
+                ts0 = MPI_Wtime()
                 call io_xios_send_2d_r4(entry%name, tmp2_r4)
+                ts1 = MPI_Wtime(); rtime_om_xsend = rtime_om_xsend + (ts1 - ts0)
                 deallocate(tmp2_r4)
               else
+                tp0 = MPI_Wtime()
                 nze = size(entry%local_values_r4_copy, 1)
                 allocate(tmp3_r4(nze, entry%p_partit%myDim_nod2D))
                 do k=1, entry%p_partit%myDim_nod2D
                   do kk=1, nze; tmp3_r4(kk,k) = entry%local_values_r4_copy(kk, k); end do
                 end do
+                tp1 = MPI_Wtime(); rtime_om_pack = rtime_om_pack + (tp1 - tp0)
+                tm0 = MPI_Wtime()
                 if (nze /= std_dens_N) call io_xios_apply_wet_3d_r4(tmp3_r4)
+                tm1 = MPI_Wtime(); rtime_om_mask = rtime_om_mask + (tm1 - tm0)
+                ts0 = MPI_Wtime()
                 call io_xios_send_3d_r4(entry%name, tmp3_r4)
+                ts1 = MPI_Wtime(); rtime_om_xsend = rtime_om_xsend + (ts1 - ts0)
                 deallocate(tmp3_r4)
               end if
             end if
@@ -2729,8 +2789,14 @@ ctime=timeold+(dayold-1.)*86400
     end if ! --> if (lfirst) then
     
     !___________________________________________________________________________
-    !PS if (partit%flag_debug .and. partit%mype==0)  print *, achar(27)//'[33m'//' -I/O-> call update_means'//achar(27)//'[0m'  
-    call update_means
+    !PS if (partit%flag_debug .and. partit%mype==0)  print *, achar(27)//'[33m'//' -I/O-> call update_means'//achar(27)//'[0m'
+    block
+      real(WP) :: tum0, tum1
+      tum0 = MPI_Wtime()
+      call update_means
+      tum1 = MPI_Wtime()
+      rtime_om_update_means = rtime_om_update_means + (tum1 - tum0)
+    end block
 
 #if defined(__MULTIO)
     output_done = .false.
@@ -2738,6 +2804,9 @@ ctime=timeold+(dayold-1.)*86400
 
     !___________________________________________________________________________
     ! loop over defined streams
+    block
+    real(WP) :: tsl0, tsl1
+    tsl0 = MPI_Wtime()
     do n=1, io_NSTREAMS
         !_______________________________________________________________________
         ! make pointer for entry onto io_stream object
@@ -2911,11 +2980,20 @@ ctime=timeold+(dayold-1.)*86400
             !___________________________________________________________________
             ! this is where the magic happens --> here do_output_callback is
             ! triggered as a method of the io_stream object --> call write_mean(...)
-            call entry%thread%run()
+            block
+              real(WP) :: tps0, tps1
+              tps0 = MPI_Wtime()
+              call entry%thread%run()
+              tps1 = MPI_Wtime()
+              entry%rtime_per_stream = entry%rtime_per_stream + (tps1 - tps0)
+            end block
             entry%thread_running = .true.
 #endif
         endif ! --> if (do_output) then
     end do ! --> do n=1, io_NSTREAMS
+    tsl1 = MPI_Wtime()
+    rtime_om_streamloop = rtime_om_streamloop + (tsl1 - tsl0)
+    end block
 
     !___________________________________________________________________________
     ! Handle 0D (scalar) output streams
@@ -3132,6 +3210,66 @@ subroutine finalize_output()
             io_stream0D(i)%ncid = -1
         end if
     end do
+end subroutine
+!
+!
+!_______________________________________________________________________________
+!> Print per-stream cumulative cost (entry%thread%run() wrap time, mean across
+!> ranks) sorted descending. Called from fesom_module's finalize block;
+!> master-rank only to keep the log readable.
+subroutine print_per_stream_costs(comm, mype, npes)
+    use mpi
+    integer, intent(in) :: comm, mype, npes
+    integer :: i, ierr, k, top_n, idx
+    real(real32) :: ttime
+    real(real32), allocatable :: per_stream(:), per_stream_max(:), sorted(:)
+    integer, allocatable :: order(:)
+
+    if (io_NSTREAMS <= 0) return
+    allocate(per_stream(io_NSTREAMS), per_stream_max(io_NSTREAMS))
+    do i = 1, io_NSTREAMS
+        per_stream(i) = real(io_stream(i)%p%rtime_per_stream, real32)
+    end do
+    per_stream_max = per_stream
+    call MPI_AllREDUCE(MPI_IN_PLACE, per_stream,     io_NSTREAMS, MPI_REAL, MPI_SUM, comm, ierr)
+    per_stream = per_stream / real(npes, real32)
+    call MPI_AllREDUCE(MPI_IN_PLACE, per_stream_max, io_NSTREAMS, MPI_REAL, MPI_MAX, comm, ierr)
+
+    if (mype /= 0) then
+        deallocate(per_stream, per_stream_max)
+        return
+    end if
+
+    ! sort by mean descending
+    allocate(order(io_NSTREAMS), sorted(io_NSTREAMS))
+    do i = 1, io_NSTREAMS; order(i) = i; end do
+    sorted = per_stream
+    do i = 1, io_NSTREAMS-1
+        do k = i+1, io_NSTREAMS
+            if (sorted(k) > sorted(i)) then
+                ttime = sorted(i); sorted(i) = sorted(k); sorted(k) = ttime
+                idx = order(i);    order(i)  = order(k);    order(k)  = idx
+            end if
+        end do
+    end do
+
+    write(*,*) '___PER-STREAM OUTPUT COST [seconds] (entry%thread%run() wrap, sorted desc)'
+    write(*,'(2x,a30,2a12,3x,a8,2x,a5)') 'stream', 'mean', 'max', 'freq', 'is_3D'
+    top_n = min(io_NSTREAMS, 30)
+    do i = 1, top_n
+        idx = order(i)
+        block
+          character(len=8) :: freq_str
+          write(freq_str,'(i0,a1)') io_stream(idx)%p%freq, io_stream(idx)%p%freq_unit
+          write(*,'(2x,a30,2f12.4,3x,a8,2x,L5)') trim(io_stream(idx)%p%name), &
+              per_stream(idx), per_stream_max(idx), &
+              adjustl(freq_str), &
+              (io_stream(idx)%p%glsize(1) > 1)
+        end block
+    end do
+    if (io_NSTREAMS > top_n) write(*,'(2x,a,i0,a)') '...', io_NSTREAMS - top_n, ' more streams below the top 30'
+
+    deallocate(per_stream, per_stream_max, order, sorted)
 end subroutine
 !
 !

--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -12,7 +12,8 @@ module io_MEANDATA
   use io_data_strategy_module
   use async_threads_module
   use netcdf
-  use io_xios_module, only: io_xios_is_on, io_xios_send_2d_r8, io_xios_send_2d_r4, &
+  use io_xios_module, only: io_xios_is_on, io_xios_field_is_active, &
+                            io_xios_send_2d_r8, io_xios_send_2d_r4, &
                             io_xios_send_3d_r8, io_xios_send_3d_r4, &
                             io_xios_set_ice_conc, io_xios_is_ice_field, &
                             io_xios_apply_ice_mask_2d_r4, io_xios_apply_ice_mask_2d_r8, &
@@ -2748,8 +2749,19 @@ ctime=timeold+(dayold-1.)*86400
 !#endif
 
         !_______________________________________________________________________
-        !check whether output will be written based on event frequency
+        ! Cadence dispatch:
+        !   - XIOS-driven path: ask XIOS whether this field needs a sample now.
+        !     Cadence is set in XML (field_def freq_op), so the per-event heavy
+        !     work below (mean-divide, pack, mask, write_mean dispatch) only
+        !     fires at the XML-declared cadence, not every model step.
+        !   - Native (non-XIOS) path: keep the namelist.io freq_unit-based
+        !     event check (unchanged behaviour for FESOM-standalone runs).
         do_output=.false.
+#if defined(__XIOS)
+        if (io_xios_is_on()) then
+            do_output = io_xios_field_is_active(trim(entry%name))
+        else
+#endif
         if (entry%freq_unit.eq.'y') then
             call annual_event(do_output, entry%freq)
         else if (entry%freq_unit == 'm') then
@@ -2766,6 +2778,9 @@ ctime=timeold+(dayold-1.)*86400
             call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
             stop
         endif
+#if defined(__XIOS)
+        end if
+#endif
 
 #if defined(__MULTIO)
         output_done = output_done .or. do_output

--- a/src/io_xios.F90
+++ b/src/io_xios.F90
@@ -633,6 +633,7 @@ contains
   implicit none
   private
   public :: io_xios_is_on
+  public :: io_xios_field_is_active
   public :: io_xios_send_2d_r8, io_xios_send_3d_r8
   public :: io_xios_send_2d_r4, io_xios_send_3d_r4
   public :: io_xios_owned_elem_local, io_xios_n_owned_elem
@@ -646,6 +647,11 @@ contains
   public :: io_xios_apply_wet_3d_elem_r4, io_xios_apply_wet_3d_elem_r8
 contains
   logical function io_xios_is_on() result(r)
+    r = .false.
+  end function
+
+  logical function io_xios_field_is_active(name) result(r)
+    character(len=*), intent(in) :: name
     r = .false.
   end function
 

--- a/src/io_xios.F90
+++ b/src/io_xios.F90
@@ -41,6 +41,7 @@ module io_xios_module
   public :: io_xios_send_2d_r8, io_xios_send_3d_r8
   public :: io_xios_send_2d_r4, io_xios_send_3d_r4
   public :: io_xios_is_on
+  public :: io_xios_field_is_active
   public :: io_xios_set_ice_conc, io_xios_is_ice_field
   public :: io_xios_apply_ice_mask_2d_r4, io_xios_apply_ice_mask_2d_r8
   public :: io_xios_apply_ice_mask_2d_elem_r4, io_xios_apply_ice_mask_2d_elem_r8
@@ -102,6 +103,29 @@ contains
 
   logical function io_xios_is_on() result(r)
     r = xios_on
+  end function
+
+  !> Wrapper around the XIOS Fortran binding xios_field_is_active. Returns
+  !> true only when XIOS expects a sample for this field at the current
+  !> calendar timestep. Used by io_meandata's streamloop to gate per-stream
+  !> heavy work (mean-divide, pack, mask, write_mean dispatch) on the
+  !> cadence XIOS XML declares via field_def freq_op.
+  !>
+  !> CRITICAL: xios_field_is_active is called with at_current_timestep=.TRUE..
+  !> When that argument is omitted the binding defaults it to .FALSE. and
+  !> returns "is this field registered in any output?" (= unconditionally
+  !> true), which would defeat the gate.
+  logical function io_xios_field_is_active(name) result(r)
+    character(len=*), intent(in) :: name
+    if (.not. xios_on) then
+       r = .false.
+       return
+    end if
+    if (.not. xios_is_valid_field(trim(name))) then
+       r = .false.
+       return
+    end if
+    r = xios_field_is_active(trim(name), .TRUE.)
   end function
 
 
@@ -303,25 +327,30 @@ contains
   end subroutine
 
 
+  ! All four send wrappers gate the actual xios_send_field call on
+  ! xios_field_is_active(name, .TRUE.). With field_def freq_op set per file
+  ! (e.g., 1d / 1mo to match output_freq), xios_field_is_active returns true
+  ! only at the cadence XIOS expects a sample, so xios_send_field — and its
+  ! client-side pipeline (inputField, temporal_filter, downstream MPI) —
+  ! only runs when the XML asks. xios_is_valid_field stays as a defensive
+  ! check for fields not declared in field_def (silently dropped).
   !> Send a 2D (node-only) field. Shape: (ni=myDim_nod2D).
   !> Caller (io_meandata.F90) must already have sliced to owned nodes.
   subroutine io_xios_send_2d_r8(name, buf)
     character(len=*), intent(in) :: name
     real(kind=8),     intent(in) :: buf(:)
-    logical :: is_valid
     if (.not. xios_on) return
-    is_valid = xios_is_valid_field(trim(name))
-    if (.not. is_valid) return
+    if (.not. xios_is_valid_field(trim(name))) return
+    if (.not. xios_field_is_active(trim(name), .TRUE.)) return
     call xios_send_field(trim(name), buf)
   end subroutine
 
   subroutine io_xios_send_2d_r4(name, buf)
     character(len=*), intent(in) :: name
     real(kind=4),     intent(in) :: buf(:)
-    logical :: is_valid
     if (.not. xios_on) return
-    is_valid = xios_is_valid_field(trim(name))
-    if (.not. is_valid) return
+    if (.not. xios_is_valid_field(trim(name))) return
+    if (.not. xios_field_is_active(trim(name), .TRUE.)) return
     call xios_send_field(trim(name), buf)
   end subroutine
 
@@ -330,20 +359,18 @@ contains
   subroutine io_xios_send_3d_r8(name, buf)
     character(len=*), intent(in) :: name
     real(kind=8),     intent(in) :: buf(:,:)
-    logical :: is_valid
     if (.not. xios_on) return
-    is_valid = xios_is_valid_field(trim(name))
-    if (.not. is_valid) return
+    if (.not. xios_is_valid_field(trim(name))) return
+    if (.not. xios_field_is_active(trim(name), .TRUE.)) return
     call xios_send_field(trim(name), buf)
   end subroutine
 
   subroutine io_xios_send_3d_r4(name, buf)
     character(len=*), intent(in) :: name
     real(kind=4),     intent(in) :: buf(:,:)
-    logical :: is_valid
     if (.not. xios_on) return
-    is_valid = xios_is_valid_field(trim(name))
-    if (.not. is_valid) return
+    if (.not. xios_is_valid_field(trim(name))) return
+    if (.not. xios_field_is_active(trim(name), .TRUE.)) return
     call xios_send_field(trim(name), buf)
   end subroutine
 


### PR DESCRIPTION
## Summary

When `__XIOS` is on, FESOM today fires `xios_send_field` on every model step for every registered stream (the `freq=1, unit='s'` registration in `io_meandata.F90:ini_mean_io`). XIOS then accepts every sample, runs it through the `temporal_filter`, and gates output internally based on `output_freq`. The XIOS pipeline cost (`Streamfilter::inputField`, `Temporal filter::functor`, `Streamfilter::downstream`, `MPI_Isend`) is paid every step on every rank for every active field.

This PR matches the OpenIFS pattern (`arpifs/module/suxios.F90`) and asks XIOS — once per field per step — whether it actually wants a sample right now. The cadence policy moves from FESOM Fortran into the XIOS XML (field_def `freq_op` per file). With `freq_op` set to match `output_freq` (1d / 1mo), `xios_field_is_active` returns `.true.` only at the output boundary, so the heavy XIOS-side work runs once per output cycle instead of every model step.

Net effect (HR config, ratio=50/pools=2, dt=360):

| metric                     | before    | after        |
| --                         | --        | --           |
| streamData calls / rank/mo | ~558,000  | ~470 (1200×) |
| Streamfilter inputField    | 22.8 s    | 0.0 s        |
| Temporal filter functor    | 24.0 s    | 0.0 s        |
| Streamfilter downstream    | 37.0 s    | 4.9 s        |
| `runtime output` mean      | 228 s     | 90 s         |
| Wall                       | 28:54     | 25:32 (-3:22)|

CMIP7 conformance preserved: `cell_methods` stays `"time: mean"` because XIOS's `operation="average"` over a single sample reduces to identity and writes the FESOM-internal monthly/daily mean produced by `update_means`. As a side effect, dMOC density-class fields (`U_rho_x_DZ`, `std_dens_*`, …) that previously wrote near-fill garbage now contain correct physical values — the every-step send pattern was averaging
mid-recompute states.

