### PR TITLE
ci: switch to FESOM-org docker image + add fesom2_xios end-to-end run-test

### DIFF
--- a/.github/workflows/fesom2_build_tests.yml
+++ b/.github/workflows/fesom2_build_tests.yml
@@ -15,7 +15,7 @@ jobs:
     # Use matrix strategy to build all configurations in parallel
     strategy:
       matrix:
-        preset: [default, coupled, coupled_yac, recom, ifs_interface, xios]
+        preset: [default, coupled, coupled_yac, recom, ifs_interface]
         include:
           - preset: default
             display_name: "Default Configuration"
@@ -27,14 +27,12 @@ jobs:
             display_name: "REcoM3 Configuration"
           - preset: ifs_interface
             display_name: "IFS Interface Configuration"
-          - preset: xios
-            display_name: "XIOS Configuration"
 
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
     # FESOM-org-owned CI image: ubuntu 22.04 + GCC/MPI/NetCDF/HDF5/LAPACK,
-    # OASIS3-MCT pre-built at /oasis, XIOS 2.5 pre-built at /xios. Built and
-    # published from FESOM/FESOM2_Docker (fesom2_ci/Dockerfile).
+    # OASIS3-MCT pre-built at /oasis. Built and published from
+    # FESOM/FESOM2_Docker (fesom2_ci/Dockerfile).
     container: ghcr.io/fesom/fesom2_docker:fesom2_ci-master
 
     # Service containers to run with `gfortran_ubuntu`
@@ -53,11 +51,6 @@ jobs:
       run: |
         cp -rf /oasis ../
 
-    - name: Copy XIOS directory
-      if: matrix.preset == 'xios'
-      run: |
-        cp -rf /xios ../
-
     - name: List available CMake presets
       run: |
         echo "Available CMake presets:"
@@ -67,8 +60,6 @@ jobs:
         ctest --list-presets
 
     - name: Configure and build ${{ matrix.display_name }}
-      env:
-        XIOS_ROOT: ${{ github.workspace }}/../xios
       run: |
         echo "Building ${{ matrix.display_name }} (preset: ${{ matrix.preset }})"
         cmake --preset ${{ matrix.preset }}
@@ -78,7 +69,7 @@ jobs:
       run: |
         echo "Running integration tests for ${{ matrix.display_name }}..."
         ctest --preset ${{ matrix.preset }} --output-on-failure
-      continue-on-error: ${{ matrix.preset == 'recom' || matrix.preset == 'xios' }}  # REcoM3 tests may fail as noted in documentation; xios cell is build-only (no XIOS server runs in CI)
+      continue-on-error: ${{ matrix.preset == 'recom' }}  # REcoM3 tests may fail as noted in documentation
 
     - name: Verify build artifacts for ${{ matrix.display_name }}
       run: |

--- a/.github/workflows/fesom2_build_tests.yml
+++ b/.github/workflows/fesom2_build_tests.yml
@@ -15,7 +15,7 @@ jobs:
     # Use matrix strategy to build all configurations in parallel
     strategy:
       matrix:
-        preset: [default, coupled, coupled_yac, recom, ifs_interface]
+        preset: [default, coupled, coupled_yac, recom, ifs_interface, xios]
         include:
           - preset: default
             display_name: "Default Configuration"
@@ -27,11 +27,15 @@ jobs:
             display_name: "REcoM3 Configuration"
           - preset: ifs_interface
             display_name: "IFS Interface Configuration"
-    
+          - preset: xios
+            display_name: "XIOS Configuration"
+
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
-    # Docker Hub image that `container-job` executes in
-    container: ghcr.io/suvarchal/fesom2-ci:latest
+    # FESOM-org-owned CI image: ubuntu 22.04 + GCC/MPI/NetCDF/HDF5/LAPACK,
+    # OASIS3-MCT pre-built at /oasis, XIOS 2.5 pre-built at /xios. Built and
+    # published from FESOM/FESOM2_Docker (fesom2_ci/Dockerfile).
+    container: ghcr.io/fesom/fesom2_docker:fesom2_ci-master
 
     # Service containers to run with `gfortran_ubuntu`
     steps:
@@ -49,6 +53,11 @@ jobs:
       run: |
         cp -rf /oasis ../
 
+    - name: Copy XIOS directory
+      if: matrix.preset == 'xios'
+      run: |
+        cp -rf /xios ../
+
     - name: List available CMake presets
       run: |
         echo "Available CMake presets:"
@@ -58,17 +67,19 @@ jobs:
         ctest --list-presets
 
     - name: Configure and build ${{ matrix.display_name }}
+      env:
+        XIOS_ROOT: ${{ github.workspace }}/../xios
       run: |
         echo "Building ${{ matrix.display_name }} (preset: ${{ matrix.preset }})"
         cmake --preset ${{ matrix.preset }}
         cmake --build --preset ${{ matrix.preset }} --parallel $(nproc)
-        
+
     - name: Run integration tests for ${{ matrix.display_name }}
       run: |
         echo "Running integration tests for ${{ matrix.display_name }}..."
         ctest --preset ${{ matrix.preset }} --output-on-failure
-      continue-on-error: ${{ matrix.preset == 'recom' }}  # REcoM3 tests may fail as noted in documentation
-        
+      continue-on-error: ${{ matrix.preset == 'recom' || matrix.preset == 'xios' }}  # REcoM3 tests may fail as noted in documentation; xios cell is build-only (no XIOS server runs in CI)
+
     - name: Verify build artifacts for ${{ matrix.display_name }}
       run: |
         echo "Checking build artifacts for ${{ matrix.display_name }}:"

--- a/.github/workflows/fesom2_openmp.yml
+++ b/.github/workflows/fesom2_openmp.yml
@@ -16,7 +16,7 @@ jobs:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
     # Docker Hub image that `container-job` executes in
-    container: ghcr.io/fesom/fesom2_docker:fesom2_test_refactoring-nightly
+    container: ghcr.io/fesom/fesom2_docker:fesom2_test_refactoring-master
 
     # Service containers to run with `gfortran_ubuntu`
     steps:

--- a/.github/workflows/fesom2_xios.yml
+++ b/.github/workflows/fesom2_xios.yml
@@ -1,0 +1,81 @@
+name: "FESOM2: XIOS output"
+# Controls when the action will run. Triggers the workflow on pull request only.
+on:
+  workflow_dispatch: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - main
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  general_test:
+    # Containers must run in Linux based operating systems
+    runs-on: ubuntu-latest
+    # Image with mkfesom + XIOS 2.5 prebuilt at /xios (see FESOM/FESOM2_Docker
+    # fesom2_test_refactoring/Dockerfile).
+    container: ghcr.io/fesom/fesom2_docker:fesom2_test_refactoring-master
+
+    steps:
+      # NK: this changes working directory to fesom2
+      - uses: actions/checkout@v2
+
+      - name: Git safe directory
+        run: |
+          git config --global --add safe.directory ${PWD}
+
+      - name: Copy XIOS install from container
+        run: |
+          cp -rf /xios ../
+
+      - name: Compile model with XIOS
+        env:
+          XIOS_ROOT: ${{ github.workspace }}/../xios
+        run: |
+          ./configure.sh ubuntu -DFESOM_WITH_XIOS=ON
+
+      - name: Create global test run
+        run: |
+          mkrun pi test_pi -m docker
+
+      - name: Stage XIOS XMLs
+        run: |
+          # context_fesom / field_def_fesom / file_def_fesom ship in the repo;
+          # iodef.xml ships configured for AWI-ESM3 coupled (references OIFS
+          # context, sets using_server=true, using_oasis=true) so we write a
+          # minimal standalone variant here.
+          cp docs/xios_xml/context_fesom.xml   work_pi/
+          cp docs/xios_xml/field_def_fesom.xml work_pi/
+          cp docs/xios_xml/file_def_fesom.xml  work_pi/
+          cat > work_pi/iodef.xml <<'EOF'
+          <?xml version="1.0"?>
+          <simulation>
+            <context id="fesom" src="./context_fesom.xml" />
+            <context id="xios">
+              <variable_definition>
+                <variable_group id="parameters">
+                  <variable id="using_server" type="bool">false</variable>
+                  <variable id="info_level"   type="int" >0</variable>
+                  <variable id="print_file"   type="bool">true</variable>
+                </variable_group>
+              </variable_definition>
+            </context>
+          </simulation>
+          EOF
+
+      - name: FESOM2 XIOS test run
+        run: |
+          cd work_pi
+          chmod +x job_docker_new
+          ./job_docker_new
+
+      - name: Check XIOS produced output
+        run: |
+          # In attached mode XIOS writes from rank 0 of the FESOM communicator.
+          # The minimal file_def_fesom.xml has fesom_1d/fesom_1mo/fesom_3h
+          # groups; existence of any sst*.nc produced via XIOS is enough to
+          # confirm the path works.
+          ls -la work_pi/
+          ls work_pi/sst.fesom*.nc 2>/dev/null && echo "XIOS output OK" || (echo "no XIOS sst output" && exit 1)

--- a/.github/workflows/fesom2_xios.yml
+++ b/.github/workflows/fesom2_xios.yml
@@ -42,12 +42,33 @@ jobs:
 
       - name: Stage XIOS XMLs
         run: |
-          # All FESOM XIOS XMLs (context, field/file/axis/domain/grid_def) ship
-          # in docs/xios_xml/. Copy them all, then overwrite iodef.xml — the
-          # bundled iodef is the AWI-ESM3 coupled variant (references OIFS
-          # context, sets using_server=true, using_oasis=true), so a minimal
-          # standalone iodef is written inline below.
+          # All FESOM XIOS XMLs (context/field/file/axis/domain/grid_def) ship
+          # in docs/xios_xml/. Copy them all, then overwrite iodef.xml and
+          # file_def_fesom.xml in-place:
+          #   - bundled iodef is the AWI-ESM3 coupled variant (references OIFS
+          #     context, using_server=true, using_oasis=true) — write a
+          #     minimal standalone variant here (attached mode, no OASIS).
+          #   - bundled file_def_fesom.xml lists ~50 fields; we write a 6-field
+          #     subset matching what the standard test_pi setup checks for
+          #     bit-identical results (sst, a_ice, temp, salt, u, v). Verified
+          #     locally on Levante that this configuration reaches
+          #     write_mean → io_xios_send_2d_r4/r8 → xios_send_field and
+          #     successfully writes per-rank netcdf files in attached mode.
           cp docs/xios_xml/*.xml work_pi/
+          cat > work_pi/file_def_fesom.xml <<'EOF'
+          <?xml version="1.0"?>
+          <file_definition type="one_file" format="netcdf4" par_access="collective"
+                           time_counter_name="time" time_counter="exclusive">
+            <file_group id="fesom_1d" output_freq="1d" split_freq="1y" enabled="true">
+              <file id="f_sst"   name="sst.fesom"  ><field field_ref="sst"  /></file>
+              <file id="f_a_ice" name="a_ice.fesom"><field field_ref="a_ice"/></file>
+              <file id="f_temp"  name="temp.fesom" ><field field_ref="temp" /></file>
+              <file id="f_salt"  name="salt.fesom" ><field field_ref="salt" /></file>
+              <file id="f_u"     name="u.fesom"    ><field field_ref="u"    /></file>
+              <file id="f_v"     name="v.fesom"    ><field field_ref="v"    /></file>
+            </file_group>
+          </file_definition>
+          EOF
           cat > work_pi/iodef.xml <<'EOF'
           <?xml version="1.0"?>
           <simulation>
@@ -72,9 +93,17 @@ jobs:
 
       - name: Check XIOS produced output
         run: |
-          # In attached mode XIOS writes from rank 0 of the FESOM communicator.
-          # The minimal file_def_fesom.xml has fesom_1d/fesom_1mo/fesom_3h
-          # groups; existence of any sst*.nc produced via XIOS is enough to
-          # confirm the path works.
+          # In attached mode (using_server=false) XIOS writes one netcdf per
+          # rank with name <var>.fesom_<startyear>-<endyear>_<rank>.nc. Confirm
+          # all 6 fields wrote at least one file.
           ls -la work_pi/
-          ls work_pi/sst.fesom*.nc 2>/dev/null && echo "XIOS output OK" || (echo "no XIOS sst output" && exit 1)
+          missing=0
+          for var in sst a_ice temp salt u v; do
+            if ! ls work_pi/${var}.fesom_*.nc >/dev/null 2>&1; then
+              echo "MISSING: ${var}.fesom_*.nc"
+              missing=1
+            else
+              echo "OK: $(ls work_pi/${var}.fesom_*.nc | head -1)"
+            fi
+          done
+          [ "$missing" -eq 0 ] || exit 1

--- a/.github/workflows/fesom2_xios.yml
+++ b/.github/workflows/fesom2_xios.yml
@@ -42,13 +42,12 @@ jobs:
 
       - name: Stage XIOS XMLs
         run: |
-          # context_fesom / field_def_fesom / file_def_fesom ship in the repo;
-          # iodef.xml ships configured for AWI-ESM3 coupled (references OIFS
-          # context, sets using_server=true, using_oasis=true) so we write a
-          # minimal standalone variant here.
-          cp docs/xios_xml/context_fesom.xml   work_pi/
-          cp docs/xios_xml/field_def_fesom.xml work_pi/
-          cp docs/xios_xml/file_def_fesom.xml  work_pi/
+          # All FESOM XIOS XMLs (context, field/file/axis/domain/grid_def) ship
+          # in docs/xios_xml/. Copy them all, then overwrite iodef.xml — the
+          # bundled iodef is the AWI-ESM3 coupled variant (references OIFS
+          # context, sets using_server=true, using_oasis=true), so a minimal
+          # standalone iodef is written inline below.
+          cp docs/xios_xml/*.xml work_pi/
           cat > work_pi/iodef.xml <<'EOF'
           <?xml version="1.0"?>
           <simulation>

--- a/.github/workflows/fesom2_xios.yml
+++ b/.github/workflows/fesom2_xios.yml
@@ -103,19 +103,21 @@ jobs:
           import glob, sys
           import numpy as np
           from netCDF4 import Dataset
-          # Reference means measured on Levante intel + openmpi (job 24651279
-          # against fesom2_test_refactoring-master after FESOM2_Docker#6).
-          # Tolerance is loose (1e-3) to absorb intel-vs-gfortran rounding;
-          # tighten once first CI run gives gfortran-side numbers.
+          # Reference means measured in the CI environment (ubuntu 22.04 +
+          # gfortran + openmpi + sequential netcdf XIOS) running mkrun-defined
+          # test_pi settings (96 steps/day, 1 day, force_rotation=True). Lock
+          # to bit-identical tolerance — any future PR that perturbs these
+          # values will fail this check and either adjust the references or
+          # explain the divergence.
           ref = {
-              "sst":   8.454588890075684,
-              "a_ice": 0.8644400634765625,
-              "temp":  2.488135939910957,
-              "salt":  34.72926110273129,
-              "u":    -0.001790326627187989,
-              "v":     0.001086981141056039,
+              "sst":   8.673937797546387,
+              "a_ice": 0.8812576105565201,
+              "temp":  2.473328515513666,
+              "salt":  34.73029091319962,
+              "u":    -0.002066224489183517,
+              "v":     0.0002165362787114573,
           }
-          tol = 1e-3
+          tol = 1e-12
           fail = False
           for var, want in ref.items():
               files = sorted(glob.glob(f"work_pi/{var}.fesom_*.nc"))

--- a/.github/workflows/fesom2_xios.yml
+++ b/.github/workflows/fesom2_xios.yml
@@ -91,19 +91,46 @@ jobs:
           chmod +x job_docker_new
           ./job_docker_new
 
-      - name: Check XIOS produced output
+      - name: Check XIOS produced output (means + bit-id)
         run: |
           # In attached mode (using_server=false) XIOS writes one netcdf per
-          # rank with name <var>.fesom_<startyear>-<endyear>_<rank>.nc. Confirm
-          # all 6 fields wrote at least one file.
-          ls -la work_pi/
-          missing=0
-          for var in sst a_ice temp salt u v; do
-            if ! ls work_pi/${var}.fesom_*.nc >/dev/null 2>&1; then
-              echo "MISSING: ${var}.fesom_*.nc"
-              missing=1
-            else
-              echo "OK: $(ls work_pi/${var}.fesom_*.nc | head -1)"
-            fi
-          done
-          [ "$missing" -eq 0 ] || exit 1
+          # rank with name <var>.fesom_<startyear>-<endyear>_<rank>.nc. The
+          # standard mkfesom fcheck only handles the native single-file
+          # naming, so do the equivalent inline: per variable, concat all
+          # rank files, compute the masked mean, compare to the reference
+          # measured against fesom2_test_refactoring-master post-#6.
+          python3 - <<'PY'
+          import glob, sys
+          import numpy as np
+          from netCDF4 import Dataset
+          # Reference means measured on Levante intel + openmpi (job 24651279
+          # against fesom2_test_refactoring-master after FESOM2_Docker#6).
+          # Tolerance is loose (1e-3) to absorb intel-vs-gfortran rounding;
+          # tighten once first CI run gives gfortran-side numbers.
+          ref = {
+              "sst":   8.454588890075684,
+              "a_ice": 0.8644400634765625,
+              "temp":  2.488135939910957,
+              "salt":  34.72926110273129,
+              "u":    -0.001790326627187989,
+              "v":     0.001086981141056039,
+          }
+          tol = 1e-3
+          fail = False
+          for var, want in ref.items():
+              files = sorted(glob.glob(f"work_pi/{var}.fesom_*.nc"))
+              if not files:
+                  print(f"MISSING: {var}.fesom_*.nc")
+                  fail = True
+                  continue
+              vals = np.ma.concatenate([Dataset(f).variables[var][:].flatten()
+                                        for f in files])
+              got = float(vals.mean())
+              ok  = abs(got - want) < tol
+              tag = "OK" if ok else "FAIL"
+              print(f"{tag}: {var:6s} got={got:.16g}  want={want:.16g}  "
+                    f"|d|={abs(got-want):.3e}  tol={tol:.0e}")
+              if not ok:
+                  fail = True
+          sys.exit(1 if fail else 0)
+          PY

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -134,6 +134,33 @@
       "environment": {
         "FESOM_PLATFORM_STRATEGY": "ubuntu"
       }
+    },
+    {
+      "name": "xios",
+      "displayName": "XIOS Output FESOM2 Build",
+      "description": "FESOM2 build with XIOS-async output (FESOM_WITH_XIOS=ON); requires XIOS_ROOT in env",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/xios",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "BUILD_TESTING": "ON",
+        "FESOM_COUPLED": "OFF",
+        "OIFS_COUPLED": "OFF",
+        "RECOM_COUPLED": "OFF",
+        "USE_ICEPACK": "OFF",
+        "ENABLE_IFS_INTERFACE": "OFF",
+        "ENABLE_OPENMP": "OFF",
+        "ENABLE_MULTIO": "OFF",
+        "ASYNC_ICEBERGS": "ON",
+        "VERBOSE": "OFF",
+        "FESOM_PROFILING": "OFF",
+        "BUILD_MESHPARTITIONER": "OFF",
+        "BUILD_MESHDIAG": "OFF",
+        "FESOM_WITH_XIOS": "ON"
+      },
+      "environment": {
+        "FESOM_PLATFORM_STRATEGY": "ubuntu"
+      }
     }
   ],
   "buildPresets": [
@@ -166,6 +193,12 @@
       "configurePreset": "ifs_interface",
       "displayName": "Build IFS Interface Configuration",
       "description": "Build the IFS interface FESOM2 configuration"
+    },
+    {
+      "name": "xios",
+      "configurePreset": "xios",
+      "displayName": "Build XIOS Configuration",
+      "description": "Build the XIOS-async-output FESOM2 configuration"
     }
   ],
   "testPresets": [
@@ -218,6 +251,17 @@
       "configurePreset": "ifs_interface",
       "displayName": "Test IFS Interface Configuration",
       "description": "Run integration tests for the IFS interface FESOM2 configuration",
+      "filter": {
+        "include": {
+          "name": "integration_.*"
+        }
+      }
+    },
+    {
+      "name": "xios",
+      "configurePreset": "xios",
+      "displayName": "Test XIOS Configuration",
+      "description": "Run integration tests for the XIOS-async-output FESOM2 configuration",
       "filter": {
         "include": {
           "name": "integration_.*"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -134,33 +134,6 @@
       "environment": {
         "FESOM_PLATFORM_STRATEGY": "ubuntu"
       }
-    },
-    {
-      "name": "xios",
-      "displayName": "XIOS Output FESOM2 Build",
-      "description": "FESOM2 build with XIOS-async output (FESOM_WITH_XIOS=ON); requires XIOS_ROOT in env",
-      "generator": "Unix Makefiles",
-      "binaryDir": "${sourceDir}/build/xios",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "BUILD_TESTING": "ON",
-        "FESOM_COUPLED": "OFF",
-        "OIFS_COUPLED": "OFF",
-        "RECOM_COUPLED": "OFF",
-        "USE_ICEPACK": "OFF",
-        "ENABLE_IFS_INTERFACE": "OFF",
-        "ENABLE_OPENMP": "OFF",
-        "ENABLE_MULTIO": "OFF",
-        "ASYNC_ICEBERGS": "ON",
-        "VERBOSE": "OFF",
-        "FESOM_PROFILING": "OFF",
-        "BUILD_MESHPARTITIONER": "OFF",
-        "BUILD_MESHDIAG": "OFF",
-        "FESOM_WITH_XIOS": "ON"
-      },
-      "environment": {
-        "FESOM_PLATFORM_STRATEGY": "ubuntu"
-      }
     }
   ],
   "buildPresets": [
@@ -193,12 +166,6 @@
       "configurePreset": "ifs_interface",
       "displayName": "Build IFS Interface Configuration",
       "description": "Build the IFS interface FESOM2 configuration"
-    },
-    {
-      "name": "xios",
-      "configurePreset": "xios",
-      "displayName": "Build XIOS Configuration",
-      "description": "Build the XIOS-async-output FESOM2 configuration"
     }
   ],
   "testPresets": [
@@ -251,17 +218,6 @@
       "configurePreset": "ifs_interface",
       "displayName": "Test IFS Interface Configuration",
       "description": "Run integration tests for the IFS interface FESOM2 configuration",
-      "filter": {
-        "include": {
-          "name": "integration_.*"
-        }
-      }
-    },
-    {
-      "name": "xios",
-      "configurePreset": "xios",
-      "displayName": "Test XIOS Configuration",
-      "description": "Run integration tests for the XIOS-async-output FESOM2 configuration",
       "filter": {
         "include": {
           "name": "integration_.*"

--- a/docs/xios_xml/axis_def_fesom.xml
+++ b/docs/xios_xml/axis_def_fesom.xml
@@ -1,9 +1,15 @@
 <axis_definition>
-  <!-- FESOM vertical axis. n_glo and value are set at runtime from the
+  <!-- FESOM vertical axes. n_glo and value are set at runtime from the
        Fortran side (mesh%nl-1 cell-centred depths in metres, positive down
        converted to positive up if desired). -->
   <axis_group id="fesom_axes" unit="m" positive="down" axis_type="Z">
     <axis id="nz"     long_name="depth below sea level at layer mid-points" standard_name="depth" />
     <axis id="nz1"    long_name="depth below sea level at layer interfaces" standard_name="depth" />
   </axis_group>
+
+  <!-- dMOC density coordinate. n_glo and value populated at runtime from
+       std_dens_N / std_dens (oce_dens_MOC). io_xios_init unconditionally
+       calls xios_set_axis_attr("std_dens", ...), so the axis declaration
+       must exist even when ldiag_dMOC=false. -->
+  <axis id="std_dens" unit="kg/m^3" long_name="potential density (sigma2) for dMOC" standard_name="sea_water_potential_density" />
 </axis_definition>


### PR DESCRIPTION
- Switches the build-test workflow container from the externally-owned `ghcr.io/suvarchal/fesom2-ci:latest` to the FESOM-org-owned `ghcr.io/fesom/fesom2_docker:fesom2_ci-master`, built from [FESOM/FESOM2_Docker#3](https://github.com/FESOM/FESOM2_Docker/pull/3). Same toolchain (ubuntu 22.04 + GCC + OpenMPI + NetCDF/HDF5 + LAPACK + OASIS3-MCT prebuilt at `/oasis`); the recipe was reverse-engineered from suvarchal's image so behavior is identical for the existing five matrix cells (default, coupled, coupled_yac, recom, ifs_interface).
- Adds a new `fesom2_xios.yml` end-to-end run-test mirroring the structure of `fesom2_recom.yml` / `fesom2_cavities.yml`. It runs inside `ghcr.io/fesom/fesom2_docker:fesom2_test_refactoring-master` (XIOS 2.5 install at `/xios` added in [FESOM2_Docker#5](https://github.com/FESOM/FESOM2_Docker/pull/5); attached-mode finalize segv fixed in [#6](https://github.com/FESOM/FESOM2_Docker/pull/6)), compiles FESOM with `./configure.sh ubuntu -DFESOM_WITH_XIOS=ON`, runs `mkrun pi test_pi -m docker`, stages a minimal standalone `iodef.xml` (`using_server=false`, no OASIS) plus a 6-field `file_def_fesom.xml` (`sst`, `a_ice`, `temp`, `salt`, `u`, `v` — matching the field set of the standard `test_pi` bit-identical check), runs `./job_docker_new`, and verifies all six XIOS-output netcdf files were produced per rank.
- Aligns `fesom2_openmp.yml` with the other run-test workflows by switching its container tag from `fesom2_test_refactoring-nightly` to `-master`. The nightly tag is only refreshed by a monthly cron, which let it lag behind master on the recent setuptools / pkg_resources fix from [FESOM2_Docker#4](https://github.com/FESOM/FESOM2_Docker/pull/4).
- Adds the missing `std_dens` axis declaration to `docs/xios_xml/axis_def_fesom.xml`. `src/io_xios.F90:274` calls `xios_set_axis_attr("std_dens", ...)` unconditionally — to populate the dMOC density coordinate from `std_dens_N` / `std_dens` in `oce_dens_MOC` — so the axis must exist in the registry even when `ldiag_dMOC=.false.`. Without the declaration `xios_close_context_definition` aborts with `CException: axis std_dens not found`. Discovered by the new `fesom2_xios.yml` workflow.