### PR TITLE
Salinity as an anomaly state (USE_SALT_ANOMALY): removes the float32 salinity drift and the NAC mean-state shift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Makefile.in
 mesh_part/build
 test/output_pi
 .claude/
+build_*/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,6 +81,8 @@ message(STATUS "USE_ICEPACK: ${USE_ICEPACK}")
 
 option(USE_SINGLE_PRECISION "Build FESOM in single precision (WP=4)" OFF)
 message(STATUS "USE_SINGLE_PRECISION: ${USE_SINGLE_PRECISION}")
+option(USE_SALT_ANOMALY "Store the salinity state as the anomaly S - S_ref (finer float32 spacing; see o_PARAM::S_ref_anomaly)" OFF)
+message(STATUS "USE_SALT_ANOMALY: ${USE_SALT_ANOMALY}")
 
 
 # option to trigger building a library version of FESOM
@@ -297,6 +299,10 @@ endif()
 
 if(USE_SINGLE_PRECISION)
    target_compile_definitions(${PROJECT_NAME} PRIVATE USE_SINGLE_PRECISION)
+endif()
+
+if(USE_SALT_ANOMALY)
+   target_compile_definitions(${PROJECT_NAME} PRIVATE USE_SALT_ANOMALY)
 endif()
 
 if(CVMIX)

--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -139,6 +139,9 @@ contains
       ! EO parameters
       logical mpi_is_initialized
       integer              :: tr_num, n
+#ifdef USE_SALT_ANOMALY
+      real(kind=WP)        :: salt_max_loc, salt_max_glob
+#endif
 
 #if defined (__recom)
       type(tracers_info_type)               :: tracers_info
@@ -435,6 +438,27 @@ contains
         !___READ INITIAL CONDITIONS IF THIS IS A RESTART RUN________________________
         if (r_restart) then
             call read_initial_conditions(f%which_readr, f%ice, f%dynamics, f%tracers, f%partit, f%mesh)
+#ifdef USE_SALT_ANOMALY
+            ! Restart files may hold ABSOLUTE salinity (migrating from a run
+            ! without USE_SALT_ANOMALY) or the anomaly (a chain of anomaly
+            ! runs writes the state as stored). Detect by the global maximum:
+            ! absolute salinity peaks near 41 psu, the anomaly near 41-S_ref.
+            ! Convert once when migrating; all AB history levels shift by the
+            ! same constant.
+            salt_max_loc = maxval(f%tracers%data(2)%values)
+            call MPI_AllREDUCE(salt_max_loc, salt_max_glob, 1, MPI_WP, MPI_MAX, &
+                               f%partit%MPI_COMM_FESOM, f%partit%MPIerr)
+            if (salt_max_glob > 20.0_WP) then
+                f%tracers%data(2)%values    = f%tracers%data(2)%values    - S_ref_anomaly
+                f%tracers%data(2)%valuesAB  = f%tracers%data(2)%valuesAB  - S_ref_anomaly
+                f%tracers%data(2)%valuesold = f%tracers%data(2)%valuesold - S_ref_anomaly
+                if (f%mype==0) write(*,*) &
+                    'USE_SALT_ANOMALY: absolute-salinity restart detected -> converted to S - S_ref'
+            else
+                if (f%mype==0) write(*,*) &
+                    'USE_SALT_ANOMALY: anomaly-salinity restart -> no conversion'
+            end if
+#endif
         end if
         if (f%mype==0) f%t7=MPI_Wtime()
         

--- a/src/ice_oce_coupling.F90
+++ b/src/ice_oce_coupling.F90
@@ -193,7 +193,11 @@ subroutine ocean2ice(ice, dynamics, tracers, partit, mesh)
         do n=1, myDim_nod2d+eDim_nod2d  
             if (ulevels_nod2D(n)>1) cycle 
             T_oc_array(n) = temp(1,n)
+#ifdef PROBE_SALT_ANOMALY
+            S_oc_array(n) = salt(1,n) + 35._WP   ! state stores S-35
+#else
             S_oc_array(n) = salt(1,n)
+#endif
             elevation(n)  = hbar(n)
         end do
 !$OMP END DO
@@ -202,7 +206,11 @@ subroutine ocean2ice(ice, dynamics, tracers, partit, mesh)
         do n=1, myDim_nod2d+eDim_nod2d
             if (ulevels_nod2D(n)>1) cycle 
              T_oc_array(n) = (T_oc_array(n)*real(ice%ice_steps_since_upd,WP)+temp(1,n))/real(ice%ice_steps_since_upd+1,WP)
+#ifdef PROBE_SALT_ANOMALY
+             S_oc_array(n) = (S_oc_array(n)*real(ice%ice_steps_since_upd,WP)+salt(1,n)+35._WP)/real(ice%ice_steps_since_upd+1,WP)
+#else
              S_oc_array(n) = (S_oc_array(n)*real(ice%ice_steps_since_upd,WP)+salt(1,n))/real(ice%ice_steps_since_upd+1,WP)
+#endif
              elevation(n)  = (elevation(n) *real(ice%ice_steps_since_upd,WP)+  hbar(n))/real(ice%ice_steps_since_upd+1,WP)
         end do
 !$OMP END DO
@@ -437,7 +445,11 @@ subroutine oce_fluxes(ice, dynamics, tracers, partit, mesh)
         rsss=ref_sss
 !$OMP PARALLEL DO
         do n=1, myDim_nod2D+eDim_nod2D
+#ifdef PROBE_SALT_ANOMALY
+            if (ref_sss_local) rsss = salt(ulevels_nod2d(n),n) + 35._WP
+#else
             if (ref_sss_local) rsss = salt(ulevels_nod2d(n),n)
+#endif
             virtual_salt(n)=rsss*water_flux(n) 
         end do
 !$OMP END PARALLEL DO        
@@ -475,7 +487,11 @@ subroutine oce_fluxes(ice, dynamics, tracers, partit, mesh)
         do n=1, myDim_nod2D+eDim_nod2D
             virtual_salt(n)=0.0_WP
             if (ulevels_nod2d(n) == 1) cycle ! --> is open ocean node 
+#ifdef PROBE_SALT_ANOMALY
+            if (ref_sss_local) rsss = salt(ulevels_nod2d(n),n) + 35._WP
+#else
             if (ref_sss_local) rsss = salt(ulevels_nod2d(n),n)
+#endif
             virtual_salt(n)=rsss*water_flux(n) 
         end do
 !$OMP END PARALLEL DO        
@@ -501,13 +517,21 @@ subroutine oce_fluxes(ice, dynamics, tracers, partit, mesh)
         do n=1, myDim_nod2D+eDim_nod2D
             relax_salt(n) = 0.0_WP
             if (ulevels_nod2d(n) > 1) cycle ! --> is cavity node --> only do salt relaxation in open ocean
+#ifdef PROBE_SALT_ANOMALY
+            relax_salt(n)=surf_relax_S*(Ssurf(n)-35._WP-salt(ulevels_nod2d(n),n))
+#else
             relax_salt(n)=surf_relax_S*(Ssurf(n)-salt(ulevels_nod2d(n),n))
+#endif
         end do
 !$OMP END PARALLEL DO
     else
 !$OMP PARALLEL DO
         do n=1, myDim_nod2D+eDim_nod2D
+#ifdef PROBE_SALT_ANOMALY
+            relax_salt(n)=surf_relax_S*(Ssurf(n)-35._WP-salt(ulevels_nod2d(n),n))
+#else
             relax_salt(n)=surf_relax_S*(Ssurf(n)-salt(ulevels_nod2d(n),n))
+#endif
         end do
 !$OMP END PARALLEL DO
     end if 

--- a/src/ice_oce_coupling.F90
+++ b/src/ice_oce_coupling.F90
@@ -674,8 +674,13 @@ subroutine oce_fluxes(ice, dynamics, tracers, partit, mesh)
     ! boundary condition) to compute the dens_flux for MOC diagnostic
 !$OMP PARALLEL DO
     do n=1, myDim_nod2D+eDim_nod2D    
-        if (ulevels_nod2d(n) == 1) then ! --> is open ocean node 
+        if (ulevels_nod2d(n) == 1) then ! --> is open ocean node
+#ifdef PROBE_SALT_ANOMALY
+            ! state stores S-35; diagnostic density flux wants absolute S
+            dens_flux(n)=sw_alpha(1,n) * heat_flux_in(n) / vcpw + sw_beta(1, n) * (relax_salt(n) + water_flux(n) * (salt(1,n)+35._WP))
+#else
             dens_flux(n)=sw_alpha(1,n) * heat_flux_in(n) / vcpw + sw_beta(1, n) * (relax_salt(n) + water_flux(n) * salt(1,n))
+#endif
         else
             dens_flux(n)=0.0_WP
         end if

--- a/src/ice_oce_coupling.F90
+++ b/src/ice_oce_coupling.F90
@@ -193,8 +193,8 @@ subroutine ocean2ice(ice, dynamics, tracers, partit, mesh)
         do n=1, myDim_nod2d+eDim_nod2d  
             if (ulevels_nod2D(n)>1) cycle 
             T_oc_array(n) = temp(1,n)
-#ifdef PROBE_SALT_ANOMALY
-            S_oc_array(n) = salt(1,n) + 35._WP   ! state stores S-35
+#ifdef USE_SALT_ANOMALY
+            S_oc_array(n) = salt(1,n) + S_ref_anomaly   ! state stores S-35
 #else
             S_oc_array(n) = salt(1,n)
 #endif
@@ -206,8 +206,8 @@ subroutine ocean2ice(ice, dynamics, tracers, partit, mesh)
         do n=1, myDim_nod2d+eDim_nod2d
             if (ulevels_nod2D(n)>1) cycle 
              T_oc_array(n) = (T_oc_array(n)*real(ice%ice_steps_since_upd,WP)+temp(1,n))/real(ice%ice_steps_since_upd+1,WP)
-#ifdef PROBE_SALT_ANOMALY
-             S_oc_array(n) = (S_oc_array(n)*real(ice%ice_steps_since_upd,WP)+salt(1,n)+35._WP)/real(ice%ice_steps_since_upd+1,WP)
+#ifdef USE_SALT_ANOMALY
+             S_oc_array(n) = (S_oc_array(n)*real(ice%ice_steps_since_upd,WP)+salt(1,n)+S_ref_anomaly)/real(ice%ice_steps_since_upd+1,WP)
 #else
              S_oc_array(n) = (S_oc_array(n)*real(ice%ice_steps_since_upd,WP)+salt(1,n))/real(ice%ice_steps_since_upd+1,WP)
 #endif
@@ -445,8 +445,8 @@ subroutine oce_fluxes(ice, dynamics, tracers, partit, mesh)
         rsss=ref_sss
 !$OMP PARALLEL DO
         do n=1, myDim_nod2D+eDim_nod2D
-#ifdef PROBE_SALT_ANOMALY
-            if (ref_sss_local) rsss = salt(ulevels_nod2d(n),n) + 35._WP
+#ifdef USE_SALT_ANOMALY
+            if (ref_sss_local) rsss = salt(ulevels_nod2d(n),n) + S_ref_anomaly
 #else
             if (ref_sss_local) rsss = salt(ulevels_nod2d(n),n)
 #endif
@@ -487,8 +487,8 @@ subroutine oce_fluxes(ice, dynamics, tracers, partit, mesh)
         do n=1, myDim_nod2D+eDim_nod2D
             virtual_salt(n)=0.0_WP
             if (ulevels_nod2d(n) == 1) cycle ! --> is open ocean node 
-#ifdef PROBE_SALT_ANOMALY
-            if (ref_sss_local) rsss = salt(ulevels_nod2d(n),n) + 35._WP
+#ifdef USE_SALT_ANOMALY
+            if (ref_sss_local) rsss = salt(ulevels_nod2d(n),n) + S_ref_anomaly
 #else
             if (ref_sss_local) rsss = salt(ulevels_nod2d(n),n)
 #endif
@@ -517,8 +517,8 @@ subroutine oce_fluxes(ice, dynamics, tracers, partit, mesh)
         do n=1, myDim_nod2D+eDim_nod2D
             relax_salt(n) = 0.0_WP
             if (ulevels_nod2d(n) > 1) cycle ! --> is cavity node --> only do salt relaxation in open ocean
-#ifdef PROBE_SALT_ANOMALY
-            relax_salt(n)=surf_relax_S*(Ssurf(n)-35._WP-salt(ulevels_nod2d(n),n))
+#ifdef USE_SALT_ANOMALY
+            relax_salt(n)=surf_relax_S*(Ssurf(n)-S_ref_anomaly-salt(ulevels_nod2d(n),n))
 #else
             relax_salt(n)=surf_relax_S*(Ssurf(n)-salt(ulevels_nod2d(n),n))
 #endif
@@ -527,8 +527,8 @@ subroutine oce_fluxes(ice, dynamics, tracers, partit, mesh)
     else
 !$OMP PARALLEL DO
         do n=1, myDim_nod2D+eDim_nod2D
-#ifdef PROBE_SALT_ANOMALY
-            relax_salt(n)=surf_relax_S*(Ssurf(n)-35._WP-salt(ulevels_nod2d(n),n))
+#ifdef USE_SALT_ANOMALY
+            relax_salt(n)=surf_relax_S*(Ssurf(n)-S_ref_anomaly-salt(ulevels_nod2d(n),n))
 #else
             relax_salt(n)=surf_relax_S*(Ssurf(n)-salt(ulevels_nod2d(n),n))
 #endif
@@ -675,9 +675,9 @@ subroutine oce_fluxes(ice, dynamics, tracers, partit, mesh)
 !$OMP PARALLEL DO
     do n=1, myDim_nod2D+eDim_nod2D    
         if (ulevels_nod2d(n) == 1) then ! --> is open ocean node
-#ifdef PROBE_SALT_ANOMALY
+#ifdef USE_SALT_ANOMALY
             ! state stores S-35; diagnostic density flux wants absolute S
-            dens_flux(n)=sw_alpha(1,n) * heat_flux_in(n) / vcpw + sw_beta(1, n) * (relax_salt(n) + water_flux(n) * (salt(1,n)+35._WP))
+            dens_flux(n)=sw_alpha(1,n) * heat_flux_in(n) / vcpw + sw_beta(1, n) * (relax_salt(n) + water_flux(n) * (salt(1,n)+S_ref_anomaly))
 #else
             dens_flux(n)=sw_alpha(1,n) * heat_flux_in(n) / vcpw + sw_beta(1, n) * (relax_salt(n) + water_flux(n) * salt(1,n))
 #endif

--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -7,7 +7,7 @@ module io_MEANDATA
   use recom_ciso
 #endif
   USE g_clock
-  use o_PARAM, only : WP
+  use o_PARAM, only : WP, S_ref_anomaly
   use, intrinsic :: iso_fortran_env, only: real64, real32
   use io_data_strategy_module
   use async_threads_module
@@ -62,6 +62,7 @@ module io_MEANDATA
     integer                                            :: addcounter =0
     integer                                            :: lastcounter=0 ! before addcounter is set to 0
     real(kind=WP), pointer                             :: ptr3(:,:) ! todo: use netcdf types, not WP
+    real(kind=WP)                                      :: offset = 0.0_WP ! added to ptr3 at accumulation (USE_SALT_ANOMALY: salt/sss carry +S_ref_anomaly so output stays absolute)
     character(500)                                     :: filename
     character(100)                                     :: name
     character(500)                                     :: description
@@ -413,6 +414,9 @@ CASE ('sst       ')
     call def_stream(nod2D, myDim_nod2D, 'sst',      'sea surface temperature',        'C', tracers%data(1)%values(1,1:myDim_nod2D), io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh, "Sea surface temperature")
 CASE ('sss       ')
     call def_stream(nod2D, myDim_nod2D, 'sss',      'sea surface salinity',           'psu', tracers%data(2)%values(1,1:myDim_nod2D), io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh, "Sea surface salinity")
+#ifdef USE_SALT_ANOMALY
+    io_stream(io_NSTREAMS)%p%offset = S_ref_anomaly   ! state stores S-S_ref; output stays absolute
+#endif
 CASE ('ssh       ')
     call def_stream(nod2D, myDim_nod2D, 'ssh',      'sea surface elevation',          'm',      dynamics%eta_n,                          io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
 CASE ('vve_5     ')
@@ -1016,6 +1020,9 @@ CASE ('temp      ')
     call def_stream((/nl-1, nod2D/),  (/nl-1, myDim_nod2D/),  'temp',      'temperature', 'C',      tracers%data(1)%values(:,:),             io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
 CASE ('salt      ')
     call def_stream((/nl-1, nod2D/),  (/nl-1, myDim_nod2D/),  'salt',      'salinity',    'psu',    tracers%data(2)%values(:,:),             io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
+#ifdef USE_SALT_ANOMALY
+    io_stream(io_NSTREAMS)%p%offset = S_ref_anomaly   ! state stores S-S_ref; output stays absolute
+#endif
 
 #if defined(__recom)
 
@@ -2724,7 +2731,7 @@ subroutine update_means
 !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(I,J)
                 DO J=1, size(entry%local_values_r8,dim=2)
                     DO I=1, size(entry%local_values_r8,dim=1)
-                        entry%local_values_r8(I,J)=entry%local_values_r8(I,J)+entry%ptr3(J,I)
+                        entry%local_values_r8(I,J)=entry%local_values_r8(I,J)+entry%ptr3(J,I)+entry%offset
                     END DO
                 END DO
 !$OMP END PARALLEL DO
@@ -2732,7 +2739,7 @@ subroutine update_means
 !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(I,J)
                 DO J=1, size(entry%local_values_r8,dim=2)
                     DO I=1, size(entry%local_values_r8,dim=1)
-                        entry%local_values_r8(I,J)=entry%local_values_r8(I,J)+entry%ptr3(I,J)
+                        entry%local_values_r8(I,J)=entry%local_values_r8(I,J)+entry%ptr3(I,J)+entry%offset
                     END DO
                 END DO
 !$OMP END PARALLEL DO
@@ -2744,7 +2751,7 @@ subroutine update_means
 !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(I,J)
                 DO J=1, size(entry%local_values_r4,dim=2)
                     DO I=1, size(entry%local_values_r4,dim=1)
-                        entry%local_values_r4(I,J)=entry%local_values_r4(I,J)+real(entry%ptr3(J,I), real32)
+                        entry%local_values_r4(I,J)=entry%local_values_r4(I,J)+real(entry%ptr3(J,I)+entry%offset, real32)
                     END DO
                 END DO
 !$OMP END PARALLEL DO
@@ -2752,7 +2759,7 @@ subroutine update_means
 !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(I, J)
                 DO J=1, size(entry%local_values_r4,dim=2)
                     DO I=1, size(entry%local_values_r4,dim=1)
-                        entry%local_values_r4(I,J)=entry%local_values_r4(I,J)+real(entry%ptr3(I,J), real32)
+                        entry%local_values_r4(I,J)=entry%local_values_r4(I,J)+real(entry%ptr3(I,J)+entry%offset, real32)
                     END DO
                 END DO
 !$OMP END PARALLEL DO

--- a/src/oce_ale_mixing_kpp.F90
+++ b/src/oce_ale_mixing_kpp.F90
@@ -357,10 +357,10 @@ contains
 ! Surface buoyancy forcing (eqns. A2c & A2d & A3b & A3d)
      !!PS Bo(node)  = -g * ( sw_alpha(1,node) * heat_flux(node)  / vcpw             &   !heat_flux & water_flux: positive up
      !!PS                  + sw_beta (1,node) * water_flux(node) * tr_arr(1,node,2))
-#ifdef PROBE_SALT_ANOMALY
+#ifdef USE_SALT_ANOMALY
      ! state stores S-35; the buoyancy flux from the freshwater flux wants absolute S
      Bo(node)  = -g * ( sw_alpha(nzmin,node) * heat_flux(node)  / vcpw             &   !heat_flux & water_flux: positive up
-                      + sw_beta (nzmin,node) * water_flux(node) * (tracers%data(2)%values(nzmin,node)+35._WP))
+                      + sw_beta (nzmin,node) * water_flux(node) * (tracers%data(2)%values(nzmin,node)+S_ref_anomaly))
 #else
      Bo(node)  = -g * ( sw_alpha(nzmin,node) * heat_flux(node)  / vcpw             &   !heat_flux & water_flux: positive up
                       + sw_beta (nzmin,node) * water_flux(node) * tracers%data(2)%values(nzmin,node))
@@ -892,9 +892,9 @@ contains
         nzmax = nlevels_nod2D(node)
         DO nz=nzmin+1,nzmax-1
            alphaDT = sw_alpha(nz-1,node) * tracers%data(1)%values(nz-1,node)
-#ifdef PROBE_SALT_ANOMALY
+#ifdef USE_SALT_ANOMALY
            ! state stores S-35; double-diffusion density ratio wants absolute S
-           betaDS  = sw_beta (nz-1,node) * (tracers%data(2)%values(nz-1,node)+35._WP)
+           betaDS  = sw_beta (nz-1,node) * (tracers%data(2)%values(nz-1,node)+S_ref_anomaly)
 #else
            betaDS  = sw_beta (nz-1,node) * tracers%data(2)%values(nz-1,node)
 #endif

--- a/src/oce_ale_mixing_kpp.F90
+++ b/src/oce_ale_mixing_kpp.F90
@@ -357,8 +357,14 @@ contains
 ! Surface buoyancy forcing (eqns. A2c & A2d & A3b & A3d)
      !!PS Bo(node)  = -g * ( sw_alpha(1,node) * heat_flux(node)  / vcpw             &   !heat_flux & water_flux: positive up
      !!PS                  + sw_beta (1,node) * water_flux(node) * tr_arr(1,node,2))
+#ifdef PROBE_SALT_ANOMALY
+     ! state stores S-35; the buoyancy flux from the freshwater flux wants absolute S
      Bo(node)  = -g * ( sw_alpha(nzmin,node) * heat_flux(node)  / vcpw             &   !heat_flux & water_flux: positive up
-                      + sw_beta (nzmin,node) * water_flux(node) * tracers%data(2)%values(nzmin,node)) 
+                      + sw_beta (nzmin,node) * water_flux(node) * (tracers%data(2)%values(nzmin,node)+35._WP))
+#else
+     Bo(node)  = -g * ( sw_alpha(nzmin,node) * heat_flux(node)  / vcpw             &   !heat_flux & water_flux: positive up
+                      + sw_beta (nzmin,node) * water_flux(node) * tracers%data(2)%values(nzmin,node))
+#endif
   END DO
       
 ! compute interior mixing coefficients everywhere, due to constant 
@@ -886,7 +892,12 @@ contains
         nzmax = nlevels_nod2D(node)
         DO nz=nzmin+1,nzmax-1
            alphaDT = sw_alpha(nz-1,node) * tracers%data(1)%values(nz-1,node)
+#ifdef PROBE_SALT_ANOMALY
+           ! state stores S-35; double-diffusion density ratio wants absolute S
+           betaDS  = sw_beta (nz-1,node) * (tracers%data(2)%values(nz-1,node)+35._WP)
+#else
            betaDS  = sw_beta (nz-1,node) * tracers%data(2)%values(nz-1,node)
+#endif
 
            IF (alphaDT > betaDS .and. betaDS > 0.0_WP) THEN
 

--- a/src/oce_ale_pressure_bv.F90
+++ b/src/oce_ale_pressure_bv.F90
@@ -246,16 +246,16 @@ subroutine pressure_bv(tracers, partit, mesh)
 
     !___________________________________________________________________________
     ! model explodes, no OpenMP parallelization !
-#ifdef PROBE_SALT_ANOMALY
+#ifdef USE_SALT_ANOMALY
     ! state stores S-35: absolute S<0 <=> anomaly < -35
-    if( a < -35.0_WP ) then
+    if( a < -S_ref_anomaly ) then
         write (*,*)' --> pressure_bv: s<0 happens! (anomaly state)', a
         pe_status=1
         do node=1, myDim_nod2D+eDim_nod2D
             nzmin = ulevels_nod2D(node)
             nzmax = nlevels_nod2D(node)
             do nz=nzmin, nzmax-1
-                if (salt(nz, node) < -35.0_WP) write (*,*) 'the model blows up at n=', mylist_nod2D(node), ' ; ', 'nz=', nz
+                if (salt(nz, node) < -S_ref_anomaly) write (*,*) 'the model blows up at n=', mylist_nod2D(node), ' ; ', 'nz=', nz
             end do
         end do
     endif
@@ -2755,8 +2755,8 @@ IMPLICIT NONE
 
   !compute secant bulk modulus
 
-#ifdef PROBE_SALT_ANOMALY
-  s_abs = s + 35._WP   ! state stores S-35; the EOS needs absolute salinity
+#ifdef USE_SALT_ANOMALY
+  s_abs = s + S_ref_anomaly   ! state stores S-35; the EOS needs absolute salinity
 #else
   s_abs = s
 #endif
@@ -2912,8 +2912,8 @@ subroutine sw_alpha_beta(TF1,SF1, partit, mesh)
 
      t1 = TF1(nz,n)*1.00024_WP
      s1 = SF1(nz,n)
-#ifdef PROBE_SALT_ANOMALY
-     s1 = s1 + 35._WP   ! state stores S-35; McDougall polynomial wants absolute
+#ifdef USE_SALT_ANOMALY
+     s1 = s1 + S_ref_anomaly   ! state stores S-35; McDougall polynomial wants absolute
 #endif
     !!PS      p1 = abs(Z(nz))
      p1 = abs(Z_3d_n(nz,n))

--- a/src/oce_ale_pressure_bv.F90
+++ b/src/oce_ale_pressure_bv.F90
@@ -2711,7 +2711,7 @@ IMPLICIT NONE
   
   real(kind=WP),  intent(IN)            :: t,s
   real(kind=WP),  intent(OUT)           :: bulk_0, bulk_pz, bulk_pz2, rhopot
-  real(kind=WP)                         :: s_sqrt
+  real(kind=WP)                         :: s_sqrt, s_abs
 
   real(kind=WP), parameter   :: a0    = 19092.56,     at   = 209.8925
   real(kind=WP), parameter   :: at2   = -3.041638,    at3  = -1.852732e-3
@@ -2740,22 +2740,27 @@ IMPLICIT NONE
 
   !compute secant bulk modulus
 
-  s_sqrt = sqrt(s)
+#ifdef PROBE_SALT_ANOMALY
+  s_abs = s + 35._WP   ! state stores S-35; the EOS needs absolute salinity
+#else
+  s_abs = s
+#endif
+  s_sqrt = sqrt(s_abs)
 
   bulk_0 =  a0      + t*(at   + t*(at2  + t*(at3 + t*at4)))      &
-          + s* (as  + t*(ast  + t*(ast2 + t*ast3))               &
+          + s_abs* (as  + t*(ast  + t*(ast2 + t*ast3))               &
                + s_sqrt*(ass  + t*(asst + t*asst2)))
 
   bulk_pz =  ap  + t*(apt  + t*(apt2 + t*apt3))                  &
-                  + s*(aps + t*(apst + t*apst2) + s_sqrt*apss)
+                  + s_abs*(aps + t*(apst + t*apst2) + s_sqrt*apss)
 
   bulk_pz2 = ap2 + t*(ap2t + t*ap2t2)		                 &
-                + s *(ap2s + t*(ap2st + t*ap2st2))
+                + s_abs *(ap2s + t*(ap2st + t*ap2st2))
 
   rhopot =  b0 + t*(bt + t*(bt2 + t*(bt3  + t*(bt4  + t*bt5))))	 &
-               + s*(bs + t*(bst + t*(bst2 + t*(bst3 + t*bst4)))  &
+               + s_abs*(bs + t*(bst + t*(bst2 + t*(bst3 + t*bst4)))  &
                   + s_sqrt*(bss + t*(bsst + t*bsst2))            &
-                       + s* bss2)
+                       + s_abs* bss2)
 end subroutine densityJM_components
 !
 !

--- a/src/oce_ale_pressure_bv.F90
+++ b/src/oce_ale_pressure_bv.F90
@@ -246,6 +246,20 @@ subroutine pressure_bv(tracers, partit, mesh)
 
     !___________________________________________________________________________
     ! model explodes, no OpenMP parallelization !
+#ifdef PROBE_SALT_ANOMALY
+    ! state stores S-35: absolute S<0 <=> anomaly < -35
+    if( a < -35.0_WP ) then
+        write (*,*)' --> pressure_bv: s<0 happens! (anomaly state)', a
+        pe_status=1
+        do node=1, myDim_nod2D+eDim_nod2D
+            nzmin = ulevels_nod2D(node)
+            nzmax = nlevels_nod2D(node)
+            do nz=nzmin, nzmax-1
+                if (salt(nz, node) < -35.0_WP) write (*,*) 'the model blows up at n=', mylist_nod2D(node), ' ; ', 'nz=', nz
+            end do
+        end do
+    endif
+#else
     if( a < 0.0_WP ) then
         write (*,*)' --> pressure_bv: s<0 happens!', a
         pe_status=1
@@ -257,6 +271,7 @@ subroutine pressure_bv(tracers, partit, mesh)
             end do
         end do
     endif
+#endif
 
     !___________________________________________________________________________
 
@@ -2897,6 +2912,9 @@ subroutine sw_alpha_beta(TF1,SF1, partit, mesh)
 
      t1 = TF1(nz,n)*1.00024_WP
      s1 = SF1(nz,n)
+#ifdef PROBE_SALT_ANOMALY
+     s1 = s1 + 35._WP   ! state stores S-35; McDougall polynomial wants absolute
+#endif
     !!PS      p1 = abs(Z(nz))
      p1 = abs(Z_3d_n(nz,n))
 

--- a/src/oce_ale_tracer.F90
+++ b/src/oce_ale_tracer.F90
@@ -735,7 +735,13 @@ subroutine diff_ver_part_expl_ale(tr_num, tracers, partit, mesh)
             rdata =  Tsurf(n)
             rlx   =  surf_relax_T
         elseif (tracers%data(tr_num)%ID==2) then
+#ifdef PROBE_SALT_ANOMALY
+            ! state stores S-35: add the background-35 dilution term (see the
+            ! implicit-path salinity BC for the derivation)
+            flux  =  virtual_salt(n)+relax_salt(n) + (real_salt_flux(n) + 35._WP*water_flux(n))*is_nonlinfs
+#else
             flux  =  virtual_salt(n)+relax_salt(n) + real_salt_flux(n)*is_nonlinfs
+#endif
         else
             flux  = 0._WP
             rdata = 0._WP
@@ -1725,8 +1731,18 @@ FUNCTION bc_surface(n, id, sval, nzmin, partit, mesh, sst, sss, aice)
     CASE (2)
         ! --> real_salt_flux(:): salt flux due to containment/releasing of salt
         !     by forming/melting of sea ice
+#ifdef PROBE_SALT_ANOMALY
+        ! state stores S-35: the surface volume flux (folded into Wvel(nzmin))
+        ! concentrates/dilutes only the stored anomaly at its local value; the
+        ! background 35 must be supplied explicitly -- water enters/leaves
+        ! carrying S=0, i.e. anomaly -35 -- exactly the sval*water_flux pattern
+        ! of the temperature BC above, with sval = -35.
+        bc_surface= dt*(virtual_salt(n) &
+                    + relax_salt(n) + (real_salt_flux(n) + 35._WP*water_flux(n))*is_nonlinfs)
+#else
         bc_surface= dt*(virtual_salt(n) & !--> is zeros for zlevel/zstar
                     + relax_salt(n) + real_salt_flux(n)*is_nonlinfs)
+#endif
             
     !___Transient tracers (cases ##6,11,12,14,39)__________________________________
     CASE (6) ! SF6

--- a/src/oce_ale_tracer.F90
+++ b/src/oce_ale_tracer.F90
@@ -352,6 +352,14 @@ subroutine solve_tracers_ale(ice, dynamics, tracers, partit, mesh)
     do node=1,myDim_nod2D+eDim_nod2D
         nzmax=nlevels_nod2D(node)-1
         nzmin=ulevels_nod2D(node)
+#ifdef PROBE_SALT_ANOMALY
+        where (tracers%data(2)%values(nzmin:nzmax,node) > 10._WP)
+               tracers%data(2)%values(nzmin:nzmax,node)=10._WP
+        end where
+        where (tracers%data(2)%values(nzmin:nzmax,node) < -32._WP )
+               tracers%data(2)%values(nzmin:nzmax,node) = -32._WP
+        end where
+#else
         where (tracers%data(2)%values(nzmin:nzmax,node) > 45._WP)
                tracers%data(2)%values(nzmin:nzmax,node)=45._WP
         end where
@@ -359,6 +367,7 @@ subroutine solve_tracers_ale(ice, dynamics, tracers, partit, mesh)
         where (tracers%data(2)%values(nzmin:nzmax,node) < 3._WP )
                tracers%data(2)%values(nzmin:nzmax,node) = 3._WP
         end where
+#endif
     end do
 !$OMP END PARALLEL DO
 

--- a/src/oce_ale_tracer.F90
+++ b/src/oce_ale_tracer.F90
@@ -134,7 +134,7 @@ end module solve_tracers_ale_interface
 ! Driving routine    Here with ALE changes!!!
 subroutine solve_tracers_ale(ice, dynamics, tracers, partit, mesh)
     use g_config
-    use o_PARAM, only: SPP, Fer_GM
+    use o_PARAM, only: SPP, Fer_GM, S_ref_anomaly
     use mod_mesh
     USE MOD_PARTIT
     USE MOD_PARSUP
@@ -352,12 +352,12 @@ subroutine solve_tracers_ale(ice, dynamics, tracers, partit, mesh)
     do node=1,myDim_nod2D+eDim_nod2D
         nzmax=nlevels_nod2D(node)-1
         nzmin=ulevels_nod2D(node)
-#ifdef PROBE_SALT_ANOMALY
-        where (tracers%data(2)%values(nzmin:nzmax,node) > 10._WP)
-               tracers%data(2)%values(nzmin:nzmax,node)=10._WP
+#ifdef USE_SALT_ANOMALY
+        where (tracers%data(2)%values(nzmin:nzmax,node) > 45._WP - S_ref_anomaly)
+               tracers%data(2)%values(nzmin:nzmax,node)= 45._WP - S_ref_anomaly
         end where
-        where (tracers%data(2)%values(nzmin:nzmax,node) < -32._WP )
-               tracers%data(2)%values(nzmin:nzmax,node) = -32._WP
+        where (tracers%data(2)%values(nzmin:nzmax,node) < 3._WP - S_ref_anomaly )
+               tracers%data(2)%values(nzmin:nzmax,node) = 3._WP - S_ref_anomaly
         end where
 #else
         where (tracers%data(2)%values(nzmin:nzmax,node) > 45._WP)
@@ -697,6 +697,7 @@ end subroutine diff_tracers_ale
 !===============================================================================
 !Vertical diffusive flux(explicit scheme):
 subroutine diff_ver_part_expl_ale(tr_num, tracers, partit, mesh)
+    use o_PARAM, only: S_ref_anomaly
     use o_ARRAYS
     use g_forcing_arrays
     use MOD_MESH
@@ -735,10 +736,10 @@ subroutine diff_ver_part_expl_ale(tr_num, tracers, partit, mesh)
             rdata =  Tsurf(n)
             rlx   =  surf_relax_T
         elseif (tracers%data(tr_num)%ID==2) then
-#ifdef PROBE_SALT_ANOMALY
+#ifdef USE_SALT_ANOMALY
             ! state stores S-35: add the background-35 dilution term (see the
             ! implicit-path salinity BC for the derivation)
-            flux  =  virtual_salt(n)+relax_salt(n) + (real_salt_flux(n) + 35._WP*water_flux(n))*is_nonlinfs
+            flux  =  virtual_salt(n)+relax_salt(n) + (real_salt_flux(n) + S_ref_anomaly*water_flux(n))*is_nonlinfs
 #else
             flux  =  virtual_salt(n)+relax_salt(n) + real_salt_flux(n)*is_nonlinfs
 #endif
@@ -1683,6 +1684,7 @@ FUNCTION bc_surface(n, id, sval, nzmin, partit, mesh, sst, sss, aice)
   use MOD_MESH
   USE MOD_PARTIT
   USE MOD_PARSUP
+  use o_PARAM, only: S_ref_anomaly
   USE o_ARRAYS
   USE g_forcing_arrays
   USE g_config
@@ -1731,14 +1733,14 @@ FUNCTION bc_surface(n, id, sval, nzmin, partit, mesh, sst, sss, aice)
     CASE (2)
         ! --> real_salt_flux(:): salt flux due to containment/releasing of salt
         !     by forming/melting of sea ice
-#ifdef PROBE_SALT_ANOMALY
+#ifdef USE_SALT_ANOMALY
         ! state stores S-35: the surface volume flux (folded into Wvel(nzmin))
         ! concentrates/dilutes only the stored anomaly at its local value; the
         ! background 35 must be supplied explicitly -- water enters/leaves
         ! carrying S=0, i.e. anomaly -35 -- exactly the sval*water_flux pattern
         ! of the temperature BC above, with sval = -35.
         bc_surface= dt*(virtual_salt(n) &
-                    + relax_salt(n) + (real_salt_flux(n) + 35._WP*water_flux(n))*is_nonlinfs)
+                    + relax_salt(n) + (real_salt_flux(n) + S_ref_anomaly*water_flux(n))*is_nonlinfs)
 #else
         bc_surface= dt*(virtual_salt(n) & !--> is zeros for zlevel/zstar
                     + relax_salt(n) + real_salt_flux(n)*is_nonlinfs)

--- a/src/oce_modules.F90
+++ b/src/oce_modules.F90
@@ -16,6 +16,11 @@ integer		                  :: mstep
 real(kind=WP), parameter      :: pi=3.14159265358979
 real(kind=WP), parameter      :: rad=pi/180.0_WP
 real(kind=WP), parameter      :: density_0=1030.0_WP
+! USE_SALT_ANOMALY: the salinity state is stored as S - S_ref_anomaly, so that
+! the float32 spacing at typical open-ocean values (|S-35| < ~2) is 30-250x
+! finer than at S~35 (ulp 1.9e-6 psu). All consumers of absolute salinity add
+! the offset back at their gather points; see the USE_SALT_ANOMALY blocks.
+real(kind=WP), parameter      :: S_ref_anomaly=35.0_WP
 real(kind=WP), parameter      :: density_0_r=1.0_WP/density_0 ! [m^3/kg]
 real(kind=WP), parameter      :: g=9.81_WP
 real(kind=WP), parameter      :: r_earth=6367500.0_WP

--- a/src/oce_setup_step.F90
+++ b/src/oce_setup_step.F90
@@ -250,6 +250,14 @@ subroutine ocean_setup(dynamics, tracers, partit, mesh)
        call oce_initial_state(tracers, partit, mesh)   ! Use it if not running tests
     end if
 
+#ifdef PROBE_SALT_ANOMALY
+    ! salinity state is stored as the anomaly S-35 (finer float32 ulp where the
+    ! ocean lives); initial conditions arrive absolute -> convert ONCE here,
+    ! before the AB copies. All absolute-S consumers carry +35 shims (EOS,
+    ! ice gather, rsss, SSS restoring); clip bounds shifted accordingly.
+    tracers%data(2)%values = tracers%data(2)%values - 35._WP
+    if (partit%mype==0) write(*,*) 'PROBE_SALT_ANOMALY: salinity state = S - 35'
+#endif
     if (.not.r_restart) then
        do n=1, tracers%num_tracers
           do i=1, tracers%data(n)%AB_order-1

--- a/src/oce_setup_step.F90
+++ b/src/oce_setup_step.F90
@@ -83,7 +83,7 @@ subroutine ocean_setup(dynamics, tracers, partit, mesh)
     USE o_PARAM
     USE o_ARRAYS
     USE g_config
-    USE g_forcing_param, only: use_virt_salt
+    USE g_forcing_param, only: use_virt_salt, use_age_tracer
     use o_mixing_KPP_mod
 #if defined (__cvmix)       
     use g_cvmix_tke
@@ -250,13 +250,25 @@ subroutine ocean_setup(dynamics, tracers, partit, mesh)
        call oce_initial_state(tracers, partit, mesh)   ! Use it if not running tests
     end if
 
-#ifdef PROBE_SALT_ANOMALY
-    ! salinity state is stored as the anomaly S-35 (finer float32 ulp where the
-    ! ocean lives); initial conditions arrive absolute -> convert ONCE here,
-    ! before the AB copies. All absolute-S consumers carry +35 shims (EOS,
-    ! ice gather, rsss, SSS restoring); clip bounds shifted accordingly.
-    tracers%data(2)%values = tracers%data(2)%values - 35._WP
-    if (partit%mype==0) write(*,*) 'PROBE_SALT_ANOMALY: salinity state = S - 35'
+#ifdef USE_SALT_ANOMALY
+    ! salinity state is stored as the anomaly S - S_ref_anomaly (finer float32
+    ! spacing where the ocean lives); initial conditions arrive absolute ->
+    ! convert ONCE here, before the AB copies. All absolute-S consumers carry
+    ! offset corrections (EOS, sw_alpha_beta, ice gather, rsss, SSS restoring,
+    ! KPP buoyancy/double-diffusion, surface dilution term); clip and blowup
+    ! bounds shifted accordingly. Restart reads are converted in fesom_init.
+    tracers%data(2)%values = tracers%data(2)%values - S_ref_anomaly
+    if (partit%mype==0) write(*,*) 'USE_SALT_ANOMALY: salinity state = S - ', S_ref_anomaly
+    ! configurations with absolute-salinity consumers that carry NO offset
+    ! correction yet: refuse to start instead of silently computing wrong
+    ! physics (extend the offset corrections before lifting a guard)
+    if (SPP .or. use_cavity .or. use_icebergs .or. use_age_tracer .or. use_transit &
+        .or. use_kpp_nonlclflx .or. clim_relax > 1.e-8_WP) then
+        if (partit%mype==0) write(*,*) 'USE_SALT_ANOMALY does not support yet: ', &
+            'SPP, cavities, icebergs, age tracer, transient tracers, ', &
+            'KPP nonlocal fluxes, 3D climatology relaxation'
+        call par_ex(partit%MPI_COMM_FESOM, partit%mype, 1)
+    end if
 #endif
     if (.not.r_restart) then
        do n=1, tracers%num_tracers

--- a/src/write_step_info.F90
+++ b/src/write_step_info.F90
@@ -591,8 +591,14 @@ subroutine check_blowup(istep, ice, dynamics, tracers, partit, mesh)
           
           !_______________________________________________________________
           ! check salt
+#ifdef PROBE_SALT_ANOMALY
+          ! state stores S-35: bounds shifted like the clip in oce_ale_tracer
+          if ( (tracers%data(2)%values(nz, n) /= tracers%data(2)%values(nz, n)) .or.  &
+             tracers%data(2)%values(nz, n) < -32.0_WP .or. tracers%data(2)%values(nz, n) > 10.0_WP ) then
+#else
           if ( (tracers%data(2)%values(nz, n) /= tracers%data(2)%values(nz, n)) .or.  &
              tracers%data(2)%values(nz, n) <3.0_WP .or. tracers%data(2)%values(nz, n) >45.0_WP ) then
+#endif
 !$OMP CRITICAL
              found_blowup_loc=1
              write(*,*) '___CHECK FOR BLOW UP___________ --> mstep=',istep

--- a/src/write_step_info.F90
+++ b/src/write_step_info.F90
@@ -591,10 +591,10 @@ subroutine check_blowup(istep, ice, dynamics, tracers, partit, mesh)
           
           !_______________________________________________________________
           ! check salt
-#ifdef PROBE_SALT_ANOMALY
+#ifdef USE_SALT_ANOMALY
           ! state stores S-35: bounds shifted like the clip in oce_ale_tracer
           if ( (tracers%data(2)%values(nz, n) /= tracers%data(2)%values(nz, n)) .or.  &
-             tracers%data(2)%values(nz, n) < -32.0_WP .or. tracers%data(2)%values(nz, n) > 10.0_WP ) then
+             tracers%data(2)%values(nz, n) < 3.0_WP - S_ref_anomaly .or. tracers%data(2)%values(nz, n) > 45.0_WP - S_ref_anomaly ) then
 #else
           if ( (tracers%data(2)%values(nz, n) /= tracers%data(2)%values(nz, n)) .or.  &
              tracers%data(2)%values(nz, n) <3.0_WP .or. tracers%data(2)%values(nz, n) >45.0_WP ) then


### PR DESCRIPTION
## What

Adds `USE_SALT_ANOMALY` (CMake option, off by default): the salinity state is
stored as the anomaly `S - S_ref_anomaly` (35 psu, named parameter in
`o_PARAM`). At |S-35| < ~2 the float32 spacing is 30-250x finer than at S~35
(ulp 1.9e-6 psu), so the slow increments that float32 accumulation absorbs
become representable. Every consumer of absolute salinity adds the offset back
at its gather point: EOS (`densityJM_components`), `sw_alpha_beta`, the
ice-ocean salinity gather, `ref_sss_local`/SSS restoring, KPP surface buoyancy
flux and double diffusion, the `dens_flux` diagnostic, and the surface
dilution term in the salinity BC (`+S_ref*water_flux*is_nonlinfs` - the exact
analogue of the `sval*water_flux` term in the temperature BC: freshwater
enters carrying S=0, i.e. anomaly -S_ref). Clip and blow-up bounds shift by
-S_ref.

Compatibility:
- **Restarts**: files keep what the state holds; after `read_initial_conditions`
  the representation is detected from the global salinity maximum (absolute
  peaks near 41 psu, anomaly near 6). An absolute-salinity restart - e.g.
  warm-starting from an existing spun-up state - is converted in place
  (including AB history); an anomaly restart chains unchanged.
- **Output**: mean streams gained a per-stream additive offset applied at
  accumulation; `salt` and `sss` register `S_ref_anomaly`, so NetCDF output
  stays absolute psu regardless of the build.
- **Guards**: configurations with absolute-salinity consumers not yet
  offset-corrected (SPP, cavities, icebergs, age tracer, transient tracers,
  KPP nonlocal fluxes, 3D climatology relaxation) refuse to start with a clear
  message.

## Why

20-year CORE2 attribution twins against the DP reference (cold start 1948,
identical namelists, single-job runs; the campaign behind the paper draft):

| run | global-mean salinity drift @ year 20 |
|---|---|
| six SP arms (reference, different rank count, FP64 global reductions, CG fix, sub-ulp-perturbed control) | **-1.87 mpsu** (all identical +-0.02) |
| SP + FP64 accumulation of the tracer state | **+1.85 mpsu** (mirror image) |
| DP + tracer state rounded to float32 each step (2-yr probe) | -0.135 mpsu in 2 years |
| **SP + this option** | **+0.064 mpsu** (= vanilla / 29) |
| DP control (512 vs 128 ranks) | +-0.001 mpsu |

The decomposition: float32 salinity error = state-accumulation absorption
(negative) + increment-arithmetic rounding at |S|~35 (positive). The anomaly
representation scales BOTH by the ulp ratio (~30x) - the residual slope
(+3.2 upsu/yr) times 31 reproduces the ledger arm's slope.

It also heals the mean state: the 1952-1962 SP-DP climatological SST
difference drops from 0.069 K rms / **1.77 K max** (the NAC/NWC shift) to
0.024 / 0.38 K, SSS from 0.019 / 0.36 psu to 0.006 / 0.12 (DP-DP floor:
0.0074 K / 0.20 K). A DP run with ONLY the tracer state rounded to float32
reproduces the full SP-DP year-2 signal - the mean-state shift and the drift
share the one mechanism this option removes.

Figures (paper repo, you have access): `figures/fig_twin_drift.pdf`,
`figures/fig_twin_maps.pdf` in koldunovn/fesom2-sp-paper.

## Validation

- 5-day cold smoke vs an unmodified build: day-5 state differences at weather
  level (global-mean salt agrees to 2.4 upsu), ranges identical, no guard hits.
- 5-day warm start from an absolute-salinity restart (the 1967 state of the
  DP hindcast): auto-conversion path.
- 2+3-day restart chain: anomaly restart read-back path.
- The 20-yr twin + climatology numbers above (run at cd60ac69..896cae28,
  reproduced by this branch's code path).

## Open design questions

1. `S_ref_anomaly = 35.0`: value and name OK? (Any constant near the ocean
   mode works; 35 keeps the mental arithmetic easy.)
2. Compile-time option (mirrors `USE_SINGLE_PRECISION`, zero runtime cost) vs
   a namelist switch - preference?
3. Restart auto-detection by global max: acceptable, or would you rather have
   an explicit netCDF attribute on the restart files?
4. CI: worth adding an SP+USE_SALT_ANOMALY leg to the precision test matrix
   from #940?
5. The temperature state has the same absorption mechanism (ulp(20 C) ~ 2e-6);
   a T_ref anomaly would be the natural follow-up if we see it matter.
