### PR TITLE
Introduce scaling factor for grounded iceberg velocity

### DIFF
--- a/src/icb_step.F90
+++ b/src/icb_step.F90
@@ -507,9 +507,8 @@ if((local_idx_of(iceberg_elem)>0) .and. (local_idx_of(iceberg_elem)<=partit%myDi
   
   !=================CHECK IF ICEBERG IS GROUNDED...===================
  old_element = iceberg_elem !save if iceberg left model domain
- if((draft_scale(ib)*abs(depth_ib) .gt. Zdepth) .and. l_allowgrounding ) then 
- !if((draft_scale(ib)*abs(depth_ib) .gt. minval(Zdepth3)) .and. l_allowgrounding ) then 
-   !icebergs remains stationary (iceberg can melt above in iceberg_dyn!)
+ if((draft_scale(ib)*abs(depth_ib) .gt. Zdepth) .and. l_allowgrounding ) then  
+   ! grounded iceberg velocity is scaled down by a factor (0, 1] according to Marsh et al. https://doi.org/10.5194/gmd-8-1547-2015 (iceberg can melt above in iceberg_dyn!)
     left_mype = 0.0 
     fact=1.0-((draft_scale(ib)*abs(depth_ib)-Zdepth) / (draft_scale(ib)*abs(depth_ib)))
     u_ib = u_ib * fact

--- a/src/icb_step.F90
+++ b/src/icb_step.F90
@@ -353,6 +353,7 @@ use iceberg_params, only: length_ib, width_ib, scaling, elem_block, elem_area_gl
  !for grounding										!=
  real, dimension(3)		:: Zdepth3						!=
  real				:: Zdepth						!=
+ real               :: fact                 ! factor to scale down the velocity of grounded icebergs 
  											!=
  real, dimension(2)             :: coords_tmp
 ! integer, pointer  :: mype
@@ -510,8 +511,9 @@ if((local_idx_of(iceberg_elem)>0) .and. (local_idx_of(iceberg_elem)<=partit%myDi
  !if((draft_scale(ib)*abs(depth_ib) .gt. minval(Zdepth3)) .and. l_allowgrounding ) then 
    !icebergs remains stationary (iceberg can melt above in iceberg_dyn!)
     left_mype = 0.0 
-    u_ib = 0.0
-    v_ib = 0.0
+    fact=1.0-((draft_scale(ib)*abs(depth_ib)-Zdepth) / (draft_scale(ib)*abs(depth_ib)))
+    u_ib = u_ib * fact
+    v_ib = v_ib * fact
     old_lon = lon_rad
     old_lat = lat_rad
  


### PR DESCRIPTION
Added a scaling factor to adjust the velocity of grounded icebergs instead of setting it to 0 based on Marsh et al. (https://doi.org/10.5194/gmd-8-1547-2015). Depending on the seafloor depth and the iceberg draft of grounded icebergs the velocity is scaled down by a factor in the range (0, 1] to slow down grounded icebergs rather than making them stop. Grounded icebergs that do not move at all are rare in reality, they are e.g. lifted and ungrounded by tides frequently.

@ackerlar, is this a good default or should I make this optional with a namelist flag to enable this feature?

Kudos to @cwekerle :) 