### PR TITLE
fix: melt pond ice-lid sign + caller; tune pond parameters

### DIFF
--- a/src/ice_meltponds.F90
+++ b/src/ice_meltponds.F90
@@ -20,13 +20,13 @@ module ice_meltponds
     real(kind=WP), parameter :: hs0 = 0.0_WP         ! Snow depth controlling drainage [m] 
     real(kind=WP), parameter :: hs1 = 0.03_WP        ! Snow depth threshold [m]
     real(kind=WP), parameter :: rfracmin = 0.15_WP   ! Minimum retained melt fraction
-    real(kind=WP), parameter :: rfracmax = 1.0_WP    ! Maximum retained melt fraction
+    real(kind=WP), parameter :: rfracmax = 0.5_WP    ! Maximum retained melt fraction
     real(kind=WP), parameter :: pndaspect = 0.8_WP   ! Pond aspect ratio
     real(kind=WP), parameter :: dpscale = 1.e-3_WP   ! Drainage timescale parameter
-    
-    ! Pond albedo parameters
-    real(kind=WP), parameter :: albpnd = 0.2_WP      ! Pond albedo (open water-like)
-    real(kind=WP), parameter :: albpnd_frz = 0.36_WP ! Frozen pond albedo
+
+    ! Pond albedo parameters (CICE/CESM-range)
+    real(kind=WP), parameter :: albpnd = 0.30_WP     ! Open melt pond albedo
+    real(kind=WP), parameter :: albpnd_frz = 0.50_WP ! Frozen pond albedo
     
     ! Physical constants
     real(kind=WP), parameter :: puny = 1.e-11_WP     ! Small number

--- a/src/ice_meltponds.F90
+++ b/src/ice_meltponds.F90
@@ -100,8 +100,8 @@ module ice_meltponds
         ! Current pond volume per unit area
         volpnd_init = apnd * hpnd
         
-        ! Add melt water (both surface and snow melt)
-        dvolpnd = rfrac * (meltt + melts) * dt
+        ! Add melt water (only positive contributions; freezing must not remove pond water)
+        dvolpnd = rfrac * (max(c0, meltt) + max(c0, melts)) * dt
         volpnd = volpnd_init + dvolpnd
         
         ! Pond drainage - simple exponential decay when snow is thin
@@ -136,15 +136,14 @@ module ice_meltponds
         ! Calculate fresh water flux (pond volume change)
         fpond = (volpnd - volpnd_init) / dt
         
-        ! Simple pond ice formation/melting (frozen lid)
-        if (meltt < c0 .and. apnd > puny) then
-            ! Freezing conditions - form/thicken pond ice
-            ipnd = ipnd - meltt * dt  ! meltt is negative for freezing
-            ipnd = max(c0, ipnd)
-        else
-            ! Melting conditions - melt pond ice
-            ipnd = max(c0, ipnd + meltt * dt)
-        endif
+        ! Pond ice lid update; meltt sign convention: <0 freezing, >0 melting.
+        if (meltt < c0) then
+            ! Surface freezing: thicken lid only where a pond actually exists
+            if (apnd > puny) ipnd = ipnd - meltt * dt   ! meltt<0 -> grow
+        else if (meltt > c0) then
+            ! Surface melting: thin pond ice lid
+            ipnd = max(c0, ipnd - meltt * dt)           ! meltt>0 -> shrink
+        end if
         
     end subroutine meltpond_area
     

--- a/src/ice_thermo_cpl.F90
+++ b/src/ice_thermo_cpl.F90
@@ -483,9 +483,12 @@ contains
     !---- melt pond calculations (if enabled)
     fpond = 0._WP
     if (ice%thermo%use_meltponds .and. A > Aimin) then
-        ! Calculate melt rates for pond formation
-        meltt_rate = max(0._WP, -dhgrowth)  ! Top melt rate (negative dhgrowth is melting)
-        melts_rate = max(0._WP, -dhsngrowth) ! Snow melt rate
+        ! Signed net thermodynamic tendency as proxy for surface conditions:
+        !   meltt_rate > 0  -> net melting  (top surface losing ice)
+        !   meltt_rate < 0  -> net freezing (top surface gaining ice)
+        ! meltpond_area uses the sign to drive pond-lid formation/melt.
+        meltt_rate = -dhgrowth
+        melts_rate = -dhsngrowth
         
         ! Update melt pond area and depth
         call meltpond_area(A, h, hsn, meltt_rate, melts_rate, dt, &


### PR DESCRIPTION
Fix two sign bugs in the melt-pond parameterization that let `ipnd` accumulate unbounded (>3 m at LR, >2 m at HR), and re-tune pond parameters into the CICE/CESM range.

- `ice_thermo_cpl.F90`: caller clamped meltt/melts ≥ 0 via `max(0, -dhgrowth)`, making the freezing branch in `meltpond_area` dead code. Pass signed net tendency.
- `ice_meltponds.F90`: melting branch had wrong sign (`ipnd + meltt*dt` grew the lid during melt). Restructured to a 3-way conditional; `meltt=0` is now a no-op; freezing branch only thickens lid where a pond exists.
- `ice_meltponds.F90`: clamp melt-water input ≥ 0 in `dvolpnd` so freezing does not remove pond water.

Tuning: `rfracmax` 1.0→0.5, `albpnd` 0.20→0.30, `albpnd_frz` 0.36→0.50.

Direct bug fix impact:

<img width="1020" height="600" alt="ipnd_compare_NH" src="https://github.com/user-attachments/assets/feca5edb-51c0-4d97-9188-7efd237f7077" />
<img width="1020" height="600" alt="ipnd_compare_SH" src="https://github.com/user-attachments/assets/031e6c52-240b-477b-99a9-da2cd82824b6" />


## Validation

20-yr AWI-ESM3 TCO95L91-core2 A/B (clim 1910–1919), no-fix vs fix+tune:

| variable                | no-fix | fix+tune | Δ        |
|-------------------------|--------|----------|----------|
| NH Mar area  [10⁶ km²]  | 17.19  | 16.33    | −5.0 %   |
| NH Sep area             |  4.77  |  4.93    | +3.3 %   |
| NH Sep volume [10³ km³] |  9.69  | 10.08    | +4.0 %   |
| SH Sep area             | 15.09  | 16.75    | +11.0 %  |
| SH Sep volume           |  8.73  | 10.15    | +16.2 %  |

<img width="1560" height="840" alt="20yr_trajectory" src="https://github.com/user-attachments/assets/d005cd19-cd8f-44ea-91c2-2d1d3c3d1b44" />
<img width="1560" height="1080" alt="20yr_annual_cycle" src="https://github.com/user-attachments/assets/cbd5dba0-ed7b-470f-bdca-77101b593111" />
<img width="1800" height="1080" alt="20yr_NH_sep_maps" src="https://github.com/user-attachments/assets/93418a90-9db4-464c-a289-efe12df586b1" />
<img width="1800" height="1080" alt="20yr_SH_sep_maps" src="https://github.com/user-attachments/assets/37ae951c-3761-49fb-9dfc-25e8e6653bec" />



