### PR TITLE
cavity: reset restart hnode to the mesh nominal in restart_thickness_ale (moving cavity)

### DIFF
--- a/src/oce_ale.F90
+++ b/src/oce_ale.F90
@@ -1293,15 +1293,30 @@ subroutine restart_thickness_ale(partit, mesh)
         do n=1, myDim_nod2D+eDim_nod2D
             nzmin = ulevels_nod2D(n)
             nzmax = nlevels_nod2D(n)-1
-            
+
             !___________________________________________________________________
-            ! if there is a cavity layer thickness is not updated, its 
-            ! kept fixed 
-            if (nzmin > 1) cycle
-            
+            ! Cavity columns AND their open-ocean edge ring (any node touching
+            ! a cavity element, ulevels_nod2D_max>1 -- the same exclusion class
+            ! as the per-step hnode<->hnode_new sync loop) keep layer
+            ! thicknesses fixed at the mesh nominal (hnode_new from
+            ! init_thickness_ale, untouched by the restart read). A restart
+            ! hnode deviating from that nominal (e.g. remapped from a formerly
+            ! ice-free zstar column) would persist forever, and the tracer T*
+            ! update applies the mismatch as a multiplicative content drain
+            ! every step. Force restart hnode to the nominal and rebuild the
+            ! depth arrays.
+            if (ulevels_nod2D_max(n) > 1) then
+                hnode(nzmin:nzmax,n) = hnode_new(nzmin:nzmax,n)
+                do nz=nzmax,nzmin,-1
+                    zbar_3d_n(nz,n) = zbar_3d_n(nz+1,n) + hnode(nz,n)
+                    Z_3d_n(nz,n)    = zbar_3d_n(nz+1,n) + hnode(nz,n)/2.0_WP
+                end do
+                cycle
+            end if
+
             !___________________________________________________________________
             ! be sure that bottom layerthickness uses partial cell layer thickness
-            ! in case its activated, especially when you make a restart from a non 
+            ! in case its activated, especially when you make a restart from a non
             ! partiall cell runs towards a simulation with partial cells
             hnode(nzmax,n) = bottom_node_thickness(n)
             


### PR DESCRIPTION
## What

Fixes a persistent tracer-content drain when restarting a run whose ice-shelf **cavity geometry has changed between legs** — i.e. a **moving-cavity** coupled setup (FESOM ↔ an ice-sheet model such as PISM, where the ice-shelf draft is updated and the mesh regenerated/remapped each coupling leg).

## Why it only bites a moving cavity

In `restart_thickness_ale`, cavity columns (and their open-ocean edge ring — any node touching a cavity element, `ulevels_nod2D_max > 1`) keep their layer thicknesses fixed at the mesh nominal (`hnode_new` from `init_thickness_ale`, the same exclusion class as the per-step `hnode`↔`hnode_new` sync loop). The previous code `cycle`d these columns on the restart read.

With a **static** mesh that is harmless: the restart `hnode` equals the nominal, so nothing drifts. But when the cavity **moves**, a column that was open-ocean zstar in the leg that *wrote* the restart can be cavity (or edge-ring) in the leg that *reads* it, so its remapped restart `hnode` no longer matches the new mesh's nominal. Because the column is `cycle`d, that mismatch **persists forever**, and the tracer `T*` update then applies it as a multiplicative content drain every step.

## Fix

For cavity/edge-ring columns, force restart `hnode` to the nominal (`hnode_new`) and rebuild the depth arrays (`zbar_3d_n`, `Z_3d_n`) before `cycle`. Open-ocean columns are unchanged, so static-mesh and non-cavity runs are entirely unaffected.
