### PR TITLE
io: route CMOR 0D scalars through XIOS at file_def cadence

### DIFF
--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -776,14 +776,15 @@ contains
         call fesom_profiler_end("compute_diagnostics")
 #endif
 
-        ! XIOS send for CMOR 0D scalars. xios_field_is_active gates the
-        ! actual transmission to file_def freq_op (e.g. 1mo); the work
-        ! between cadence boundaries is no-op. Only rank 0 sends since
-        ! the values are MPI_AllReduced inside compute_cmor_diag. The
-        ! legacy output_0D_streams writer is gated on io_xios_is_on() so
-        ! these scalars no longer double-write at every step (was 87600
-        ! records/year for HR pre-fix).
-        if (ldiag_cmor .and. io_xios_is_on() .and. f%mype == 0) then
+        ! XIOS send for CMOR 0D scalars. xios_send_field is a collective
+        ! over the FESOM client context: ALL ranks must participate or
+        ! XIOS errors with "callers not coherent" (event_server.cpp:29).
+        ! The values are MPI_AllReduced inside compute_cmor_diag so every
+        ! rank has the same global value; XIOS-side operation="average"
+        ! over identical values reduces to that value. The legacy
+        ! output_0D_streams writer is gated on io_xios_is_on() so these
+        ! scalars no longer double-write at every step.
+        if (ldiag_cmor .and. io_xios_is_on()) then
             call io_xios_send_0d_r8('volo',      real(volo,      kind=8))
             call io_xios_send_0d_r8('soga',      real(soga,      kind=8))
             call io_xios_send_0d_r8('thetaoga',  real(thetaoga,  kind=8))

--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -19,6 +19,15 @@ module fesom_main_storage_module
   use io_xios_module
   use io_mesh_info
   use diagnostics
+  ! Read-only access to the CMOR scalar diagnostics computed inside
+  ! compute_diagnostics → compute_cmor_diag, so we can send them to XIOS
+  ! from this top-level module. Doing the send inside cmor_variables_diag
+  ! itself would create a cycle (io_xios → diagnostics → cmor_variables_diag
+  ! → io_xios) and break the build.
+  use cmor_variables_diag, only: ldiag_cmor, &
+                                 volo, soga, thetaoga, &
+                                 siarean, siareas, siextentn, siextents, &
+                                 sivoln, sivols
   use mo_tidal
   use tracer_init_interface
   use ocean_setup_interface
@@ -766,6 +775,25 @@ contains
 #if defined (FESOM_PROFILING)
         call fesom_profiler_end("compute_diagnostics")
 #endif
+
+        ! XIOS send for CMOR 0D scalars. xios_field_is_active gates the
+        ! actual transmission to file_def freq_op (e.g. 1mo); the work
+        ! between cadence boundaries is no-op. Only rank 0 sends since
+        ! the values are MPI_AllReduced inside compute_cmor_diag. The
+        ! legacy output_0D_streams writer is gated on io_xios_is_on() so
+        ! these scalars no longer double-write at every step (was 87600
+        ! records/year for HR pre-fix).
+        if (ldiag_cmor .and. io_xios_is_on() .and. f%mype == 0) then
+            call io_xios_send_0d_r8('volo',      real(volo,      kind=8))
+            call io_xios_send_0d_r8('soga',      real(soga,      kind=8))
+            call io_xios_send_0d_r8('thetaoga',  real(thetaoga,  kind=8))
+            call io_xios_send_0d_r8('siarean',   real(siarean,   kind=8))
+            call io_xios_send_0d_r8('siareas',   real(siareas,   kind=8))
+            call io_xios_send_0d_r8('siextentn', real(siextentn, kind=8))
+            call io_xios_send_0d_r8('siextents', real(siextents, kind=8))
+            call io_xios_send_0d_r8('sivoln',    real(sivoln,    kind=8))
+            call io_xios_send_0d_r8('sivols',    real(sivols,    kind=8))
+        end if
 
         f%t4 = MPI_Wtime()
         !___prepare output______________________________________________________

--- a/src/gen_modules_cmor_diag.F90
+++ b/src/gen_modules_cmor_diag.F90
@@ -331,7 +331,12 @@ contains
     siextents = siextents / 1.0e12_WP  ! to 10^12 m^2
     sivoln = sivoln / 1.0e9_WP         ! to 10^9 m^3
     sivols = sivols / 1.0e9_WP         ! to 10^9 m^3
-    
+
+    ! NOTE: XIOS send for these scalars happens in fesom_module.F90 right
+    ! after compute_diagnostics returns. Placing it here would create a
+    ! circular module dependency: io_xios → diagnostics → cmor_variables_diag
+    ! → io_xios.
+
     ! Update previous tracer values for next time step
     do n2 = 1, myDim_nod2D
         do k = ulevels_nod2D(n2), nlevels_nod2D(n2)-1
@@ -339,7 +344,7 @@ contains
             previous_salt(k, n2) = salt(k, n2)
         end do
     end do
-    
+
   end subroutine compute_cmor_diag
 
 

--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -3019,13 +3019,21 @@ subroutine output_0D_streams(istep, partit)
     implicit none
     integer, intent(in) :: istep
     type(t_partit), intent(inout) :: partit
-    
+
     integer :: n, ierr
     logical :: do_output
     type(Meandata0D), pointer :: entry0D
     character(500) :: filepath
     real(real64) :: mean_value, rtime
-    
+
+    ! When XIOS is the I/O driver, the 0D scalar fields are written via
+    ! xios_send_field calls (see gen_modules_cmor_diag.F90's compute_cmor_diag)
+    ! and gated by file_def freq_op (e.g. "1mo"). The legacy writer below
+    ! would otherwise double-write those streams at the bypass-loop's
+    ! freq=1/'s' (every model step → ~87600 records/year for HR), which is
+    ! both wrong cadence AND a duplicate output. Skip when XIOS is on.
+    if (io_xios_is_on()) return
+
     do n = 1, io_NSTREAMS0D
         entry0D => io_stream0D(n)
         

--- a/src/io_xios.F90
+++ b/src/io_xios.F90
@@ -40,6 +40,7 @@ module io_xios_module
   public :: io_xios_update_calendar
   public :: io_xios_send_2d_r8, io_xios_send_3d_r8
   public :: io_xios_send_2d_r4, io_xios_send_3d_r4
+  public :: io_xios_send_0d_r8, io_xios_send_0d_r4
   public :: io_xios_is_on
   public :: io_xios_field_is_active
   public :: io_xios_set_ice_conc, io_xios_is_ice_field
@@ -375,6 +376,32 @@ contains
   end subroutine
 
 
+  !> Send a 0D (scalar) field. For CMOR global diagnostics
+  !> (siarean / siareas / siextentn / siextents / sivoln / sivols / volo /
+  !> soga / thetaoga, etc.). Field must be declared in field_def with
+  !> grid_ref="grid_scalar" and routed to a file_def entry — see
+  !> namelists/fesom2/xios_xml_cmip7/{field_def,file_def_*}.xml{,.j2}.
+  !> The XIOS-side scalar grid has no spatial dim; netCDF write produces
+  !> a (time)-only variable.
+  subroutine io_xios_send_0d_r8(name, val)
+    character(len=*), intent(in) :: name
+    real(kind=8),     intent(in) :: val
+    if (.not. xios_on) return
+    if (.not. xios_is_valid_field(trim(name))) return
+    if (.not. xios_field_is_active(trim(name), .TRUE.)) return
+    call xios_send_field(trim(name), val)
+  end subroutine
+
+  subroutine io_xios_send_0d_r4(name, val)
+    character(len=*), intent(in) :: name
+    real(kind=4),     intent(in) :: val
+    if (.not. xios_on) return
+    if (.not. xios_is_valid_field(trim(name))) return
+    if (.not. xios_field_is_active(trim(name), .TRUE.)) return
+    call xios_send_field(trim(name), val)
+  end subroutine
+
+
   !> Insertion sort owned elements by global index (i_index), carrying
   !> lon/lat/local-id in lock-step. ne_owned is typically ~1000-3000 per rank,
   !> so O(n^2) is fine here.
@@ -636,6 +663,7 @@ contains
   public :: io_xios_field_is_active
   public :: io_xios_send_2d_r8, io_xios_send_3d_r8
   public :: io_xios_send_2d_r4, io_xios_send_3d_r4
+  public :: io_xios_send_0d_r8, io_xios_send_0d_r4
   public :: io_xios_owned_elem_local, io_xios_n_owned_elem
   public :: io_xios_set_ice_conc, io_xios_is_ice_field
   public :: io_xios_apply_ice_mask_2d_r4, io_xios_apply_ice_mask_2d_r8
@@ -673,6 +701,16 @@ contains
   subroutine io_xios_send_3d_r4(name, buf)
     character(len=*), intent(in) :: name
     real(kind=4),     intent(in) :: buf(:,:)
+  end subroutine
+
+  subroutine io_xios_send_0d_r8(name, val)
+    character(len=*), intent(in) :: name
+    real(kind=8),     intent(in) :: val
+  end subroutine
+
+  subroutine io_xios_send_0d_r4(name, val)
+    character(len=*), intent(in) :: name
+    real(kind=4),     intent(in) :: val
   end subroutine
 
   function io_xios_owned_elem_local() result(p)


### PR DESCRIPTION
## Summary

Routes the nine CMIP CMOR 0D global scalars (`volo`, `soga`, `thetaoga`, `siarean`, `siareas`, `siextentn`, `siextents`, `sivoln`, `sivols`) through XIOS at `file_def` cadence instead of the legacy `output_0D_streams` writer.

The legacy writer produces one record per FESOM step (87600 records/year at HR `dt=400s`), which is not what CMOR / CMIP wants — these are monthly-mean diagnostics. With XIOS active, the legacy writer is now gated on `io_xios_is_on()`, the values are MPI_AllReduce'd inside `compute_cmor_diag` as before, and a thin `io_xios_send_0d_r{4,8}` wrapper around `xios_send_field` is invoked from `fesom_runloop` after `compute_diagnostics`. The resulting cadence (`1mo`, `1y`, …) is whatever the XIOS XML's `file_def` says, not the FESOM dt.