### PR TITLE
Revert seta calculation from #924

### DIFF
--- a/src/cavity_param.F90
+++ b/src/cavity_param.F90
@@ -357,7 +357,7 @@ subroutine cavity_heat_water_fluxes_3eq(ice, dynamics, tracers, partit, mesh)
         
         !_______________________________________________________________________
         ! Calculate the melting/freezing rate [m/s]
-        ! seta = rhow / rhofw * gas * (1.0-sal/sf)
+        ! seta = ep5*(1.0-sal/sf)     !rt thinks this is not needed, ep5=gas/rhor
         !rt  t_surf_flux(i,j)=gat*(tf-tin)
         !rt  s_surf_flux(i,j)=gas*(sf-(s(i,j,N,lrhs)+35.0))
         


### PR DESCRIPTION
I didn't add the `ep5` var back in the code because it is not used anymore but left it in the comment, in case someone needs it again.

From @RalphTimmermann's [comment](https://github.com/FESOM/fesom2/pull/924#issuecomment-4621853449).