### PR TITLE
icebergs: allow ib_num = 0

### DIFF
--- a/src/icb_step.F90
+++ b/src/icb_step.F90
@@ -253,7 +253,7 @@ end do
 
  if (mod(istep_end_synced,icb_outfreq)==0 .AND. .not.ascii_out) then
 
-   if (mype==0) call write_buoy_props_netcdf(partit)
+   if (mype==0 .AND. ib_num > 0) call write_buoy_props_netcdf(partit)
        
    ! all PEs: set back to zero for next round
    bvl_mean=0.0
@@ -1234,7 +1234,7 @@ type(t_partit), intent(inout), target :: partit
   write(*,*) 'read iceberg restart file'
 
   !if(.NOT.ascii_out) call determine_save_count ! computed from existing records in netcdf file
-  if(.NOT.ascii_out) call init_buoy_output(partit)
+  if(.NOT.ascii_out .AND. ib_num > 0) call init_buoy_output(partit)
   !call init_icebergs_with_icesheet ! all PEs read LON,LAT,LENGTH from files
 
   !write(*,*) '*************************************************************'
@@ -1244,7 +1244,7 @@ type(t_partit), intent(inout), target :: partit
   if(mype==0) then
   write(*,*) 'no iceberg restart'
 
-  if(.NOT.ascii_out) call init_buoy_output(partit)
+  if(.NOT.ascii_out .AND. ib_num > 0) call init_buoy_output(partit)
 
   end if
 
@@ -1301,7 +1301,7 @@ type(t_partit), intent(inout), target :: partit
   write(*,*) 'read iceberg restart file'
 
   !if(.NOT.ascii_out) call determine_save_count ! computed from existing records in netcdf file
-  if(.NOT.ascii_out) call init_buoy_output(partit)
+  if(.NOT.ascii_out .AND. ib_num > 0) call init_buoy_output(partit)
   end if
   call init_icebergs_with_icesheet
   !write(*,*) 'initialized positions and length/width from file'
@@ -1311,7 +1311,7 @@ type(t_partit), intent(inout), target :: partit
   if(mype==0) then
   write(*,*) 'no iceberg restart'
 
-  if(.NOT.ascii_out) call init_buoy_output(partit)
+  if(.NOT.ascii_out .AND. ib_num > 0) call init_buoy_output(partit)
 
   end if
 


### PR DESCRIPTION
## What

Guard the five iceberg-output call sites in `src/icb_step.F90` on `ib_num > 0`.

## Why

An ice-sheet-coupled run legitimately reaches zero icebergs: a cold start before the ice sheet has discharged anything, or a leg where it discharges into no basin. Today that kills the run at step 1.

`ib_num` is never tested against zero anywhere in the iceberg code, and the stepping itself is fine with it. The loops are `do ib = 1, ib_num` and the work arrays are `dimension(16*ib_num)`, both harmless when empty.

Only the diagnostic output is not. `init_buoy_output` does

```fortran
status = nf_def_dim(ncid, 'number_tracer', ib_num, dimid_ib)
status = nf_def_dim(ncid, 'time', NF_UNLIMITED, dimid_rec)
```

In classic netCDF a zero-size dimension **is** unlimited, and only one unlimited dimension is allowed per file, so the second call fails:

```
initialize new buoy/iceberg output file
Error: NetCDF: NC_UNLIMITED size already in use
Run finished unexpectedly!
```

## Alternative considered

Creating the file as `NF_NETCDF4` instead of `nf_clobber` would also fix it, since there zero-size dimensions are ordinary and several unlimited dimensions are allowed. That is one line rather than five, but it changes the output format for every user, so the guard seemed the smaller blast radius for a diagnostic.

## Testing

Reproduced on AWI-ESM3 (OpenIFS + FESOM2.7 + PISM) on levante, 1792 ranks, CORE3 cavity mesh, with `use_icebergs = .true.`, `use_icesheet_coupling = .true.` and `ib_num = 0`. Before: dies at step 1 with the error above. After: reaches step 3649 and continues normally, with no `NC_UNLIMITED` and no `forrtl` in the log.

Found while wiring PISM's calving discharge into the iceberg module, where chunk 1 has no bergs by construction because the ice sheet has not run yet.
