### PR TITLE
Add exceptions for fw and fh for xios wet masking

### DIFF
--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -2456,7 +2456,7 @@ subroutine write_mean(entry, entry_index)
                 tm0 = MPI_Wtime()
                 if (io_xios_is_ice_field(entry%name)) then
                    call io_xios_apply_ice_mask_2d_elem_r8(tmp2_r8)
-                else
+                else if (trim(entry%name) /= 'fw' .and. trim(entry%name) /= 'fh') then
                    call io_xios_apply_wet_2d_elem_r8(tmp2_r8)
                 end if
                 tm1 = MPI_Wtime(); rtime_om_mask = rtime_om_mask + (tm1 - tm0)
@@ -2489,7 +2489,7 @@ subroutine write_mean(entry, entry_index)
                 tm0 = MPI_Wtime()
                 if (io_xios_is_ice_field(entry%name)) then
                    call io_xios_apply_ice_mask_2d_elem_r4(tmp2_r4)
-                else
+                else if (trim(entry%name) /= 'fw' .and. trim(entry%name) /= 'fh') then
                    call io_xios_apply_wet_2d_elem_r4(tmp2_r4)
                 end if
                 tm1 = MPI_Wtime(); rtime_om_mask = rtime_om_mask + (tm1 - tm0)
@@ -2526,7 +2526,7 @@ subroutine write_mean(entry, entry_index)
                 tm0 = MPI_Wtime()
                 if (io_xios_is_ice_field(entry%name)) then
                    call io_xios_apply_ice_mask_2d_r8(tmp2_r8)
-                else
+                else if (trim(entry%name) /= 'fw' .and. trim(entry%name) /= 'fh') then
                    call io_xios_apply_wet_2d_r8(tmp2_r8)
                 end if
                 tm1 = MPI_Wtime(); rtime_om_mask = rtime_om_mask + (tm1 - tm0)
@@ -2561,7 +2561,7 @@ subroutine write_mean(entry, entry_index)
                 tm0 = MPI_Wtime()
                 if (io_xios_is_ice_field(entry%name)) then
                    call io_xios_apply_ice_mask_2d_r4(tmp2_r4)
-                else
+                else if (trim(entry%name) /= 'fw' .and. trim(entry%name) /= 'fh') then
                    call io_xios_apply_wet_2d_r4(tmp2_r4)
                 end if
                 tm1 = MPI_Wtime(); rtime_om_mask = rtime_om_mask + (tm1 - tm0)


### PR DESCRIPTION
Currently all files get "dry masked" by xios, i.e. the file content on cavity nodes is set to nan. The 2d fields fh and fw for freshwater flux and heat flux, however, are populated with the cavity heat flux and freshwater flux on cavity nodes - which are currently masked out and also set to nan. This fix adds an exception for these two files as these are fundamental cavity diagnostics.