### PR TITLE
Fix/lumi compile

### DIFF
--- a/env/lumi/shell
+++ b/env/lumi/shell
@@ -1,20 +1,17 @@
 module purge
-module load PrgEnv-cray/8.3.3
+
+module load LUMI/24.03
+module load partition/C
+module load cpeCray/24.03
+module load cray-mpich/8.1.29
+module load libaec/1.0.6-cpeCray-24.03
 module load craype-x86-milan
 
-vers=14.0.2
-module swap cce cce/$vers
-module load cray-fftw/3.3.10.1
-module load cray-hdf5/1.12.1.5
-module load cray-netcdf/4.8.1.5
+module load craype-network-ofi
+module load cray-dsmml/0.3.0
 
-export FC=ftn
-export CC=cc
-export CXX=cc
-#export NETCDF_Fortran_INCLUDE_DIRECTORIES=$CRAY_NETCDF_DIR/include
-#export NETCDF_C_INCLUDE_DIRECTORIES=$CRAY_NETCDF_DIR/include
-#export NETCDF_C_LIBRARIES=$CRAY_NETCDF_DIR/lib
-#export NETCDF_Fortran_LIBRARIES=$CRAY_NETCDF_DIR/lib
-$CC -v
-$FC -V
-$CXX -v
+module load cray-libsci/24.03.0
+module load cray-fftw/3.3.10.7
+module load cray-hdf5/1.12.2.11
+module load cray-netcdf/4.9.0.11
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,14 +15,16 @@ else()
 endif()
 
 # Cray compiler specific optimizations
-if(CMAKE_Fortran_COMPILER_ID MATCHES "Cray")
-   # Use alternative cray-mpich library, about 5% faster with cray-mpich/7.7.3
-   # Not available for modules cray-mpich > 7.7.3
-   add_compile_options(-craympich-mt)
+if(CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
    # Make sure to also set these variables in the runtime environment:
    #    MPICH_MAX_THREAD_SAFETY=multiple # allows highest MPI thread level (i.e. MPI_THREAD_MULTIPLE)
    #    MPICH_CRAY_OPT_THREAD_SYNC=0 # the Cray MPICH library falls back to using the pthread_mutex-based thread-synchronization implementation
    #    MPICH_OPT_THREAD_SYNC=0 # seems to be a duplicate variable which also appears in some documentation instead of MPICH_CRAY_OPT_THREAD_SYNC (but this one brings a huge speed gain on aleph)
+   if(DEFINED ENV{CRAY_MPICH_VERSION})
+      if("$ENV{CRAY_MPICH_VERSION}" VERSION_LESS_EQUAL "7.7.3")
+         add_compile_options(-craympich-mt)
+      endif()
+   endif()
 endif()
 
 # Backward compatibility: convert old DISABLE_MULTITHREADING to new ASYNCHRONOUS_IO_THREADS


### PR DESCRIPTION
use new environment / modules and fix cray compiler optins (lumi has `cray-mpich >= 7.7.3`, so can not use  `-craympich-mt` there.