### PR TITLE
icebergs: do not index ulevels_nod2d with a halo node marked 0

### DIFF
--- a/src/icb_coupling.F90
+++ b/src/icb_coupling.F90
@@ -109,8 +109,11 @@ type(t_partit), intent(inout), target :: partit
 
         do i=1, 3
             iceberg_node=ib_nods_in_ib_elem(i)
+            ! Halo nodes are marked 0 above. Test that before indexing, since
+            ! Fortran does not promise to short-circuit .or. and Intel does not.
+            if (iceberg_node <= 0) cycle
             ! Skip nodes with no ocean column; do NOT skip valid cavity nodes
-            if (iceberg_node <= 0 .or. ulevels_nod2d(iceberg_node) == 0) cycle
+            if (ulevels_nod2d(iceberg_node) == 0) cycle
 
             if (iceberg_node>0) then
                 ! Guard: tot_area at level 1 is zero when all element nodes are cavity nodes


### PR DESCRIPTION
In `iceberg_ocean_coupling`, nodes of the iceberg's element that this PE does not own are deliberately marked with 0. The loop below then guards against that marker and against nodes with no ocean column in one statement:

```fortran
if (iceberg_node <= 0 .or. ulevels_nod2d(iceberg_node) == 0) cycle
```

The intent is that the left test protects the right one. Fortran gives no such promise, and ifort evaluates both sides, so `ulevels_nod2d(0)` is read for exactly the case the guard was written to avoid. Any element on a partition boundary has at least one node this PE does not own, so this is the common case.

The control flow was never wrong, since the `cycle` is taken either way. The read is, and in an optimised build it quietly returns whatever sits before the array. It only shows up with bounds checking:

```
forrtl: severe (408): fort: (3): Subscript #1 of the array ULEVELS_NOD2D
  has value 0 which is less than the lower bound of 1
libfesom.so   iceberg_ocean_cou   113  icb_coupling.F90
libfesom.so   iceberg_step_mp_i   635  icb_step.F90
```

Found running AWI-ESM3 with icebergs calved from PISM discharge, on a build with `-check bounds` on the iceberg sources. It aborted within 100 timesteps. The fix splits the two tests so the index is only formed once it is known to be valid.

Same family as #960, which fixed two other out-of-bounds reads found the same way, and it sits alongside #962 in the iceberg code. This is the only instance of the pattern in the iceberg sources.
