### PR TITLE
Fix segfault in mesh partitioner on large meshes

### DIFF
--- a/src/fvom_init.F90
+++ b/src/fvom_init.F90
@@ -212,11 +212,24 @@ INTEGER                             :: i_error
   ! purely triangular, with 3 columns each. Test, how many
   ! columns there are!  
   read(21,*,iostat=i_error) elem_data(1:4*mesh%elem2D)
+  ! NR Do NOT use reshape() here: ifort places the array temporary it
+  !    creates on the stack, which overflows for large meshes (ng5 etc.)
+  !    and causes a segfault in read_mesh_ini. Copy element by element
+  !    instead, which needs no temporary and works for any mesh size.
   if (i_error == 0) then      ! There is a fourth column => quad or mixed mesh (not working yet!)
-     mesh%elem2D_nodes = reshape(elem_data, shape(mesh%elem2D_nodes))
+     do n=1, mesh%elem2D
+        mesh%elem2D_nodes(1,n) = elem_data(4*n-3)
+        mesh%elem2D_nodes(2,n) = elem_data(4*n-2)
+        mesh%elem2D_nodes(3,n) = elem_data(4*n-1)
+        mesh%elem2D_nodes(4,n) = elem_data(4*n)
+     end do
   else     ! No fourth column => triangles only
-     mesh%elem2D_nodes(1:3,:) = reshape(elem_data, shape(mesh%elem2D_nodes(1:3,:)))
-     mesh%elem2D_nodes(4,:)   = mesh%elem2D_nodes(1,:)
+     do n=1, mesh%elem2D
+        mesh%elem2D_nodes(1,n) = elem_data(3*n-2)
+        mesh%elem2D_nodes(2,n) = elem_data(3*n-1)
+        mesh%elem2D_nodes(3,n) = elem_data(3*n)
+        mesh%elem2D_nodes(4,n) = elem_data(3*n-2)  ! 4th node = 1st node for triangles
+     end do
   end if
     
   deallocate(elem_data)


### PR DESCRIPTION
## Problem

`fesom_meshpart` segfaults in `read_mesh_ini` on large meshes (e.g. ng5,
7.4M nodes / 14.7M elements) while smaller meshes (e.g. core2) work. The crash
happens right after `read elem2d.out & nod2d.out`, before `Mesh is read`:

```
read_mesh_ini_()
MAIN__()
```

## Root cause

`read_mesh_ini` builds `elem2D_nodes` with `reshape(elem_data, ...)`. ifort
places the array temporary `reshape` creates on the stack. For ng5 that
temporary is `3 * elem2D * 4 bytes` ≈ 177 MB, which overflows the stack and
segfaults on the first write into it. The fault address is in the stack region,
and the disassembly shows a mesh-sized `sub %rsp` right before the faulting
store. core2's temporary is ~2.9 MB, so it fits and works.

It is not an integer overflow (`3*elem2D` and `4*elem2D` fit in int32 here).
The code is unchanged since 2019; the current build (no `-heap-arrays`) plus the
stack limit is what exposed the latent issue. With the default 8 MB stack even
moderately large meshes would hit this.

## Fix

Replace the two `reshape` calls with explicit element-wise copy loops. No
temporary is created, so it works at any mesh size, independent of compiler or
`ulimit -s`. The column-major element-node layout is preserved exactly.

## Verification

Output is bit-identical to the previous code for any mesh the old code could
process:

- Isolated equivalence test (`reshape` vs loop, both the triangular and quad
  branches, 100k elements): 0 differing entries.
- End-to-end on core2, old binary (`reshape`) vs new binary (loop): every
  produced file is bit-identical — the full `dist_12/` partition set
  (`rpart.out`, `my_list*`, `com_info*`), `edges.out`, `edge_tri.out`,
  `edgenum.out`, `elvls*`, `nlvls*`; same METIS edgecut.
- ng5 now partitions without crashing.
