### PR TITLE
Account for additional fields from Lars iceberg fix in oifs

### DIFF
--- a/src/MOD_ICE.F90
+++ b/src/MOD_ICE.F90
@@ -161,7 +161,7 @@ TYPE T_ICE
     !___________________________________________________________________________
     ! total number of ice tracers (default=3, 1=area, 2=mice, 3=msnow, (4=ice_temp)
 #if defined (__oifs) || defined (__ifsinterface)
-    integer                                     :: num_itracers=4
+    integer                                     :: num_itracers=6
 #else
 !    integer                                     :: num_itracers=3
     !------------------------------


### PR DESCRIPTION
This fixes an oifs crash right after the first coupling in awiesm3-v3.4.2. Lars added two fields and oifs was receiving 0K for the ice temperature which caused a floating point exception. 