### PR TITLE
io: collective parallel restart read

### DIFF
--- a/config/namelist.config
+++ b/config/namelist.config
@@ -137,11 +137,14 @@ l_allowgrounding      = 2        ! iceberg grounding mode: 0=free drift (no grou
 ! PARALLEL I/O
 ! ============================================================================
 &io_parallel
-parallel_write = .false.   ! .true.: writers write their own part of the file collectively,
-                           ! instead of gathering onto one CPU. Switch it on only at a file
-                           ! boundary (new year/month): the collective path cannot append to
-                           ! a file the gather path created.
-n_writers      = 0         ! writing CPUs, 0 = as many as the block-size guard allows.
-                           ! Output likes about a quarter of the CPUs, restarts like fewer.
-chunk_levels   = 8         ! levels per netCDF chunk; lower favours maps, higher favours profiles
+parallel_write    = .false.   ! .true.: writers write their own part of the file collectively,
+                              ! instead of gathering onto one CPU. Switch it on only at a file
+                              ! boundary (new year/month): the collective path cannot append to
+                              ! a file the gather path created.
+n_writers         = 0         ! output writers, 0 = as many as the block-size guard allows
+n_writers_restart = -1        ! restart writers, -1 = same as n_writers
+n_readers_restart = -1        ! restart readers, -1 = same as n_writers. The three peak at
+                              ! different values; on NG5/8192 reading is fastest well below the
+                              ! best writer count.
+chunk_levels      = 8         ! levels per netCDF chunk; lower favours maps, higher favours profiles
 /

--- a/src/gen_model_setup.F90
+++ b/src/gen_model_setup.F90
@@ -87,11 +87,22 @@ subroutine setup_model(partit)
   read (fileunit, NML=io_parallel, iostat=istat)
   if (istat /= 0) then
      rewind(fileunit)
-     parallel_write = .false.
-     n_writers      = 0
+     parallel_write    = .false.
+     n_writers         = 0
+     chunk_levels      = 8
+     n_writers_restart = -1
+     n_readers_restart = -1
   end if
+  ! Resolve the "same as n_writers" sentinel once, here, so that every consumer
+  ! downstream sees a concrete count and none of them has to know about -1.
+  ! Zero is NOT the sentinel: it already means "as many as the block-size guard
+  ! allows" and stays a legitimate value for each of the three.
+  if (n_writers_restart < 0) n_writers_restart = n_writers
+  if (n_readers_restart < 0) n_readers_restart = n_writers
   if (partit%mype == 0) then
-     write(*,*) 'parallel_write = ', parallel_write, '  n_writers = ', n_writers
+     write(*,*) 'parallel_write = ', parallel_write, '  n_writers = ', n_writers, &
+                '  n_writers_restart = ', n_writers_restart, &
+                '  n_readers_restart = ', n_readers_restart
   end if
 
 !!$  read (fileunit, NML=machine)

--- a/src/gen_modules_config.F90
+++ b/src/gen_modules_config.F90
@@ -147,7 +147,21 @@ module g_config
   !> out of a chunk of k costs k times the bytes. Default 8 is a compromise
   !> leaning toward maps, which are the more common access pattern here.
   integer :: chunk_levels  = 8
-  namelist /io_parallel/ parallel_write, n_writers, chunk_levels
+  !> Restart writers and restart readers, separately from the output writers.
+  !> -1 means "same as n_writers", which is what one knob used to give.
+  !>
+  !> The three want different values, measured on NG5/8192: output peaks near
+  !> 512 writers, restarts peak lower, and reading peaks lower still -- 128
+  !> readers beat 512 by a third (141.2 s gather -> 52.9 s at 512 -> 39.9 s at
+  !> 128). Output writes compressed chunks whose boundaries must coincide with
+  !> writer blocks, so its optimum is tied to chunk size; a read decompresses
+  !> whole chunks and has no such constraint, which is why its optimum sits
+  !> elsewhere. Zero keeps its meaning of "as many as the block-size guard
+  !> allows" for all three.
+  integer :: n_writers_restart = -1     !< -1 = use n_writers
+  integer :: n_readers_restart = -1     !< -1 = use n_writers
+  namelist /io_parallel/ parallel_write, n_writers, chunk_levels, &
+                         n_writers_restart, n_readers_restart
   
   !_____________________________________________________________________________
   ! *** configuration***

--- a/src/io_fesom_file.F90
+++ b/src/io_fesom_file.F90
@@ -53,7 +53,9 @@ module io_fesom_file_module
     procedure, private :: specify_elem_var_2d, specify_elem_var_3d
     procedure, private :: gather_and_write_variables
     procedure, private :: redist_and_write_variables
+    procedure, private :: redist_and_read_variables
     procedure, public  :: is_writer, is_lead_writer, writer_comm
+    procedure, public  :: is_reader, is_lead_reader, reader_comm
   end type fesom_file_type
   
   
@@ -73,7 +75,16 @@ module io_fesom_file_module
   integer, save :: m_n_writers = 0
   type(redist_type), save, target :: m_sched_nod, m_sched_elem
   logical, save :: m_sched_ready = .false.
+  !> Read-side counterparts. Separate schedules, not the write ones reversed:
+  !> a write is a partition of the global index space and a read is not, because
+  !> a rank needs every entry it holds locally and neighbours need the same ones.
+  !> See the header of io_redistribute for why elements make this mandatory
+  !> rather than merely convenient.
+  type(redist_scatter_type), save, target :: m_rsched_nod, m_rsched_elem
+  logical, save :: m_rsched_ready = .false.
   integer, save :: m_writer_comm = -1   !< communicator holding exactly the writers
+  integer, save :: m_n_readers = 0
+  integer, save :: m_reader_comm = -1   !< communicator holding exactly the readers
   
 
   type fesom_file_type_ptr
@@ -199,6 +210,11 @@ contains
       ! Schedules and the writer communicator must exist before the first file
       ! is created, because the create itself is collective over the writers.
       call ensure_schedules(partit, this%comm)
+      ! Likewise the read side: io_restart asks is_reader() to decide who opens
+      ! a restart file, which happens before anything calls into the read path,
+      ! so the reader schedules cannot be built lazily on first use. Two
+      ! Alltoall(v) once per run, paid even by a cold start that never reads.
+      call ensure_read_schedules(partit, this%comm)
     end if
   end subroutine init
   
@@ -218,6 +234,14 @@ contains
     integer mpierr
     real(kind=8) :: total_netcdf_time, total_scatter_time, total_barrier_time
     real(kind=8) :: t_start, t_end
+
+    ! Collective path: every rank takes part in the exchange, only the readers
+    ! touch netCDF, and the requested lists already cover the halo, so nothing
+    ! below this point applies.
+    if(m_parallel_write) then
+      call this%redist_and_read_variables()
+      return
+    end if
 
     ! Initialize timing variables
     total_netcdf_time = 0.0d0
@@ -317,11 +341,15 @@ contains
 
   !> Select the collective write path. Call before any file is initialised.
   !> n_writers <= 0 means "as many as the block-size guard allows".
-  subroutine set_parallel_write(enable, n_writers)
+  !> Restart writer and reader counts are separate: they peak at different
+  !> values, and the reader set is therefore not the writer set in general.
+  subroutine set_parallel_write(enable, n_writers, n_readers)
     logical, intent(in) :: enable
     integer, intent(in) :: n_writers
+    integer, intent(in) :: n_readers
     m_parallel_write = enable
     m_n_writers = n_writers
+    m_n_readers = n_readers
   end subroutine set_parallel_write
 
 
@@ -375,6 +403,54 @@ contains
 
     m_sched_ready = .true.
   end subroutine ensure_schedules
+
+
+  !> Build the read-side schedules. Lazy, like the write side, so a cold start
+  !> pays nothing: this is only reached when a restart is actually read.
+  !>
+  !> The requested lists are the FULL local lists, myDim + eDim, not the owned
+  !> subsets the writer uses. For nodes that difference is the halo. For elements
+  !> it is the halo plus every local element whose first node is not owned, which
+  !> is the case no halo exchange would repair afterwards.
+  subroutine ensure_read_schedules(partit, comm)
+    type(t_partit), intent(in) :: partit
+    integer, intent(in) :: comm
+    integer :: ierr, nwant
+
+    if(m_rsched_ready) return
+
+    nwant = partit%myDim_nod2D + partit%eDim_nod2D
+    call redist_build_scatter(m_rsched_nod, partit%myList_nod2D(1:nwant), nwant, &
+                              m_nod2d, m_n_readers, comm, partit%mype==0, ierr)
+    if(ierr /= 0) then
+      if(partit%mype==0) write(*,*) 'io_fesom_file: nodal redist_build_scatter failed, ierr=', ierr
+      stop 1
+    end if
+
+    nwant = partit%myDim_elem2D + partit%eDim_elem2D
+    call redist_build_scatter(m_rsched_elem, partit%myList_elem2D(1:nwant), nwant, &
+                              m_elem2d, m_n_readers, comm, .false., ierr)
+    if(ierr /= 0) then
+      if(partit%mype==0) write(*,*) 'io_fesom_file: element redist_build_scatter failed, ierr=', ierr
+      stop 1
+    end if
+
+    ! The nodal and element schedules must select the same ranks -- both use
+    ! redist_writer_rank with the same npes and reader count -- so one
+    ! communicator serves both. Asserted rather than assumed, as on the write
+    ! side. The reader set is NOT compared against the writer set: with
+    ! n_readers_restart different from n_writers_restart they are deliberately
+    ! different, which is the whole point of the separate knob.
+    if(m_rsched_nod%is_reader .neqv. m_rsched_elem%is_reader) then
+      write(*,*) 'io_fesom_file: nodal and element reader sets disagree on rank ', partit%mype
+      stop 1
+    end if
+    call MPI_Comm_split(comm, merge(1,0,m_rsched_nod%is_reader), partit%mype, m_reader_comm, ierr)
+
+    if(partit%mype == 0) write(*,*) 'io_fesom_file: restart readers = ', m_rsched_nod%n_readers
+
+    m_rsched_ready = .true.
+  end subroutine ensure_read_schedules
 
 
   !> Communicator containing exactly the writer ranks. Valid after init.
@@ -478,10 +554,173 @@ contains
   end subroutine redist_and_write_variables
 
 
+  !> Collective read: every reader pulls its own contiguous block with one
+  !> get_var per variable, then one MPI_Alltoallv delivers every entry to every
+  !> rank that needs it.
+  !>
+  !> Mirror of redist_and_write_variables, with two asymmetries worth stating.
+  !> First, the exchange runs the other way and is a scatter rather than a
+  !> gather, so entries are duplicated on purpose. Second, the requested lists
+  !> cover myDim + eDim, so nothing is left for a halo exchange to fix up.
+  !>
+  !> Non-readers never touch netCDF here; they only take part in the exchange.
+  subroutine redist_and_read_variables(this)
+#ifdef ENABLE_NVHPC_WORKAROUNDS
+    use nvfortran_subarray_workaround_module
+#endif
+    class(fesom_file_type), target :: this
+    integer :: i, lvl, nlvl, k, ierr, nloc, last_rec_idx, nlvl_min, nlvl_max
+    integer :: nvar_min, nvar_max
+    type(var_info), pointer :: var
+    type(redist_scatter_type), pointer :: sched
+    real(kind=8), allocatable :: blk(:,:), out(:,:), lvlbuf(:), flatv(:)
+
+    call ensure_read_schedules(this%partit, this%comm)
+
+    ! Same reasoning as the nlvl check below, one level up: the loop itself must
+    ! have the same trip count everywhere, or ranks meet different exchanges.
+    call MPI_Allreduce(this%nvar_infos, nvar_min, 1, MPI_INTEGER, MPI_MIN, this%comm, ierr)
+    call MPI_Allreduce(this%nvar_infos, nvar_max, 1, MPI_INTEGER, MPI_MAX, this%comm, ierr)
+    if(nvar_min /= nvar_max) then
+      if(this%partit%mype == 0) write(*,*) 'io_fesom_file: nvar_infos disagrees across ranks: ', &
+           nvar_min, nvar_max
+      stop 1
+    end if
+
+    ! Every reader has the same file open and reads the same record count, so
+    ! they agree without a broadcast -- the same argument the write path uses.
+    last_rec_idx = 0
+    if(this%is_reader()) last_rec_idx = this%rec_count()
+
+    do i=1, this%nvar_infos
+      var => this%var_infos(i)
+
+      if(var%is_icepackvar2) then
+        nlvl = size(var%external_local_data_ptr, dim=2)
+        nloc = size(var%external_local_data_ptr, dim=1)
+      else
+        nlvl = size(var%external_local_data_ptr, dim=1)
+        nloc = size(var%external_local_data_ptr, dim=2)
+      end if
+
+      if(var%is_elem_based) then
+        sched => m_rsched_elem
+      else
+        sched => m_rsched_nod
+      end if
+
+      ! nloc is myDim+eDim for this entity, which is exactly what the schedule
+      ! was built to request. If they disagree the schedule and the model array
+      ! describe different things and the copy below would run off the end.
+      if(nloc /= sched%nwant) then
+        write(*,*) 'io_fesom_file: local size ', nloc, ' /= requested ', sched%nwant, &
+                   ' for ', trim(var%varname), ' on rank ', this%partit%mype
+        stop 1
+      end if
+
+      ! nlvl MUST agree across every rank. MPI_Alltoallv matches
+      ! sendcount(A->B) against recvcount(B<-A), and both are scaled by the
+      ! local nlvl, so a single rank disagreeing turns the exchange into a
+      ! silent hang rather than an error. Checked collectively, and the abort is
+      ! taken by everyone, so the check itself cannot deadlock.
+      call MPI_Allreduce(nlvl, nlvl_min, 1, MPI_INTEGER, MPI_MIN, this%comm, ierr)
+      call MPI_Allreduce(nlvl, nlvl_max, 1, MPI_INTEGER, MPI_MAX, this%comm, ierr)
+      if(nlvl_min /= nlvl_max) then
+        if(this%partit%mype == 0) write(*,*) 'io_fesom_file: nlvl disagrees across ranks for ', &
+             trim(var%varname), ': min ', nlvl_min, ' max ', nlvl_max
+        stop 1
+      end if
+
+      allocate(blk(nlvl, max(1, sched%count)))
+      blk = 0._8
+
+      if(this%is_reader() .and. sched%count > 0) then
+        ! One get_var per variable, matching the single put_var on the write
+        ! side. read_var takes a rank-1 buffer, and the file's order is
+        ! (entry, level), so the flat buffer is unpacked by hand -- the same
+        ! transpose the writer does, in the opposite direction.
+        if(nlvl == 1) then
+          allocate(lvlbuf(sched%count))
+          call this%read_var(var%var_index, [sched%first, last_rec_idx], &
+                             [sched%count, 1], lvlbuf)
+          blk(1, 1:sched%count) = lvlbuf(1:sched%count)
+          deallocate(lvlbuf)
+        else
+          allocate(flatv(sched%count*nlvl))
+          call this%read_var(var%var_index, [sched%first, 1, last_rec_idx], &
+                             [sched%count, nlvl, 1], flatv)
+          do lvl=1, nlvl
+            blk(lvl, 1:sched%count) = flatv((lvl-1)*sched%count+1 : lvl*sched%count)
+          end do
+          deallocate(flatv)
+        end if
+      end if
+      ! A reader with an empty block issues nothing. open_read_par uses
+      ! INDEPENDENT access precisely so that reads need not be matched across
+      ! the reader set, which is also what lets io_restart read the record
+      ! scalars from a single CPU.
+
+      allocate(out(nlvl, max(1, sched%nwant)))
+      call redist_scatter(sched, nlvl, blk, out, this%comm, ierr)
+      if(ierr /= 0) then
+        write(*,*) 'io_fesom_file: redist_scatter failed for ', trim(var%varname)
+        stop 1
+      end if
+
+#ifdef ENABLE_NVHPC_WORKAROUNDS
+      if(var%varname=='u') then
+        do k = 1, nloc; dynamics_workaround%uv(1,1:nlvl,k)       = out(1:nlvl,k); end do
+      else if(var%varname=='v') then
+        do k = 1, nloc; dynamics_workaround%uv(2,1:nlvl,k)       = out(1:nlvl,k); end do
+      else if(var%varname=='urhs_AB') then
+        do k = 1, nloc; dynamics_workaround%uv_rhsAB(1,1:nlvl,k) = out(1:nlvl,k); end do
+      else if(var%varname=='vrhs_AB') then
+        do k = 1, nloc; dynamics_workaround%uv_rhsAB(2,1:nlvl,k) = out(1:nlvl,k); end do
+      else
+#endif
+      if(var%is_icepackvar2) then
+        do k = 1, nloc
+          var%external_local_data_ptr(k, 1:nlvl) = out(1:nlvl, k)
+        end do
+      else
+        do k = 1, nloc
+          var%external_local_data_ptr(1:nlvl, k) = out(1:nlvl, k)
+        end do
+      end if
+#ifdef ENABLE_NVHPC_WORKAROUNDS
+      end if
+#endif
+
+      deallocate(blk, out)
+    end do
+  end subroutine redist_and_read_variables
+
+
   logical function is_writer(this)
     class(fesom_file_type), intent(in) :: this
     is_writer = m_parallel_write .and. m_sched_ready .and. m_sched_nod%is_writer
   end function is_writer
+
+
+  !> Reader predicates. Separate from the writer ones because
+  !> n_readers_restart may differ from n_writers_restart, so the two sets are
+  !> not the same ranks and do not hold the same blocks.
+  logical function is_reader(this)
+    class(fesom_file_type), intent(in) :: this
+    is_reader = m_parallel_write .and. m_rsched_ready .and. m_rsched_nod%is_reader
+  end function is_reader
+
+
+  logical function is_lead_reader(this)
+    class(fesom_file_type), intent(in) :: this
+    is_lead_reader = m_parallel_write .and. m_rsched_ready .and. (m_rsched_nod%widx == 0)
+  end function is_lead_reader
+
+
+  integer function reader_comm(this)
+    class(fesom_file_type), intent(in) :: this
+    reader_comm = m_reader_comm
+  end function reader_comm
 
 
   subroutine gather_and_write_variables(this)

--- a/src/io_netcdf_file_module.F90
+++ b/src/io_netcdf_file_module.F90
@@ -42,6 +42,7 @@ module io_netcdf_file_module
   contains
     procedure, public :: initialize, add_dim, add_dim_unlimited, add_var_double, add_var_real, add_var_int, open_read, flush_file, close_file, open_write_create, open_write_append
     procedure, public :: open_write_create_par, open_write_append_par, set_var_chunking
+    procedure, public :: open_read_par
     procedure, public :: is_attached, read_var_shape
     procedure, public :: ndims
     generic, public :: read_var => read_var_r4, read_var_r8, read_var_integer
@@ -264,6 +265,38 @@ contains
     ! attach our dims and vars to their counterparts in the file
     call this%attach_dims_vars_to_file()
   end subroutine open_read
+
+
+  ! Parallel counterpart of open_read: the file is opened collectively over
+  ! `comm`, which must contain the reading CPUs and only those.
+  !
+  ! Variable access is INDEPENDENT, unlike open_write_create_par. Collective
+  ! access is what makes compressed parallel WRITES work at all, so the write
+  ! side has no choice; a read has nothing equivalent to gain, since each reader
+  ! pulls a distinct chunk-aligned hyperslab and HDF5 decompresses per chunk
+  ! either way.
+  !
+  ! It also removes a deadlock rather than merely being equivalent. The restart
+  ! record scalars -- `iter` and the time axis -- are read by one CPU alone
+  ! (io_restart.F90, under is_iorank), and under collective access that single
+  ! get_var would wait forever for the other readers to join a call they never
+  ! make.
+  subroutine open_read_par(this, filepath, comm)
+    use mpi
+    class(netcdf_file_type), intent(inout) :: this
+    character(len=*), intent(in) :: filepath
+    integer, intent(in) :: comm
+    ! EO parameters
+    include "netcdf.inc"
+    integer i
+
+    this%filepath = filepath
+    call assert_nc( nf_open_par(this%filepath, ior(nf_nowrite, nf_mpiio), comm, MPI_INFO_NULL, this%ncid), __LINE__)
+    call this%attach_dims_vars_to_file()
+    do i=1, size(this%vars)
+      call assert_nc( nf_var_par_access(this%ncid, this%vars(i)%ncid, nf_independent), __LINE__)
+    end do
+  end subroutine open_read_par
 
 
   ! return an array with the dimension sizes for all dimensions of the given variable

--- a/src/io_redistribute.F90
+++ b/src/io_redistribute.F90
@@ -37,6 +37,8 @@ module io_redistribute
   public :: redist_effective_writers
   public :: redist_build, redist_free, redist_check
   public :: redist_exchange
+  public :: redist_scatter_type
+  public :: redist_build_scatter, redist_scatter, redist_scatter_free
   public :: REDIST_MIN_BLOCK
 
   !> Move a field from the model decomposition into block order.
@@ -75,6 +77,49 @@ module io_redistribute
      integer, allocatable :: rcnt(:), rdsp(:)   !< 0:npes-1
      integer, allocatable :: rloc(:)            !< 1:nrecv, offset within the block
   end type redist_type
+
+  !> Schedule for the opposite direction: block order on the readers out to
+  !> every rank that needs an entry.
+  !>
+  !> This is deliberately NOT redist_type reversed. A write schedule is a
+  !> partition -- redist_build fails with ierr = 3 if a writer would not receive
+  !> exactly its block -- because each global entry is written once. A read is
+  !> not a partition: a rank needs every entry it holds locally, owned or halo,
+  !> and neighbouring ranks need the same entry at the same time.
+  !>
+  !> For nodes the difference is only the halo, which exchange_nod3D could patch
+  !> up afterwards. For ELEMENTS there is a second gap that no halo exchange
+  !> closes, and it is the reason this type exists. myInd_elem2D_shrinked keeps
+  !> only local elements whose FIRST node is owned (oce_mesh.F90:888-899), while
+  !> an element enters the halo receive list only when NONE of its nodes belongs
+  !> to this PE (gen_comm.F90:430). An element in 1:myDim_elem2D whose first node
+  !> is a halo node is in neither set: inverting the write schedule would leave
+  !> it holding whatever was in memory, and this rank would then pass that on,
+  !> because the element does appear in its own send lists. Nothing catches this
+  !> during normal running, where such elements are recomputed from nodal values
+  !> every step; a restart read is the one place the value has to come from
+  !> outside.
+  !>
+  !> So each rank simply asks for what it needs and readers serve the requests.
+  !> Duplicate requests across ranks are expected, not an error.
+  type :: redist_scatter_type
+     integer :: n_global  = 0
+     integer :: n_readers = 0     !< same blocks as the writers, so the same count
+     integer :: block     = 0
+     integer :: npes      = 0
+     integer :: mype      = -1
+     logical :: is_reader = .false.
+     integer :: widx      = -1
+     integer :: first     = 0     !< first global index this reader owns (1-based)
+     integer :: last      = -1
+     integer :: count     = 0     !< block length held by this reader, may be 0
+     integer :: nwant     = 0     !< entries this rank needs (owned + halo)
+     integer :: nserve    = 0     !< entries this rank must send out as a reader
+     integer, allocatable :: qcnt(:), qdsp(:)   !< 0:npes-1, what we ask of each reader
+     integer, allocatable :: scnt(:), sdsp(:)   !< 0:npes-1, what we serve each requester
+     integer, allocatable :: sloc(:)            !< 1:nserve, offset within our block
+     integer, allocatable :: qperm(:)           !< 1:nwant, request slot -> local position
+  end type redist_scatter_type
 
 contains
 
@@ -286,6 +331,183 @@ contains
 
     deallocate(rbuf, sc, sd, rc, rd)
   end subroutine redist_exchange_r8
+
+
+
+  !> Build the read-side schedule. `want(1:nwant)` is every global index this
+  !> rank needs a value for -- owned AND halo, in whatever order the model keeps
+  !> them. Collective over comm.
+  !>
+  !> `n_readers_req` must be the value the WRITER used, so that first/last/count
+  !> describe the same blocks the file was written in. Passing something else is
+  !> not an error here, but then the reader blocks will not line up with the
+  !> file's chunks and every read crosses chunk boundaries.
+  !>
+  !> Unlike redist_build this does NOT require `want` to be ascending. The write
+  !> side gets away with the grouping shortcut because myList_nod2D(1:myDim) is
+  !> sorted; append the halo tail and it is not, so the destination-sorted order
+  !> is built explicitly and qperm remembers the way back.
+  subroutine redist_build_scatter(this, want, nwant, n_global, n_readers_req, comm, verbose, ierr)
+    type(redist_scatter_type), intent(out) :: this
+    integer, intent(in)  :: nwant, n_global, n_readers_req, comm
+    integer, intent(in)  :: want(nwant)
+    logical, intent(in)  :: verbose
+    integer, intent(out) :: ierr
+
+    integer :: i, w, r, mpierr, slot
+    integer, allocatable :: fill(:), qglob(:), sglob(:)
+
+    ierr = 0
+    call MPI_Comm_size(comm, this%npes, mpierr)
+    call MPI_Comm_rank(comm, this%mype, mpierr)
+
+    this%n_global  = n_global
+    this%n_readers = redist_effective_writers(n_global, n_readers_req, this%npes)
+    this%block     = redist_block_size(n_global, this%n_readers)
+    this%nwant     = nwant
+
+    ! Reader set and block range: identical rules to the writer side, so the
+    ! two agree by construction rather than by coincidence.
+    this%is_reader = .false.
+    this%widx      = -1
+    do w = 0, this%n_readers - 1
+       if (redist_writer_rank(w, this%npes, this%n_readers) == this%mype) then
+          this%is_reader = .true.
+          this%widx      = w
+          exit
+       end if
+    end do
+    if (this%is_reader) then
+       this%first = this%widx * this%block + 1
+       this%last  = min((this%widx + 1) * this%block, n_global)
+       this%count = max(0, this%last - this%first + 1)
+    else
+       this%first = 0; this%last = -1; this%count = 0
+    end if
+
+    ! --- what we ask of each reader -----------------------------------------
+    allocate(this%qcnt(0:this%npes-1), this%qdsp(0:this%npes-1))
+    allocate(this%scnt(0:this%npes-1), this%sdsp(0:this%npes-1))
+    this%qcnt = 0
+
+    do i = 1, nwant
+       if (want(i) < 1 .or. want(i) > n_global) then
+          ierr = 1
+          if (verbose) write(*,'(a,i0,a,i0)') ' io_redistribute: requested index out of range: ', &
+               want(i), ' on rank ', this%mype
+          return
+       end if
+       w = redist_owner_of(want(i), this%block, this%n_readers)
+       r = redist_writer_rank(w, this%npes, this%n_readers)
+       this%qcnt(r) = this%qcnt(r) + 1
+    end do
+
+    this%qdsp(0) = 0
+    do r = 1, this%npes - 1
+       this%qdsp(r) = this%qdsp(r-1) + this%qcnt(r-1)
+    end do
+
+    ! Destination-sorted request list, plus the permutation back to local slots.
+    allocate(qglob(max(1, nwant)), this%qperm(max(1, nwant)), fill(0:this%npes-1))
+    fill = this%qdsp
+    do i = 1, nwant
+       w = redist_owner_of(want(i), this%block, this%n_readers)
+       r = redist_writer_rank(w, this%npes, this%n_readers)
+       fill(r) = fill(r) + 1
+       slot = fill(r)
+       qglob(slot)      = want(i)
+       this%qperm(slot) = i
+    end do
+    deallocate(fill)
+
+    ! --- what we must serve --------------------------------------------------
+    call MPI_Alltoall(this%qcnt, 1, MPI_INTEGER, this%scnt, 1, MPI_INTEGER, comm, mpierr)
+    this%sdsp(0) = 0
+    do r = 1, this%npes - 1
+       this%sdsp(r) = this%sdsp(r-1) + this%scnt(r-1)
+    end do
+    this%nserve = sum(this%scnt)
+
+    if (this%nserve > 0 .and. .not. this%is_reader) then
+       ierr = 2                       ! a non-reader was asked for data
+       if (verbose) write(*,'(a,i0,a,i0)') ' io_redistribute: rank ', this%mype, &
+            ' is not a reader but was asked for ', this%nserve
+       deallocate(qglob)
+       return
+    end if
+
+    allocate(sglob(max(1, this%nserve)))
+    call MPI_Alltoallv(qglob, this%qcnt, this%qdsp, MPI_INTEGER, &
+                       sglob, this%scnt, this%sdsp, MPI_INTEGER, comm, mpierr)
+    deallocate(qglob)
+
+    allocate(this%sloc(max(1, this%nserve)))
+    do i = 1, this%nserve
+       this%sloc(i) = sglob(i) - this%first + 1
+       if (this%sloc(i) < 1 .or. this%sloc(i) > this%count) then
+          ierr = 3
+          if (verbose) write(*,'(a,i0,a,i0)') ' io_redistribute: asked for index ', sglob(i), &
+               ' outside block on rank ', this%mype
+          deallocate(sglob)
+          return
+       end if
+    end do
+    deallocate(sglob)
+  end subroutine redist_build_scatter
+
+
+  !> blk(nlev, count) in block order on the readers -> out(nlev, nwant) in the
+  !> model's own local order on every rank. Non-readers pass a size-0 blk.
+  !>
+  !> Mirror image of redist_exchange: gather into the send buffer through sloc,
+  !> one Alltoallv, then scatter through qperm.
+  subroutine redist_scatter(this, nlev, blk, out, comm, ierr)
+    type(redist_scatter_type), intent(in) :: this
+    integer, intent(in)  :: nlev, comm
+    real(kind=8), intent(in)  :: blk(nlev, *)
+    real(kind=8), intent(out) :: out(nlev, *)
+    integer, intent(out) :: ierr
+    real(kind=8), allocatable :: sbuf(:,:), rbuf(:,:)
+    integer, allocatable :: sc(:), sd(:), rc(:), rd(:)
+    integer :: i, mpierr
+
+    ierr = 0
+    allocate(sc(0:this%npes-1), sd(0:this%npes-1), rc(0:this%npes-1), rd(0:this%npes-1))
+    sc = this%scnt * nlev ; sd = this%sdsp * nlev
+    rc = this%qcnt * nlev ; rd = this%qdsp * nlev
+
+    allocate(sbuf(nlev, max(1, this%nserve)))
+    do i = 1, this%nserve
+       sbuf(1:nlev, i) = blk(1:nlev, this%sloc(i))
+    end do
+
+    allocate(rbuf(nlev, max(1, this%nwant)))
+    call MPI_Alltoallv(sbuf, sc, sd, MPI_REAL8, rbuf, rc, rd, MPI_REAL8, comm, mpierr)
+    if (mpierr /= MPI_SUCCESS) ierr = mpierr
+
+    do i = 1, this%nwant
+       out(1:nlev, this%qperm(i)) = rbuf(1:nlev, i)
+    end do
+
+    deallocate(sbuf, rbuf, sc, sd, rc, rd)
+  end subroutine redist_scatter
+
+
+  subroutine redist_scatter_free(this)
+    type(redist_scatter_type), intent(inout) :: this
+    if (allocated(this%qcnt))  deallocate(this%qcnt)
+    if (allocated(this%qdsp))  deallocate(this%qdsp)
+    if (allocated(this%scnt))  deallocate(this%scnt)
+    if (allocated(this%sdsp))  deallocate(this%sdsp)
+    if (allocated(this%sloc))  deallocate(this%sloc)
+    if (allocated(this%qperm)) deallocate(this%qperm)
+    this%is_reader = .false.
+    this%widx   = -1
+    this%count  = 0
+    this%nwant  = 0
+    this%nserve = 0
+  end subroutine redist_scatter_free
+
 
   !> Confirm the schedule partitions the global index space exactly once.
   !> Collective. Allocates two n_global integer arrays, so this is a test and

--- a/src/io_restart.F90
+++ b/src/io_restart.F90
@@ -126,7 +126,7 @@ subroutine ini_ocean_io(dynamics, tracers, partit, mesh)
   ! Select the write path before any restart file is initialised: fesom_file's
   ! init builds the redistribution schedules and the writer communicator, and
   ! both must exist before the first collective create.
-  call set_parallel_write(parallel_write, n_writers)
+  call set_parallel_write(parallel_write, n_writers_restart, n_readers_restart)
 
   !===========================================================================
   !===================== Definition part =====================================
@@ -925,16 +925,33 @@ subroutine read_netcdf_restarts(path, filegroup, mpicomm, mype)
           write(*,*) 'skipping reading restart for ', filegroup%files(i)%varname, ' at ', filegroup%files(i)%path
         end if
         
-        if(.not. skip_file(i)) call filegroup%files(i)%open_read(filegroup%files(i)%path) ! do we need to bother with read-only access?
+        ! On the collective path the open is done below by every reader, not
+        ! here by one CPU: each get_var is collective over the reader
+        ! communicator, and a file opened serially on one rank cannot take part.
+        if(.not. skip_file(i) .and. .not. parallel_write_enabled()) &
+             call filegroup%files(i)%open_read(filegroup%files(i)%path) ! do we need to bother with read-only access?
         ! todo: print a reasonable error message if the file does not exist
-      end if      
+      end if
     end if
 
     ! iorank already knows if we skip the file, tell the others
     if(.not. filegroup%files(i)%must_exist_on_read) then
       call MPI_Allreduce(current_iorank_snd, current_iorank_rcv, 1, MPI_INTEGER, MPI_SUM, mpicomm, mpierr)
       call MPI_Bcast(skip_file(i), 1, MPI_LOGICAL, current_iorank_rcv, mpicomm, mpierr)
-    end if      
+    end if
+
+    ! Collective read: every reader opens the file for itself. The path is
+    ! derived from `path` and the file's own varname, both of which every rank
+    ! holds, so the readers agree without a broadcast -- the same argument the
+    ! collective write path makes about create-versus-append.
+    if(parallel_write_enabled() .and. .not. skip_file(i)) then
+      dirpath = path(1:len(path)-3)                       ! chop the ".nc" suffix
+      filegroup%files(i)%path = dirpath//"/"//filegroup%files(i)%varname//".nc"
+      if(filegroup%files(i)%is_reader()) then
+        if(filegroup%files(i)%is_attached()) call filegroup%files(i)%close_file()
+        call filegroup%files(i)%open_read_par(filegroup%files(i)%path, filegroup%files(i)%reader_comm())
+      end if
+    end if
 
     ! ========================================================================!
     !                           _____________________                         !
@@ -977,7 +994,17 @@ subroutine read_netcdf_restarts(path, filegroup, mpicomm, mype)
 
     if(skip_file(i)) cycle
 
-    if(filegroup%files(i)%is_iorank()) then
+    ! ⛔ On the collective path this block MUST NOT be selected by is_iorank().
+    ! That rank comes from the next_io_rank pool, which hands out one rank per
+    ! host in round robin -- on a single node it gives 1, 2, 3, ... -- while the
+    ! readers are chosen by redist_writer_rank, a fixed stride: 0, 4, 8, ... on
+    ! 128 ranks with 30 readers. The two sets barely overlap, so the iorank has
+    ! no file open and every call below fails with "NetCDF: Not a valid ID"
+    ! (job 26825609, rank 9). The lead reader is rank 0 by construction, and the
+    ! reader set is its own set now that n_readers_restart is separate from
+    ! n_writers_restart -- so this must be is_lead_reader, not is_lead_writer.
+    if(merge(filegroup%files(i)%is_lead_reader(), filegroup%files(i)%is_iorank(), &
+             parallel_write_enabled())) then
       write(*,*) 'restart from record ', filegroup%files(i)%rec_count(), ' of ', filegroup%files(i)%rec_count(), filegroup%files(i)%path
 
       ! read the last entry from the iter variable
@@ -985,7 +1012,8 @@ subroutine read_netcdf_restarts(path, filegroup, mpicomm, mype)
 
       ! read the last entry from the time variable
       call filegroup%files(i)%read_var1(filegroup%files(i)%time_varindex(), [filegroup%files(i)%rec_count()], rtime)
-      call filegroup%files(i)%close_file()
+      ! On the collective path the close is done below by the whole reader set.
+      if(.not. parallel_write_enabled()) call filegroup%files(i)%close_file()
 
      if (int(ctime)/=int(rtime)) then
         print *, achar(27)//'[33m'    //'____________________________________________________________'//achar(27)//'[0m'
@@ -998,6 +1026,26 @@ subroutine read_netcdf_restarts(path, filegroup, mpicomm, mype)
         write(*,*) 'WARNING: Please verify that this is the intended behavior for your simulation.'
         print *, achar(27)//'[33m'    //'____________________________________________________________'//achar(27)//'[0m'
       end if
+    end if
+
+    ! ⛔ nc_close on a file opened with nf_open_par is COLLECTIVE over the
+    ! communicator it was opened on. Leaving the close inside the is_iorank
+    ! block above is what hung job 26825509: one CPU entered nc_close and waited
+    ! for the other 29 readers, those 29 went on to open the next restart file
+    ! -- also collective -- and every non-reader piled up in the redistribution
+    ! Alltoallv behind them. No error, no message, just a stack trace pointing at
+    ! MPI_Alltoallv, which is nowhere near the actual mistake.
+    !
+    ! Same rule as the write path: on the collective path every netCDF operation
+    ! on a shared file belongs to exactly the reader set, never to one CPU.
+    if(parallel_write_enabled()) then
+      ! Only the lead reader read the record scalars, so globalstep has to be
+      ! spread before anything downstream uses it. Broadcasting from rank 0 is
+      ! valid because is_lead_writer is rank 0 by construction. The gather path
+      ! propagates globalstep only as far as RAW_RESTART_METADATA_RANK; giving it
+      ! to everyone here is a superset, so the send/recv below still works.
+      call MPI_Bcast(globalstep, 1, MPI_INTEGER, 0, mpicomm, mpierr)
+      if(filegroup%files(i)%is_reader()) call filegroup%files(i)%close_file()
     end if
   end do
 


### PR DESCRIPTION
**TL;DR**

- Restart reads still gather a global level onto one CPU and scatter it. This adds a collective
  path: every reader pulls its own contiguous block and one exchange delivers each entry to every
  rank that needs it.
- NG5/8192: restart read **141.2 s → 39.9 s**, and model setup 218 s → 114 s. That is ~100 s off
  every warm start of every chain.
- **Off by default.** Uses the same `parallel_write` switch as #969, so nothing changes unless the
  collective path is already on.
- Adds `n_writers_restart` and `n_readers_restart`, because the three roles peak at different
  counts: on NG5/8192 output likes 512 writers while reading is fastest at 128 readers. Both
  default to "same as `n_writers`", so existing namelists behave exactly as before.
- Bit-identical to the gather read, including element fields, in three configurations: a
  collectively written restart, a gather-written one (the migration case), and readers ≠ writers.

## Speed-up

`runtime setup restart`, NG5/8192, all variants in one allocation reading the same
gather-written restart:

| | restart read | model setup total |
|---|---|---|
| gather | 141.18 s | 218.18 s |
| collective, 512 readers | 52.86 s (2.67×) | 125.22 s |
| collective, **128 readers** | **39.92 s (3.54×)** | 113.58 s |


## Namelist

```fortran
&io_parallel
parallel_write    = .true.
n_writers         = 512    ! output writers
n_writers_restart = -1     ! restart writers, -1 = same as n_writers
n_readers_restart = -1     ! restart readers, -1 = same as n_writers
chunk_levels      = 8
/
```

`-1` means "not set", not a count. Zero could not serve that purpose: it already means "as many as
the block-size guard allows", which is a legitimate value for each of the three. The sentinel is
resolved once, right after the namelist is read, so no code downstream knows about it.

The three roles peak at different counts. Output writes compressed chunks whose boundaries must
coincide with writer blocks, so its optimum is tied to chunk size; a read decompresses whole chunks
and has no such constraint. On NG5/8192 that is 512 against 128 — a third faster at the lower
count.

⚠️ There is no recommended default for the two new knobs, and that is deliberate. The reader sweep
has three points and the trend towards smaller counts has not turned round, so the optimum may be
lower still. `-1` keeps the previous single-knob behaviour until someone tunes.

## Correctness

Checked and it works. core2/128, read-then-continue: one restart, two continuations reading it, one
with each path, each integrating a model day. All fields `max|diff| = 0`, including `u`, `v`,
`urhs_AB` and `vrhs_AB` over 244659 elements. Three configurations -- a collectively written
restart, a gather-written one (the migration case), and 7 readers against 30 writers.

Bit-identity rather than a ULP tolerance is the right criterion here, because both paths fill from
the same file by global index.

The schedule also has a standalone gate needing no mesh, netCDF or model, passing at 1-8 ranks with
1-8 readers and 1, 5 and 69 levels.

## Implementation

`io_redistribute.F90` gains `redist_scatter_type`, `redist_build_scatter`, `redist_scatter` and
`redist_scatter_free`. Unlike the write side, the requested list is not ascending once the halo is
appended, so the destination-sorted order is built explicitly and a permutation remembers the way
back.

`open_read_par` uses **independent** variable access, unlike the write side. A read gains nothing
from collective access, and collective access deadlocks the restart record scalars, which
`io_restart` reads from a single CPU.

Two consistency checks guard the exchange: the variable count and the level count must agree across
ranks. Both are assembled from local array shapes and feed `MPI_Alltoallv` counts, where a
disagreement is a silent hang rather than an error, so they are checked collectively and the abort
is taken by every rank.

⚠️ On the collective path `is_iorank()` must not be used to select who touches netCDF. That rank
comes from the `next_io_rank` pool, which hands out one rank per host in round robin, while readers
come from a fixed stride. The two sets barely overlap, so the io rank has no file open. The reader
predicates are separate throughout, and the reader set is its own set now that the reader count can
differ from the writer count.

## Known limitation, inherited from #969

The collective path cannot append to an output or restart file the gather path created, so
`parallel_write` has to be switched on at a file boundary. That is why the migration test above
disables restart writing: it reads a gather-written restart, which works, but cannot then append a
new record to it.

## Not addressed

Reader-count tuning beyond three points. Output reads — only restarts are covered here.

## Appendix: why the read needs its own schedule

The obvious implementation is to run #969's schedule backwards. It does not work.

A write schedule lists what a rank **owns** and partitions the global index space exactly once. A
read has to fill what a rank **needs**, which is larger and is not a partition -- neighbours need
the same entry at the same time. For nodes that is just the halo. For elements,
`myInd_elem2D_shrinked` keeps only local elements whose *first* node is owned
(`oce_mesh.F90:888-900`), while an element enters the halo receive list only when **none** of its
nodes belongs to this PE (`gen_comm.F90:430`) -- so an element whose first node is a halo node is in
neither set, and an inverted schedule leaves it unfilled. Normal running hides this, because those
elements are recomputed from nodal values every step.

Hence a scatter schedule: each rank requests the indices it needs, readers serve duplicates, and the
halo is covered without a separate exchange.
