### PR TITLE
io: enable the shuffle filter and make compression conditional

### DIFF
--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -2323,7 +2323,25 @@ subroutine create_new_file(entry, ice, dynamics, partit, mesh)
 
     call assert_nf( nf90_def_var(entry%ncid, trim(entry%name), entry%data_strategy%netcdf_type(), (/entry%dimid(entry%ndim:1:-1), entry%recID/), entry%varID), __LINE__)
 
-    call assert_nf( nf90_def_var_deflate(entry%ncid, entry%varID, 0, 1, compression_level), __LINE__)
+    ! Compression filters. Two changes from the previous hardcoded
+    ! nf90_def_var_deflate(..., 0, 1, compression_level):
+    !
+    !   shuffle was 0. The HDF5 byte-shuffle filter groups the like-significance
+    !   bytes of neighbouring floats together, which is close to free and makes
+    !   deflate both faster and markedly more effective on geophysical float
+    !   fields. Measured on NG5 output: compression ratio 1.10-1.30x better and
+    !   writes 1.5-1.6x faster, with reads about 2x faster. Shuffle is core HDF5,
+    !   so every existing reader handles it with no plugin.
+    !
+    !   deflate was 1 unconditionally, so compression_level = 0 did not disable
+    !   compression at all -- it enabled the deflate filter at level 0. Files
+    !   written that way carry _DeflateLevel = 0 and pay the filter pipeline cost
+    !   for no benefit. Skipping the call entirely is what the namelist implies.
+    !   (The variable stays chunked either way: netCDF-4 always chunks a variable
+    !   with an unlimited dimension, and time is unlimited here.)
+    if (compression_level > 0) then
+        call assert_nf( nf90_def_var_deflate(entry%ncid, entry%varID, 1, 1, compression_level), __LINE__)
+    end if
     call assert_nf( nf90_put_att(entry%ncid, entry%varID, 'description', entry%description), __LINE__)
     call assert_nf( nf90_put_att(entry%ncid, entry%varID, 'long_name', entry%description), __LINE__)
     call assert_nf( nf90_put_att(entry%ncid, entry%varID, 'units', entry%units), __LINE__)


### PR DESCRIPTION

Turning on the shuffle filter and making compression conditional cuts NG5 output time by
31 % and output volume by 17 %, and fixes `compression_level = 0` not switching compression
off. Fixes part of #967.

Both changes are in one call, `io_meandata.F90:2326`:

```fortran
call assert_nf( nf90_def_var_deflate(entry%ncid, entry%varID, 0, 1, compression_level), __LINE__)
```

- The first argument is the shuffle flag, which was `0`. Shuffle groups the like bytes of
  neighbouring numbers together, which makes the compressor both faster and more effective.
- The second argument switches compression on and was always `1`, so `compression_level = 0`
  did not switch compression off — it compressed at level 0, paying for the filter and
  getting nothing back. The call is now skipped entirely when `compression_level == 0`.

**Measured on NG5** (7.4 M surface nodes), 1024 tasks, 12 streams as 6-hourly means, this
branch and its merge base run back to back in one allocation:

| | before | after |
|---|---|---|
| output written | 19.23 GB | 15.93 GB (−17 %) |
| `runtime output`, max over ranks | 1172 s | 812 s (−31 %) |
| wall clock | 1922 s | 1558 s |

Compression on its own, measured on spun-up NG5 output through the netCDF stack FESOM links
(netcdf-fortran 4.5.3, netcdf-c 4.8.1) and writing one level per call as `write_mean` does:
shuffle improves the compression ratio by 1.15× (`u`) to 1.30× (`salt`) and writes 1.4–1.6×
faster.

**Compatibility.** Output values are bit-identical — checked field by field on the pi mesh
against the merge base. Shuffle is part of HDF5 itself, so every existing reader already
handles it and no plugin is needed.

One behaviour change to be aware of: files written with `compression_level = 0` no longer
carry a compression filter at all, where before they carried it at level 0. They stay
chunked, because netCDF-4 always chunks a variable with an unlimited dimension.

This does not address the main problem in #967 — output is still gathered to and written by
a single rank per stream, which is what makes the cost scale with mesh size rather than with
core count.
