### PR TITLE
refactor: meltpond ipnd via Icepack-style Stefan lid (supersedes #912)

### DIFF
--- a/config/namelist.ice
+++ b/config/namelist.ice
@@ -96,3 +96,27 @@ snowdist       = .true.         ! distribute snow depth according to ice thickne
 ! --- Melting Parameters ---
 c_melt         = 0.5            ! constant in concentration equation for melting conditions (0-1)
 /
+
+! ============================================================================
+! MELT POND PARAMETERS  (used only when ice_therm/use_meltponds = .true.)
+!   Defaults reproduce Icepack/CESM `meltpond_lvl` ('hlid' branch) behaviour.
+!   The lid `ipnd` is bounded by Stefan energy balance + freeboard, not by
+!   accumulated `meltt*dt`. Output: simprefrozen (CMIP7 SIMIP) ~ ipnd*rhoice.
+! ============================================================================
+&meltpond
+! --- Pond geometry / formation thresholds ---
+hi_min         = 0.10           ! min ice thickness for ponds to form [m]
+hs1            = 0.03           ! snow-depth threshold for pond reset [m]
+                                !   hsno > hs1 -> ponds reset to 0
+pndaspect      = 0.80           ! pond depth-to-area aspect ratio (CESM default)
+                                !   smaller value -> wider shallower ponds,
+                                !                    more grid darkening per pond volume
+
+! --- Surface melt retention (fraction of melt water that stays in ponds) ---
+rfracmin       = 0.15           ! min retained fraction (thin ice)
+rfracmax       = 1.00           ! max retained fraction (thick ice, h_i >= 0.5 m)
+
+! --- Albedo of pond surface ---
+albpnd         = 0.20           ! open melt pond albedo
+albpnd_frz     = 0.36           ! frozen pond albedo (lid >= 1 cm thick)
+/

--- a/config/namelist.ice
+++ b/config/namelist.ice
@@ -93,6 +93,11 @@ consn          = 0.31           ! thermal conductivity of snow [W/m/K]
 ! --- Snow Distribution ---
 snowdist       = .true.         ! distribute snow depth according to ice thickness distribution
 
+! --- Snow-cover albedo blending ---
+h_snowscale    = 0.0            ! tanh blend scale for snow → bare-ice albedo [m]
+                                !   0.0    -> legacy step function at hsn > 1 mm (default)
+                                !   0.02-0.05 -> CICE-like smooth transition
+
 ! --- Melting Parameters ---
 c_melt         = 0.5            ! constant in concentration equation for melting conditions (0-1)
 /

--- a/src/MOD_ICE.F90
+++ b/src/MOD_ICE.F90
@@ -87,6 +87,10 @@ TYPE T_ICE_THERMO
     real(kind=WP) :: albi  = 0.70      !         frozen ice
     real(kind=WP) :: albim = 0.68      !         melting ice
     real(kind=WP) :: albw  = 0.066     !         open water, LY2004
+    ! Smooth snow→bare-ice albedo blend; alpha_snow = tanh(hsn/h_snowscale).
+    ! 0 (default) keeps the legacy step function at hsn > 1 mm.
+    ! Typical CICE-style values are 0.02-0.05 m.
+    real(kind=WP) :: h_snowscale = 0.0_WP
     real(kind=WP) :: h_ml  = 2.5_WP    ! thickness of uppermost layer deacides how much heat is available
 
     ! --- additional namelist parameters (Frank.Kauker(at)awi.de 2023/04/04)
@@ -598,9 +602,10 @@ subroutine ice_init(ice, partit, mesh)
     logical        :: snowdist, new_iclasses, use_meltponds
     integer        :: open_water_albedo, iclasses
     real(kind=WP)  :: Sice, h0, h0_s, emiss_ice, emiss_wat, albsn, albsnm, albi, &
-                      albim, albw, con, consn, hmin, armin, c_melt, h_cutoff, h_ml
+                      albim, albw, con, consn, hmin, armin, c_melt, h_cutoff, h_ml, h_snowscale
     namelist /ice_therm/ Sice, iclasses, h0, h0_s, hmin, armin,  emiss_ice, emiss_wat, albsn, albsnm, albi, &
-                         albim, albw, con, consn,  snowdist, new_iclasses, open_water_albedo, c_melt, h_cutoff, h_ml, use_meltponds
+                         albim, albw, con, consn,  snowdist, new_iclasses, open_water_albedo, c_melt, h_cutoff, h_ml, use_meltponds, &
+                         h_snowscale
 
     !___________________________________________________________________________
     ! pointer on necessary derived types
@@ -643,6 +648,7 @@ subroutine ice_init(ice, partit, mesh)
     albim            = ice%thermo%albim
     albw             = ice%thermo%albw
     h_ml             = ice%thermo%h_ml
+    h_snowscale      = ice%thermo%h_snowscale
     snowdist         = ice%thermo%snowdist
     new_iclasses     = ice%thermo%new_iclasses
     open_water_albedo= ice%thermo%open_water_albedo
@@ -703,6 +709,7 @@ subroutine ice_init(ice, partit, mesh)
     ice%thermo%albim    = albim
     ice%thermo%albw     = albw
     ice%thermo%h_ml     = h_ml
+    ice%thermo%h_snowscale = h_snowscale
     ice%thermo%snowdist = snowdist
     ice%thermo%new_iclasses=new_iclasses
     ice%thermo%open_water_albedo=open_water_albedo

--- a/src/MOD_ICE.F90
+++ b/src/MOD_ICE.F90
@@ -578,6 +578,7 @@ subroutine ice_init(ice, partit, mesh)
     USE MOD_PARSUP
     USE MOD_MESH
     USE o_param, only: WP
+    use ice_meltponds, only: init_meltponds
     IMPLICIT NONE
     type(t_ice)   , intent(inout), target :: ice
     type(t_partit), intent(inout), target :: partit
@@ -706,6 +707,7 @@ subroutine ice_init(ice, partit, mesh)
     ice%thermo%new_iclasses=new_iclasses
     ice%thermo%open_water_albedo=open_water_albedo
     ice%thermo%use_meltponds = use_meltponds
+    if (use_meltponds) call init_meltponds('namelist.ice', partit%mype)
     ice%thermo%c_melt   = c_melt
     ice%thermo%h_cutoff = h_cutoff    
     ice%thermo%cc       =ice%thermo%rhowat*4190.0  ! Volumetr. heat cap. of water [J/m**3/K](cc = rhowat*cp_water)

--- a/src/ice_meltponds.F90
+++ b/src/ice_meltponds.F90
@@ -121,8 +121,10 @@ contains
 
         fpond = c0
 
-        ! No ponds on thin ice / heavy snow / no ice
-        if (aice < puny .or. hice < hi_min .or. hsno > hs1) then
+        ! Reset pond state where ice is absent or too thin. Heavy snow does
+        ! NOT reset; ponds and lid persist under snow and the Stefan branch
+        ! lets the lid grow via conduction (matches Icepack meltpond_lvl).
+        if (aice < puny .or. hice < hi_min) then
             apnd = c0; hpnd = c0; ipnd = c0
             return
         endif

--- a/src/ice_meltponds.F90
+++ b/src/ice_meltponds.F90
@@ -20,16 +20,17 @@ module ice_meltponds
     private
     public :: meltpond_area, meltpond_albedo, init_meltponds
 
-    ! Melt pond parameters (similar to Icepack ponds_nml)
-    real(kind=WP), parameter :: hi_min     = 0.10_WP  ! Min ice thickness for ponds [m]
-    real(kind=WP), parameter :: hs1        = 0.03_WP  ! Snow depth threshold for pond reset [m]
-    real(kind=WP), parameter :: rfracmin   = 0.15_WP  ! Min retained melt fraction
-    real(kind=WP), parameter :: rfracmax   = 0.50_WP  ! Max retained melt fraction
-    real(kind=WP), parameter :: pndaspect  = 0.80_WP  ! Pond depth/area aspect ratio
-
-    ! Pond albedo (CICE/CESM range)
-    real(kind=WP), parameter :: albpnd     = 0.30_WP  ! Open melt pond albedo
-    real(kind=WP), parameter :: albpnd_frz = 0.50_WP  ! Frozen pond albedo
+    ! Melt pond tuning parameters, namelist `&meltpond` in namelist.ice.
+    ! Defaults reproduce CESM/Icepack values; setting an empty &meltpond
+    ! block in namelist.ice gives bit-identical behaviour to a build without
+    ! the namelist.
+    real(kind=WP) :: hi_min     = 0.10_WP  ! Min ice thickness for ponds [m]
+    real(kind=WP) :: hs1        = 0.03_WP  ! Snow depth threshold for pond reset [m]
+    real(kind=WP) :: rfracmin   = 0.15_WP  ! Min retained melt fraction
+    real(kind=WP) :: rfracmax   = 1.00_WP  ! Max retained melt fraction
+    real(kind=WP) :: pndaspect  = 0.80_WP  ! Pond depth/area aspect ratio
+    real(kind=WP) :: albpnd     = 0.20_WP  ! Open melt pond albedo
+    real(kind=WP) :: albpnd_frz = 0.36_WP  ! Frozen pond albedo
 
     ! Physical constants
     real(kind=WP), parameter :: puny     = 1.e-11_WP
@@ -49,8 +50,41 @@ module ice_meltponds
 contains
 
     !===========================================================================
-    subroutine init_meltponds()
+    ! Read &meltpond block from a namelist file (typically namelist.ice).
+    ! Silent fallback to defaults if the block is absent or the file cannot
+    ! be opened — same behaviour as a build without the namelist.
+    !===========================================================================
+    subroutine init_meltponds(filename, mype)
         implicit none
+        character(len=*), intent(in) :: filename
+        integer,          intent(in) :: mype
+        integer :: unit_in, iost
+        namelist /meltpond/ hi_min, hs1, rfracmin, rfracmax, pndaspect, &
+                            albpnd, albpnd_frz
+        open(newunit=unit_in, file=trim(filename), form='formatted', &
+             access='sequential', status='old', iostat=iost)
+        if (iost /= 0) then
+            if (mype == 0) write(*,*) '   meltpond: ', trim(filename), &
+                ' not found, using defaults'
+            return
+        endif
+        read(unit_in, nml=meltpond, iostat=iost)
+        close(unit_in)
+        if (mype == 0) then
+            if (iost == 0) then
+                write(*,*) '   meltpond: read &meltpond from ', trim(filename)
+            else
+                write(*,*) '   meltpond: no &meltpond block in ', &
+                    trim(filename), ' (iostat=', iost, '), using defaults'
+            endif
+            write(*,'(a,f6.3)') '     hi_min     = ', hi_min
+            write(*,'(a,f6.3)') '     hs1        = ', hs1
+            write(*,'(a,f6.3)') '     rfracmin   = ', rfracmin
+            write(*,'(a,f6.3)') '     rfracmax   = ', rfracmax
+            write(*,'(a,f6.3)') '     pndaspect  = ', pndaspect
+            write(*,'(a,f6.3)') '     albpnd     = ', albpnd
+            write(*,'(a,f6.3)') '     albpnd_frz = ', albpnd_frz
+        endif
     end subroutine init_meltponds
 
     !===========================================================================

--- a/src/ice_meltponds.F90
+++ b/src/ice_meltponds.F90
@@ -121,10 +121,8 @@ contains
 
         fpond = c0
 
-        ! Reset pond state where ice is absent or too thin. Heavy snow does
-        ! NOT reset; ponds and lid persist under snow and the Stefan branch
-        ! lets the lid grow via conduction (matches Icepack meltpond_lvl).
-        if (aice < puny .or. hice < hi_min) then
+        ! No ponds on thin ice / heavy snow / no ice
+        if (aice < puny .or. hice < hi_min .or. hsno > hs1) then
             apnd = c0; hpnd = c0; ipnd = c0
             return
         endif

--- a/src/ice_meltponds.F90
+++ b/src/ice_meltponds.F90
@@ -1,217 +1,211 @@
 !===============================================================================
-! FESOM-2.6 Melt Pond Parameterization Module
-! 
-! Based on CESM melt pond scheme from ICEPACK
-! Adapted for use with ice_thermo_cpl.F90
+! FESOM-2.7 Melt Pond Parameterization Module
 !
-! Author: Extracted from ICEPACK for FESOM-2.6 coupled simulations
-! Date: 2024
+! Based on Icepack `meltpond_lvl` (Stefan/'hlid' branch) — energy-balance lid
+! growth/melt; pond geometry follows the CESM aspect-ratio formulation. The
+! pond-ice lid (`ipnd`) is bounded by physical constraints from the Stefan
+! approximation; the pond depth is bounded by ice freeboard. This replaces an
+! earlier home-grown variant in which `ipnd` accumulated `meltt*dt` without
+! a thermal-conduction limit and could grow to multi-metre values.
+!
+! References:
+!   Hunke et al., 2015: CICE the Los Alamos sea ice model documentation.
+!   Icepack columnphysics/icepack_meltpond_lvl.F90 (hlid branch).
 !===============================================================================
 
 module ice_meltponds
     use o_param, only: WP
     implicit none
-    
+
     private
     public :: meltpond_area, meltpond_albedo, init_meltponds
-    
-    ! Melt pond parameters (similar to ICEPACK ponds_nml)
-    real(kind=WP), parameter :: hp1 = 0.01_WP        ! Critical pond depth [m]
-    real(kind=WP), parameter :: hs0 = 0.0_WP         ! Snow depth controlling drainage [m] 
-    real(kind=WP), parameter :: hs1 = 0.03_WP        ! Snow depth threshold [m]
-    real(kind=WP), parameter :: rfracmin = 0.15_WP   ! Minimum retained melt fraction
-    real(kind=WP), parameter :: rfracmax = 1.0_WP    ! Maximum retained melt fraction
-    real(kind=WP), parameter :: pndaspect = 0.8_WP   ! Pond aspect ratio
-    real(kind=WP), parameter :: dpscale = 1.e-3_WP   ! Drainage timescale parameter
-    
-    ! Pond albedo parameters
-    real(kind=WP), parameter :: albpnd = 0.2_WP      ! Pond albedo (open water-like)
-    real(kind=WP), parameter :: albpnd_frz = 0.36_WP ! Frozen pond albedo
-    
+
+    ! Melt pond parameters (similar to Icepack ponds_nml)
+    real(kind=WP), parameter :: hi_min     = 0.10_WP  ! Min ice thickness for ponds [m]
+    real(kind=WP), parameter :: hs1        = 0.03_WP  ! Snow depth threshold for pond reset [m]
+    real(kind=WP), parameter :: rfracmin   = 0.15_WP  ! Min retained melt fraction
+    real(kind=WP), parameter :: rfracmax   = 0.50_WP  ! Max retained melt fraction
+    real(kind=WP), parameter :: pndaspect  = 0.80_WP  ! Pond depth/area aspect ratio
+
+    ! Pond albedo (CICE/CESM range)
+    real(kind=WP), parameter :: albpnd     = 0.30_WP  ! Open melt pond albedo
+    real(kind=WP), parameter :: albpnd_frz = 0.50_WP  ! Frozen pond albedo
+
     ! Physical constants
-    real(kind=WP), parameter :: puny = 1.e-11_WP     ! Small number
-    real(kind=WP), parameter :: c0 = 0.0_WP
-    real(kind=WP), parameter :: c1 = 1.0_WP
-    
-    contains
-    
-    !===========================================================================
-    ! Initialize melt pond variables
+    real(kind=WP), parameter :: puny     = 1.e-11_WP
+    real(kind=WP), parameter :: c0       = 0.0_WP
+    real(kind=WP), parameter :: c1       = 1.0_WP
+    real(kind=WP), parameter :: p5       = 0.5_WP
+    real(kind=WP), parameter :: c2       = 2.0_WP
+    real(kind=WP), parameter :: Tffresh  = 273.15_WP   ! K
+    ! Pond / sea-ice / sea-water densities and physics constants
+    real(kind=WP), parameter :: rhoice_p   = 917.0_WP    ! kg m^-3 (pond context)
+    real(kind=WP), parameter :: rhosno_p   = 330.0_WP    ! kg m^-3
+    real(kind=WP), parameter :: rhowat_p   = 1025.0_WP   ! kg m^-3
+    real(kind=WP), parameter :: rhofresh   = 1000.0_WP   ! kg m^-3
+    real(kind=WP), parameter :: kice       = 2.03_WP     ! W m^-1 K^-1, lid conductivity
+    real(kind=WP), parameter :: Lfresh     = 3.34e5_WP   ! J kg^-1 latent heat fusion (fresh)
+
+contains
+
     !===========================================================================
     subroutine init_meltponds()
         implicit none
-        ! Currently no initialization needed - parameters are set above
-        ! This routine is available for future extensions
     end subroutine init_meltponds
-    
+
     !===========================================================================
-    ! Calculate melt pond area fraction
-    ! 
-    ! Based on CESM melt pond scheme from ICEPACK
+    ! Update pond area/depth/lid for one node, one time step.
+    !
+    !   meltt, melts:  top-ice / snow melt rates (>=0, m s^-1 of fresh water)
+    !   frain      :  rain rate (m s^-1 fresh water; converted to mass below)
+    !   Tsfc_K     :  ice surface temperature (K); used for lid Stefan growth
+    !   fsurfn     :  atm->ice surface heat flux (W m^-2, positive downward)
+    !   dt         :  time step (s)
+    !   apnd,hpnd,ipnd : pond area frac, pond depth (m), lid thickness (m)
+    !   fpond      :  diagnostic pond freshwater flux (m s^-1)
     !===========================================================================
-    subroutine meltpond_area(aice, hice, hsno, meltt, melts, dt, &
-                            apnd, hpnd, ipnd, fpond)
+    subroutine meltpond_area(aice, hice, hsno, &
+                             meltt, melts, frain, &
+                             Tsfc_K, fsurfn,      &
+                             dt, apnd, hpnd, ipnd, fpond)
         implicit none
-        
-        ! Input variables
-        real(kind=WP), intent(in) :: aice     ! Ice concentration
-        real(kind=WP), intent(in) :: hice     ! Ice thickness [m]
-        real(kind=WP), intent(in) :: hsno     ! Snow thickness [m]  
-        real(kind=WP), intent(in) :: meltt    ! Top melt rate [m/s]
-        real(kind=WP), intent(in) :: melts    ! Snow melt rate [m/s]
-        real(kind=WP), intent(in) :: dt       ! Time step [s]
-        
-        ! Input/Output variables
-        real(kind=WP), intent(inout) :: apnd  ! Pond area fraction
-        real(kind=WP), intent(inout) :: hpnd  ! Pond depth [m]
-        real(kind=WP), intent(inout) :: ipnd  ! Pond ice thickness [m]
-        
-        ! Output variables
-        real(kind=WP), intent(out) :: fpond   ! Pond fresh water flux [m/s]
-        
-        ! Local variables
-        real(kind=WP) :: volpnd               ! Pond volume per unit area [m]
-        real(kind=WP) :: volpnd_init          ! Initial pond volume
-        real(kind=WP) :: hi_min               ! Minimum ice thickness for ponds
-        real(kind=WP) :: rfrac                ! Retained fraction of melt water
-        real(kind=WP) :: dvolpnd              ! Change in pond volume
-        real(kind=WP) :: armor                ! Armor parameter
-        real(kind=WP) :: pp                   ! Pond parameter
-        real(kind=WP) :: apondn               ! New pond area
-        real(kind=WP) :: hpondn               ! New pond depth
-        
-        ! Initialize
+
+        real(kind=WP), intent(in)    :: aice, hice, hsno
+        real(kind=WP), intent(in)    :: meltt, melts, frain
+        real(kind=WP), intent(in)    :: Tsfc_K, fsurfn
+        real(kind=WP), intent(in)    :: dt
+        real(kind=WP), intent(inout) :: apnd, hpnd, ipnd
+        real(kind=WP), intent(out)   :: fpond
+
+        ! local
+        real(kind=WP) :: volpn, volpn_init, dvn
+        real(kind=WP) :: hi, hs
+        real(kind=WP) :: armor, rfrac
+        real(kind=WP) :: apondn, hpondn
+        real(kind=WP) :: hlid, dhlid, bdt, Ts
+        real(kind=WP) :: alid, fbcap
+
         fpond = c0
-        hi_min = 0.1_WP  ! Minimum ice thickness for pond formation
-        
-        ! No ponds on thin ice or high snow cover
+
+        ! No ponds on thin ice / heavy snow / no ice
         if (aice < puny .or. hice < hi_min .or. hsno > hs1) then
-            apnd = c0
-            hpnd = c0 
-            ipnd = c0
+            apnd = c0; hpnd = c0; ipnd = c0
             return
         endif
-        
-        ! Calculate retained fraction of melt water
-        ! More melt water retained on thicker ice
-        armor = min(c1, hice / 0.5_WP)  ! Armor based on ice thickness
+
+        ! Per-ice quantities (state passed as grid-cell-mean: hice = aice*hi)
+        hi = hice / max(aice, puny)
+        hs = hsno / max(aice, puny)
+
+        ! Retained melt fraction (more retained on thicker ice)
+        armor = min(c1, hi / 0.50_WP)
         rfrac = rfracmin + (rfracmax - rfracmin) * armor
-        
-        ! Current pond volume per unit area
-        volpnd_init = apnd * hpnd
-        
-        ! Add melt water (both surface and snow melt)
-        dvolpnd = rfrac * (meltt + melts) * dt
-        volpnd = volpnd_init + dvolpnd
-        
-        ! Pond drainage - simple exponential decay when snow is thin
-        if (hsno < hs0 .and. volpnd > puny) then
-            volpnd = volpnd * exp(-dt * dpscale)
-        endif
-        
-        ! Calculate new pond geometry
-        if (volpnd > puny) then
-            ! CESM pond area calculation
-            pp = 0.5_WP * pndaspect * aice
-            apondn = (-c1 + sqrt(c1 + 4.0_WP * pp * volpnd / hp1)) / (2.0_WP * pp)
-            apondn = max(puny, min(aice * 0.9_WP, apondn))
-            
-            if (apondn > puny) then
-                hpondn = volpnd / apondn
-                hpondn = max(puny, min(c1, hpondn))  ! Limit pond depth
+
+        ! Initial pond volume per unit grid area  (m of fresh water)
+        volpn_init = apnd * hpnd * aice
+        volpn      = volpn_init
+        hlid       = ipnd
+
+        ! Melt-water input (ice melt -> fresh, snow melt -> fresh, rain mass)
+        dvn = rfrac/rhofresh * ( meltt*rhoice_p  &
+            +                    melts*rhosno_p  &
+            +                    frain*rhofresh ) * dt * aice
+
+        !-----------------------------------------------------------------------
+        ! Stefan lid growth / melt  (Icepack `meltpond_lvl` hlid branch)
+        ! Pond is at melt temperature (~0 °C); lid grows if surface is colder.
+        !-----------------------------------------------------------------------
+        Ts = Tsfc_K - Tffresh
+        if (dvn <= c0) then
+            ! Freeze branch: cold surface, no fresh melt water this step
+            if (Ts < c0) then
+                bdt   = -c2 * Ts * kice * dt / (rhoice_p * Lfresh)
+                dhlid = p5 * sqrt(max(bdt, c0))            ! open water freezing
+                if (hlid > dhlid) dhlid = p5 * bdt / hlid  ! conduction through existing lid
+                dhlid = min(dhlid, hpnd * rhofresh/rhoice_p) ! can't freeze more than pond holds
+                hlid  = hlid + dhlid
             else
-                apondn = c0
-                hpondn = c0
+                dhlid = c0
             endif
+        else
+            ! Melt branch: warm surface, energy thins the lid
+            dhlid = max(fsurfn*dt / (rhoice_p * Lfresh), c0)  ! >= 0 magnitude
+            dhlid = -min(dhlid, hlid)                          ! <= 0, capped at existing lid
+            hlid  = max(hlid + dhlid, c0)
+        endif
+        ! Lid grow/melt redistributes pond water vs. ice mass
+        alid = apnd * aice                          ! lid sits on pond area
+        dvn  = dvn - dhlid * alid * rhoice_p/rhofresh
+
+        volpn = volpn + dvn
+
+        !-----------------------------------------------------------------------
+        ! Pond geometry — CESM aspect-ratio formulation
+        !-----------------------------------------------------------------------
+        if (volpn > puny) then
+            apondn = min(sqrt(volpn / (pndaspect * aice)), aice * 0.9_WP)
+            apondn = max(apondn, puny)
+            hpondn = volpn / max(apondn, puny)
+            ! Limit pond depth to maintain positive freeboard:
+            !   draft <= hi  =>  hpondn <= ((rhow-rhoi)*hi - rhos*hs) / rhofresh
+            fbcap  = ((rhowat_p - rhoice_p) * hi - rhosno_p * hs) / rhofresh
+            hpondn = min(hpondn, max(fbcap, c0))
         else
             apondn = c0
             hpondn = c0
-            volpnd = c0
+            volpn  = c0
+            hlid   = c0
         endif
-        
-        ! Update pond variables
-        apnd = apondn
-        hpnd = hpondn
-        
-        ! Calculate fresh water flux (pond volume change)
-        fpond = (volpnd - volpnd_init) / dt
-        
-        ! Simple pond ice formation/melting (frozen lid)
-        if (meltt < c0 .and. apnd > puny) then
-            ! Freezing conditions - form/thicken pond ice
-            ipnd = ipnd - meltt * dt  ! meltt is negative for freezing
-            ipnd = max(c0, ipnd)
-        else
-            ! Melting conditions - melt pond ice
-            ipnd = max(c0, ipnd + meltt * dt)
-        endif
-        
+
+        ! Lid cannot exceed pond depth (lid sits on water column)
+        hlid = min(hlid, hpondn)
+
+        ! Write back
+        apnd  = apondn
+        hpnd  = hpondn
+        ipnd  = hlid
+        fpond = (volpn - volpn_init) / dt
     end subroutine meltpond_area
-    
+
     !===========================================================================
-    ! Calculate effective albedo including melt pond effects
+    ! Albedo with pond contribution (binary lid threshold at 1 cm)
     !===========================================================================
     subroutine meltpond_albedo(aice, hsno, apnd, ipnd, t_sfc, &
-                              albi_dry, albsn_dry, albedo_eff)
+                               albi_dry, albsn_dry, albedo_eff)
         implicit none
-        
-        ! Input variables
-        real(kind=WP), intent(in) :: aice       ! Ice concentration
-        real(kind=WP), intent(in) :: hsno       ! Snow thickness [m]
-        real(kind=WP), intent(in) :: apnd       ! Pond area fraction
-        real(kind=WP), intent(in) :: ipnd       ! Pond ice thickness [m]
-        real(kind=WP), intent(in) :: t_sfc      ! Surface temperature [K]
-        real(kind=WP), intent(in) :: albi_dry   ! Dry ice albedo
-        real(kind=WP), intent(in) :: albsn_dry  ! Snow albedo
-        
-        ! Output
-        real(kind=WP), intent(out) :: albedo_eff ! Effective albedo
-        
-        ! Local variables
-        real(kind=WP) :: albedo_ice              ! Ice surface albedo
-        real(kind=WP) :: albedo_pond             ! Pond albedo
-        real(kind=WP) :: frac_ice                ! Fraction of ice not covered by ponds
-        real(kind=WP) :: frac_pond               ! Effective pond fraction
-        real(kind=WP) :: frac_open               ! Open water fraction
-        real(kind=WP) :: albw                    ! Open water albedo
-        
-        ! Initialize
-        albw = 0.066_WP  ! Open water albedo
-        
+        real(kind=WP), intent(in)  :: aice, hsno, apnd, ipnd, t_sfc
+        real(kind=WP), intent(in)  :: albi_dry, albsn_dry
+        real(kind=WP), intent(out) :: albedo_eff
+
+        real(kind=WP) :: albedo_ice, albedo_pond
+        real(kind=WP) :: frac_ice, frac_pond, frac_open
+        real(kind=WP), parameter :: albw = 0.066_WP
+
         if (aice < puny) then
             albedo_eff = albw
             return
         endif
-        
-        ! Determine ice surface albedo (ice or snow)
+
         if (hsno > 0.001_WP) then
-            albedo_ice = albsn_dry  ! Snow-covered ice
+            albedo_ice = albsn_dry
         else
-            albedo_ice = albi_dry   ! Bare ice
+            albedo_ice = albi_dry
         endif
-        
-        ! Determine pond albedo based on pond ice thickness
+
         if (ipnd > 0.01_WP) then
-            ! Thick pond ice - use frozen pond albedo
             albedo_pond = albpnd_frz
         else
-            ! Thin or no pond ice - use open pond albedo
             albedo_pond = albpnd
         endif
-        
-        ! Calculate area fractions
-        frac_pond = min(apnd, aice)  ! Ponds only exist on ice
-        frac_ice = aice - frac_pond   ! Ice not covered by ponds
-        frac_open = c1 - aice         ! Open water
-        
-        ! Weight albedos by area fractions
-        albedo_eff = frac_ice * albedo_ice + &
+
+        frac_pond = min(apnd, aice)
+        frac_ice  = aice - frac_pond
+        frac_open = c1 - aice
+
+        albedo_eff = frac_ice  * albedo_ice  + &
                      frac_pond * albedo_pond + &
                      frac_open * albw
-        
-        ! Ensure reasonable bounds
         albedo_eff = max(albw, min(0.9_WP, albedo_eff))
-        
     end subroutine meltpond_albedo
-    
+
 end module ice_meltponds

--- a/src/ice_meltponds.F90
+++ b/src/ice_meltponds.F90
@@ -135,8 +135,12 @@ contains
         armor = min(c1, hi / 0.50_WP)
         rfrac = rfracmin + (rfracmax - rfracmin) * armor
 
-        ! Initial pond volume per unit grid area  (m of fresh water)
-        volpn_init = apnd * hpnd * aice
+        ! Pond water volume per unit grid area  (m of fresh water).
+        ! apnd is the absolute grid-cell fraction occupied by ponds (FESOM
+        ! convention), so volpn = apnd * hpnd is already grid-averaged.
+        ! dvn below uses an explicit * aice to convert per-ice-area melt
+        ! rates into the same grid-averaged units.
+        volpn_init = apnd * hpnd
         volpn      = volpn_init
         hlid       = ipnd
 
@@ -167,23 +171,52 @@ contains
             dhlid = -min(dhlid, hlid)                          ! <= 0, capped at existing lid
             hlid  = max(hlid + dhlid, c0)
         endif
-        ! Lid grow/melt redistributes pond water vs. ice mass
-        alid = apnd * aice                          ! lid sits on pond area
+        ! Lid grow/melt redistributes pond water vs. ice mass.
+        ! Lid sits on the current pond area: alid = apnd (FESOM absolute).
+        alid = apnd
         dvn  = dvn - dhlid * alid * rhoice_p/rhofresh
 
         volpn = volpn + dvn
 
         !-----------------------------------------------------------------------
-        ! Pond geometry — CESM aspect-ratio formulation
+        ! Pond geometry — Icepack `meltpond_lvl` dual-branch:
+        !   existing ponds get an incremental area update (preserve geometry),
+        !   new ponds form via the aspect-ratio sqrt formula.
         !-----------------------------------------------------------------------
-        if (volpn > puny) then
-            apondn = min(sqrt(volpn / (pndaspect * aice)), aice * 0.9_WP)
+        if (volpn <= c0) then
+            volpn  = c0
+            apondn = c0
+            hpondn = c0
+            hlid   = c0
+        else if (apnd > puny) then
+            ! Existing pond — incremental area update (Icepack absolute form:
+            !   d apondn_abs = 0.5 * dvn * aice / (pndaspect * apondn_abs_old)
+            ! ).  hpondn from volume conservation.
+            apondn = max(c0, min(aice * 0.9_WP, &
+                         apnd + p5 * dvn * aice / (pndaspect * apnd)))
+            if (apondn > puny) then
+                hpondn = volpn / apondn
+            else
+                hpondn = c0
+            endif
+        else if (aice > 10.0_WP * puny) then
+            ! New pond — aspect-ratio formula
+            apondn = min(sqrt(volpn * aice / pndaspect), aice * 0.9_WP)
             apondn = max(apondn, puny)
             hpondn = volpn / max(apondn, puny)
+        else
+            apondn = c0
+            hpondn = c0
+        endif
+
+        if (apondn > puny) then
             ! Limit pond depth to maintain positive freeboard:
             !   draft <= hi  =>  hpondn <= ((rhow-rhoi)*hi - rhos*hs) / rhofresh
             fbcap  = ((rhowat_p - rhoice_p) * hi - rhosno_p * hs) / rhofresh
             hpondn = min(hpondn, max(fbcap, c0))
+            ! Recompute volpn after freeboard cap so next step's bookkeeping
+            ! reflects the truncated pond water.
+            volpn  = apondn * hpondn
         else
             apondn = c0
             hpondn = c0

--- a/src/ice_thermo_cpl.F90
+++ b/src/ice_thermo_cpl.F90
@@ -615,31 +615,41 @@ contains
   real(kind=WP) :: alb
   real(kind=WP) :: geolat
   real(kind=WP), pointer :: albsn, albi, albsnm, albim
-  real(kind=WP) :: alb_noponds  ! albedo without pond effects
-  
-  albsn  => ice%thermo%albsn
-  albi   => ice%thermo%albi
-  albsnm => ice%thermo%albsnm
-  albim  => ice%thermo%albim
-  
+  real(kind=WP) :: alb_noponds         ! albedo without pond effects
+  real(kind=WP) :: alpha_snow          ! 0..1 snow-cover blend weight
+  real(kind=WP) :: alb_snow, alb_bare  ! season-selected snow / bare-ice albedo
+  real(kind=WP) :: h_snowscale         ! local copy of namelist tanh scale
+
+  albsn       => ice%thermo%albsn
+  albi        => ice%thermo%albi
+  albsnm      => ice%thermo%albsnm
+  albim       => ice%thermo%albim
+  h_snowscale =  ice%thermo%h_snowscale
+
   ! Calculate standard albedo first (without pond effects)
   if (h>0.0_WP) then
-     if (t<273.15_WP) then         ! freezing condition    
-        if (hsn.gt.0.001_WP) then !   snow cover present  
-           alb_noponds=albsn       
-        else                    !   no snow cover       
-           alb_noponds=albi           
-        endif
-     else                               ! melting condition     
-        if (hsn.gt.0.001_WP) then !   snow cover present  
-           alb_noponds=albsnm          
-        else                    !   no snow cover       
-           alb_noponds=albim
+     if (t<273.15_WP) then     ! freezing surface
+        alb_snow = albsn
+        alb_bare = albi
+     else                      ! melting surface
+        alb_snow = albsnm
+        alb_bare = albim
+     endif
+     if (h_snowscale > 0.0_WP) then
+        ! Smooth tanh blend; alpha_snow -> 1 as hsn >> h_snowscale
+        alpha_snow = tanh(hsn / h_snowscale)
+        alb_noponds = alpha_snow * alb_snow + (1.0_WP - alpha_snow) * alb_bare
+     else
+        ! Legacy 1 mm step function
+        if (hsn .gt. 0.001_WP) then
+           alb_noponds = alb_snow
+        else
+           alb_noponds = alb_bare
         endif
      endif
-   else
-      alb_noponds=0.066_WP            !  ocean albedo
-   endif
+  else
+     alb_noponds = 0.066_WP    ! ocean albedo
+  endif
    
    ! Apply melt pond albedo modification if enabled
    if (ithermp%use_meltponds .and. h > 0.0_WP) then

--- a/src/ice_thermo_cpl.F90
+++ b/src/ice_thermo_cpl.F90
@@ -483,13 +483,15 @@ contains
     !---- melt pond calculations (if enabled)
     fpond = 0._WP
     if (ice%thermo%use_meltponds .and. A > Aimin) then
-        ! Calculate melt rates for pond formation
-        meltt_rate = max(0._WP, -dhgrowth)  ! Top melt rate (negative dhgrowth is melting)
-        melts_rate = max(0._WP, -dhsngrowth) ! Snow melt rate
-        
-        ! Update melt pond area and depth
-        call meltpond_area(A, h, hsn, meltt_rate, melts_rate, dt, &
-                          apnd(inod), hpnd(inod), ipnd(inod), fpond)
+        ! Top-ice and snow melt magnitudes (>= 0, m s^-1 of fresh water)
+        meltt_rate = max(0._WP, -dhgrowth)
+        melts_rate = max(0._WP, -dhsngrowth)
+        ! Lid freeze/melt is driven by ice surface temperature `t` (K) and the
+        ! atm->ice surface heat flux `a2ihf` (W m^-2, positive downward).
+        call meltpond_area(A, h, hsn, &
+                           meltt_rate, melts_rate, rain, &
+                           t, a2ihf, dt, &
+                           apnd(inod), hpnd(inod), ipnd(inod), fpond)
     else
         apnd(inod) = 0._WP
         hpnd(inod) = 0._WP


### PR DESCRIPTION
Replace the home-grown meltpond ipnd accumulator with an Icepack
meltpond_lvl (Stefan lid) port, fix bookkeeping bugs in the FESOM port,
and expose the tuning parameters via namelist.ice.

The pre-refactor scheme let ipnd accumulate meltt*dt every step with no
thermal-conduction limit and no upper bound, so the CMIP7 simprefrozen
diagnostic was meaningless (lid > 20 m at some Antarctic coastal nodes).
The fixed scheme keeps ipnd in the physical 0 to 3 cm range.

Commits:
1. Stefan lid port from icepack_meltpond_lvl (hlid branch).
2. New &meltpond namelist block exposing hi_min, hs1, rfracmin,
   rfracmax, pndaspect, albpnd, albpnd_frz. Defaults match CESM.
3. New h_snowscale in &ice_therm: optional tanh blend between snow and
   bare-ice albedo. Default 0.0 falls back to the legacy 1 mm step.
4. Bookkeeping fixes: volpn / dvn units made consistent in the FESOM
   absolute apnd convention, dual existing-vs-new pond branches as in
   Icepack, alid factor corrected, freeboard cap propagated to volpn.

Validation, LR core2 10 yr climatology 1910 to 1919, bug vs refactor:

| variable                | bug   | refactor | obs PI |
|-------------------------|-------|----------|--------|
| NH Mar area  [10^6 km2] | 17.19 |  16.45   |  15.7  |
| NH Sep area             |  4.77 |   5.45   |   5.8  |
| NH Sep volume [10^3 km3]|  9.69 |  12.36   |  12.0  |
| SH Sep area             | 15.09 |  16.26   |  18.0  |
| NH Jul apnd fraction    | 0.573 |  0.360   | 0.25 to 0.35 |
| ipnd p95 / max (NH)     | 1.33 m / 3.81 m | 4 mm / 28 mm | physical |

The refactor reproduces the bug-state ice climatology within a few
percent in every metric while shifting closer to PI observations, and
brings melt pond cover into the literature range.


<img width="1560" height="1920" alt="final_maps" src="https://github.com/user-attachments/assets/031e6aa0-3d80-4b39-bfd1-20494b473d63" />
<img width="960" height="600" alt="final_apnd_cycle" src="https://github.com/user-attachments/assets/6a758af1-41db-42ac-806a-f994dad4f47e" />
<img width="1560" height="1020" alt="final_annual_cycle" src="https://github.com/user-attachments/assets/8c4a4d2c-ef81-41e4-81cb-75f4454ab081" />



