### PR TITLE
io_meandata: gate sel_trgrd_xyz on ldiag_trgrd_xyz

### DIFF
--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -1830,8 +1830,8 @@ CASE ('UVW_SQR   ')
 !_______________________________________________________________________________
 ! compute horizontal and vertical tracer gradients
 CASE ('TRGRD_XYZ ')
-    sel_trgrd_xyz=1
     if (ldiag_trgrd_xyz) then
+        sel_trgrd_xyz = 1
         call def_stream((/nl-1, elem2D/), (/nl-1, myDim_elem2D/),  'temp_grdx',   'zonal temperature gradient',        'K/m', trgrd_x(1,:,:), io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
         call def_stream((/nl-1, elem2D/), (/nl-1, myDim_elem2D/),  'temp_grdy',   'meridional temperature gradient',   'K/m', trgrd_y(1,:,:), io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
         call def_stream((/nl-1,  nod2D/), (/nl-1, myDim_nod2D /),  'temp_grdz',   'vertical temperature gradient',     'K/m', trgrd_z(1,:,:), io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)


### PR DESCRIPTION
Under XIOS-mode `ini_mean_io` swaps `io_list` for the hardcoded `xios_ids` list, which always contains `TRGRD_XYZ`. The `CASE ('TRGRD_XYZ ')` branch then always flips `sel_trgrd_xyz=1` (unconditionally, before the inner `if (ldiag_trgrd_xyz)`), which gates out the later trflx registration block:

```fortran
if (ldiag_trflx .and. sel_trgrd_xyz==0) then
    ! utemp / vtemp / usalt / vsalt def_streams
end if
```

So utemp/vtemp/usalt/vsalt never get registered, even with `ldiag_trflx=.true.` and the matching `<file>` blocks in `file_def_fesom.xml`.

Fix: only flip `sel_trgrd_xyz=1` when the user actually requested gradient diagnostics — restoring the original namelist-driven semantics.

Verified locally: 1900 LR coupled run with `ldiag_trflx=.true.` now produces `utemp/vtemp/usalt/vsalt.fesom.1900.nc`. No regression on other 3D-element output.