### PR TITLE
Bugfix in MOD_ICE. Wrong array allocation for alpha_evp_array in case…

### DIFF
--- a/src/MOD_ICE.F90
+++ b/src/MOD_ICE.F90
@@ -759,8 +759,8 @@ subroutine ice_init(ice, partit, mesh)
         ice%vice_aux    = 0.0_WP
     end if
     if (ice%whichEVP == 2) then
-        allocate(ice%alpha_evp_array(  node_size))
-        allocate(ice%beta_evp_array(   node_size))
+        allocate(ice%alpha_evp_array(  elem_size))   ! element-indexed in stress_tensor_a/find_alpha_field_a
+        allocate(ice%beta_evp_array(   node_size))   ! node-indexed in ice_momentum_step_a
         ice%alpha_evp_array = ice%alpha_evp
         ice%beta_evp_array  = ice%alpha_evp
     end if

--- a/src/solver.F90
+++ b/src/solver.F90
@@ -220,27 +220,6 @@ subroutine ssh_solve_cg(x, rhs, solverinfo, partit, mesh)
 
   call MPI_Allreduce(MPI_IN_PLACE, s_aux, 1, MPI_DOUBLE, MPI_SUM, partit%MPI_COMM_FESOM, MPIerr)
 
-  ! *** CG breakdown check ***
-  ! s_aux = p^T A p must be strictly positive for a SPD matrix.
-  ! If it is zero, negative, or NaN the matrix has lost positive definiteness
-  ! (ill-conditioned stiffness matrix, too large dt, or extreme ssh forcing).
-  ! Without this guard al = s_old/s_aux produces NaN/Inf which then silently
-  ! poisons d_eta -> UV -> Wvel through the rest of the time step.
-  if (s_aux <= 0.0_WP .or. s_aux /= s_aux) then
-      if (mype == 0) then
-          write(*,*)
-          write(*,*) '*** CG BREAKDOWN in ssh_solve_cg ***'
-          write(*,*) '    iter   = ', iter
-          write(*,*) '    s_aux  = p^T A p = ', s_aux   ! should be > 0
-          write(*,*) '    s_old  = r^T z   = ', s_old
-          write(*,*) '    rtol   = ', rtol
-          write(*,*) '    --> stiffness matrix lost positive definiteness'
-          write(*,*) '    --> likely cause: dt too large for mesh resolution,'
-          write(*,*) '    -->               extreme ssh forcing, or large dhe'
-      end if
-      exit   ! keep current X (d_eta) rather than overwriting it with NaN
-  end if
-
   al=s_old/s_aux
      ! ===========
      ! New X and residual r

--- a/src/solver.F90
+++ b/src/solver.F90
@@ -219,6 +219,28 @@ subroutine ssh_solve_cg(x, rhs, solverinfo, partit, mesh)
 #endif
 
   call MPI_Allreduce(MPI_IN_PLACE, s_aux, 1, MPI_DOUBLE, MPI_SUM, partit%MPI_COMM_FESOM, MPIerr)
+
+  ! *** CG breakdown check ***
+  ! s_aux = p^T A p must be strictly positive for a SPD matrix.
+  ! If it is zero, negative, or NaN the matrix has lost positive definiteness
+  ! (ill-conditioned stiffness matrix, too large dt, or extreme ssh forcing).
+  ! Without this guard al = s_old/s_aux produces NaN/Inf which then silently
+  ! poisons d_eta -> UV -> Wvel through the rest of the time step.
+  if (s_aux <= 0.0_WP .or. s_aux /= s_aux) then
+      if (mype == 0) then
+          write(*,*)
+          write(*,*) '*** CG BREAKDOWN in ssh_solve_cg ***'
+          write(*,*) '    iter   = ', iter
+          write(*,*) '    s_aux  = p^T A p = ', s_aux   ! should be > 0
+          write(*,*) '    s_old  = r^T z   = ', s_old
+          write(*,*) '    rtol   = ', rtol
+          write(*,*) '    --> stiffness matrix lost positive definiteness'
+          write(*,*) '    --> likely cause: dt too large for mesh resolution,'
+          write(*,*) '    -->               extreme ssh forcing, or large dhe'
+      end if
+      exit   ! keep current X (d_eta) rather than overwriting it with NaN
+  end if
+
   al=s_old/s_aux
      ! ===========
      ! New X and residual r


### PR DESCRIPTION
… of aEVP.

After restarting AWI-ESM3 and changing from mEVP to aEVP at the same time, Fesom crashes with Wvel becoming NaNs.

After debugging, a wrong allocation of the alpha_evp_array was found causing Fesom to crash.

A short explanation:

> Root cause: alpha_evp_array allocation was wrong size
> In MOD_ICE.F90 (same bug in both v3.4.1 and v3.4.2):
> 
> 
> ! BEFORE (wrong):
> allocate(ice%alpha_evp_array(node_size))   ! node_size ≈ nod2D
> ! AFTER (fixed):
> allocate(ice%alpha_evp_array(elem_size))   ! elem_size ≈ 2×nod2D ← elements on a triangulated mesh
>
> alpha_evp_array is indexed by element throughout ice_maEVP.F90 (in stress_tensor_a, find_alpha_field_a, find_alpha_field_a_beta), but was allocated with the number of nodes — roughly half the number of elements. Every access for elem > node_size was out-of-bounds, reading/writing into adjacent allocations (likely beta_evp_array), corrupting both arrays.
> 
> Why it didn't crash with whichEVP=1 (mEVP): The if (ice%whichEVP == 2) block is completely skipped — these arrays are never allocated or accessed.
> 
> Why it crashed in the first days/weeks with whichEVP=2 (aEVP): The corruption builds up over timesteps as find_alpha_field_a overwrites beta_evp_array memory with the out-of-bounds write, and stress_tensor_a reads garbage alpha values, eventually producing extreme ice stress → stress_surf ~ -8800 → SSH RHS = NaN → CG breakdown at iter=1.