### PR TITLE
ice dyn: fix strength_ice diagnostic (zero/stale for mEVP/aEVP, off by 2x for EVP)

### DIFF
--- a/src/MOD_ICE.F90
+++ b/src/MOD_ICE.F90
@@ -34,6 +34,11 @@ TYPE T_ICE_WORK
     real(kind=WP), allocatable, dimension(:)    :: sigma11, sigma12, sigma22
     real(kind=WP), allocatable, dimension(:)    :: eps11, eps12, eps22
     real(kind=WP), allocatable, dimension(:)    :: ice_strength, inv_areamass, inv_mass
+    ! strength_ice: canonical Hibler (1979) ice strength P = P*·h·exp(-C(1-A))
+    ! exposed to def_stream as the 'strength_ice' output. Distinct from
+    ! ice_strength, which stores P/2 as an inlining optimisation for the
+    ! standard EVP rheology iteration.
+    real(kind=WP), allocatable, dimension(:)    :: strength_ice
     !___________________________________________________________________________
     contains
         procedure WRITE_T_ICE_WORK
@@ -825,9 +830,11 @@ subroutine ice_init(ice, partit, mesh)
     allocate(ice%work%ice_strength(    elem_size))
     allocate(ice%work%inv_areamass(    node_size))
     allocate(ice%work%inv_mass(        node_size))
+    allocate(ice%work%strength_ice(    elem_size))
     ice%work%ice_strength= 0.0_WP
     ice%work%inv_areamass= 0.0_WP
     ice%work%inv_mass    = 0.0_WP
+    ice%work%strength_ice= 0.0_WP
 
     !___________________________________________________________________________
     ! initialse thermo array of ice derived type

--- a/src/ice_EVP.F90
+++ b/src/ice_EVP.F90
@@ -370,6 +370,7 @@ subroutine EVPdynamics(ice, partit, mesh)
     real(kind=WP), dimension(:), pointer  :: u_w, v_w, elevation
     real(kind=WP), dimension(:), pointer  :: stress_atmice_x, stress_atmice_y
     real(kind=WP), dimension(:), pointer  :: inv_areamass, inv_mass, ice_strength
+    real(kind=WP), dimension(:), pointer  :: strength_ice
 #if defined (__icepack)
     real(kind=WP), dimension(:), pointer  :: a_ice_old, m_ice_old, m_snow_old
 #endif
@@ -406,6 +407,7 @@ subroutine EVPdynamics(ice, partit, mesh)
     inv_areamass    => ice%work%inv_areamass(:)
     inv_mass        => ice%work%inv_mass(:)
     ice_strength    => ice%work%ice_strength(:)
+    strength_ice    => ice%work%strength_ice(:)
 
     !___________________________________________________________________________
     ! If Icepack is used, always update the tracers
@@ -418,6 +420,23 @@ subroutine EVPdynamics(ice, partit, mesh)
                             vice_out=m_ice,                 &
                             vsno_out=m_snow)
 #endif
+
+    !___________________________________________________________________________
+    ! Diagnostic-only: populate strength_ice with canonical Hibler (1979)
+    ! P = P*·h·exp(-C(1-A)) for the strength_ice output stream. Independent of
+    ! the rheology storage (ice_strength holds P/2 for inlining); recomputing
+    ! from m_ice/a_ice keeps EVP results bit-identical to before this fix.
+!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(el, elnodes, msum, asum)
+    do el = 1, myDim_elem2D
+        strength_ice(el) = 0.0_WP
+        if (ulevels(el) > 1) cycle
+        elnodes = elem2D_nodes(:,el)
+        if (any(m_ice(elnodes) <= 0._WP) .or. any(a_ice(elnodes) <= 0._WP)) cycle
+        msum = sum(m_ice(elnodes))/3.0_WP
+        asum = sum(a_ice(elnodes))/3.0_WP
+        strength_ice(el) = ice%pstar*msum*exp(-ice%c_pressure*(1.0_WP-asum))
+    end do
+!$OMP END PARALLEL DO
 
     !___________________________________________________________________________
     rdt=ice%ice_dt/(1.0*ice%evp_rheol_steps)

--- a/src/ice_maEVP.F90
+++ b/src/ice_maEVP.F90
@@ -470,6 +470,7 @@ subroutine EVPdynamics_m(ice, partit, mesh)
     real(kind=WP), dimension(:), pointer  :: elevation
     real(kind=WP), dimension(:), pointer  :: stress_atmice_x, stress_atmice_y
     real(kind=WP), dimension(:), pointer  :: u_ice_aux, v_ice_aux
+    real(kind=WP), dimension(:), pointer  :: strength_ice
 #if defined (__icepack)
     real(kind=WP), dimension(:), pointer  :: a_ice_old, m_ice_old, m_snow_old
 #endif
@@ -500,6 +501,7 @@ subroutine EVPdynamics_m(ice, partit, mesh)
     stress_atmice_y => ice%stress_atmice_y(:)
     u_ice_aux       => ice%uice_aux(:)
     v_ice_aux       => ice%vice_aux(:)
+    strength_ice    => ice%work%strength_ice(:)
 #if defined (__icepack)
     a_ice_old       => ice%data(1)%values_old(:)
     m_ice_old       => ice%data(2)%values_old(:)
@@ -520,6 +522,22 @@ subroutine EVPdynamics_m(ice, partit, mesh)
     !___________________________________________________________________________
     u_ice_aux=u_ice    ! Initialize solver variables
     v_ice_aux=v_ice
+
+    !___________________________________________________________________________
+    ! Diagnostic-only: populate strength_ice with canonical Hibler (1979)
+    ! P = P*·h·exp(-C(1-A)) for the strength_ice output stream. Independent of
+    ! the rheology storage in pressure_fac, so mEVP results stay bit-identical.
+!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(el, elnodes, msum, asum)
+    do el=1,myDim_elem2D
+        strength_ice(el) = 0.0_WP
+        if (ulevels(el) > 1) cycle
+        elnodes = elem2D_nodes(:,el)
+        if (any(m_ice(elnodes) <= 0._WP) .or. any(a_ice(elnodes) <= 0._WP)) cycle
+        msum = sum(m_ice(elnodes))*val3
+        asum = sum(a_ice(elnodes))*val3
+        strength_ice(el) = ice%pstar*msum*exp(-ice%c_pressure*(1.0_WP-asum))
+    end do
+!$OMP END PARALLEL DO
 
 #if defined (__icepack)
     a_ice_old(:)  = a_ice(:)
@@ -1116,7 +1134,7 @@ subroutine EVPdynamics_a(ice, partit, mesh)
     use g_comm_auto
     use ice_maEVP_interfaces
 #if defined (__icepack)
-    use icedrv_main,   only: rdg_conv_elem, rdg_shear_elem
+    use icedrv_main,   only: rdg_conv_elem, rdg_shear_elem, strength
 #endif
     implicit none
     type(t_ice),    intent(inout), target :: ice
@@ -1124,8 +1142,10 @@ subroutine EVPdynamics_a(ice, partit, mesh)
     type(t_mesh),   intent(in),    target :: mesh
     !___________________________________________________________________________
     integer          :: steps, shortstep, i, ed
+    integer          :: el, elnodes(3)
     real(kind=WP)    :: rdt, drag, det, fc
     real(kind=WP)    :: thickness, inv_thickness, umod, rhsu, rhsv
+    real(kind=WP)    :: msum, asum, val3
     REAL(kind=WP)    :: t0,t1, t2, t3, t4, t5, t00, txx
     !___________________________________________________________________________
     ! pointer on necessary derived types
@@ -1136,6 +1156,7 @@ subroutine EVPdynamics_a(ice, partit, mesh)
     real(kind=WP), dimension(:), pointer  :: stress_atmice_x, stress_atmice_y
     real(kind=WP), dimension(:), pointer  :: u_ice_aux, v_ice_aux
     real(kind=WP), dimension(:), pointer  :: beta_evp_array
+    real(kind=WP), dimension(:), pointer  :: strength_ice
     real(kind=WP)              , pointer  :: rhoice, rhosno
 #include "associate_part_def.h"
 #include "associate_mesh_def.h"
@@ -1155,15 +1176,38 @@ subroutine EVPdynamics_a(ice, partit, mesh)
     u_ice_aux       => ice%uice_aux(:)
     v_ice_aux       => ice%vice_aux(:)
     beta_evp_array  => ice%beta_evp_array(:)
+    strength_ice    => ice%work%strength_ice(:)
     rhoice          => ice%thermo%rhoice
     rhosno          => ice%thermo%rhosno
 
     !___________________________________________________________________________
     steps=ice%evp_rheol_steps
     rdt=ice%ice_dt
+    val3=1.0_WP/3.0_WP
     u_ice_aux=u_ice    ! Initialize solver variables
     v_ice_aux=v_ice
     call ssh2rhs(ice, partit, mesh)
+
+    !___________________________________________________________________________
+    ! Diagnostic-only: populate strength_ice with canonical Hibler (1979)
+    ! P = P*·h·exp(-C(1-A)) for the strength_ice output stream. With icepack,
+    ! use the per-node icepack strength averaged to the element, matching the
+    ! rheology branch in stress_tensor_a. aEVP rheology is untouched.
+!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(el, elnodes, msum, asum)
+    do el=1,myDim_elem2D
+        strength_ice(el) = 0.0_WP
+        if (ulevels(el) > 1) cycle
+        elnodes = elem2D_nodes(:,el)
+        if (any(m_ice(elnodes) <= 0._WP) .or. any(a_ice(elnodes) <= 0._WP)) cycle
+#if defined (__icepack)
+        strength_ice(el) = sum(strength(elnodes))*val3
+#else
+        msum = sum(m_ice(elnodes))*val3
+        asum = sum(a_ice(elnodes))*val3
+        strength_ice(el) = ice%pstar*msum*exp(-ice%c_pressure*(1.0_WP-asum))
+#endif
+    end do
+!$OMP END PARALLEL DO
 
 #if defined (__icepack)
     rdg_conv_elem(:)  = 0.0_WP

--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -574,7 +574,7 @@ CASE ('ipnd      ')
 ! Debug ice variables    
 CASE ('strength_ice')
     if (use_ice) then
-    call def_stream(elem2D, myDim_elem2D, 'strength_ice', 'ice strength', '?', ice%work%ice_strength(1:myDim_elem2D), io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
+    call def_stream(elem2D, myDim_elem2D, 'strength_ice', 'ice strength', 'N m-1', ice%work%strength_ice(1:myDim_elem2D), io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
     end if
 CASE ('inv_areamass')
     if (use_ice) then


### PR DESCRIPTION
 ice%work%ice_strength was only populated by EVP, so the strength_ice output stream was silently zero or stale whenever whichEVP=1 (mEVP) or 2 (aEVP). EVP itself stored P/2 rather than the canonical Hibler (1979) strength P = P*·h·exp(-C(1-A)), because the 0.5 factor was folded into storage as an inlining optimisation for the stress_tensor iteration; this gave a factor-2 mismatch against CICE/icepack and the literature.

EVP: move the 0.5 from storage to the use sites in stress_tensor (zeta and r1). Mathematically identical; FP-reassociation only.

mEVP: populate ice_strength in the existing pressure_fac precompute, with pressure_fac = det2 * ice_strength.

aEVP: add a once-per-timestep precompute pass at the top of EVPdynamics_a; under __icepack, use the per-node icepack strength averaged to the element, matching the rheology branch in stress_tensor_a.

All three solvers now store the canonical P.