### PR TITLE
tests: let a fesom test pin extra success markers

### DIFF
--- a/cmake/FesomTesting.cmake
+++ b/cmake/FesomTesting.cmake
@@ -367,9 +367,20 @@ endfunction()
 function(add_fesom_test_with_options TEST_NAME MESH_NAME STEP_PER_DAY RUN_LENGTH RUN_LENGTH_UNIT RESTART_LENGTH RESTART_LENGTH_UNIT LOGFILE_OUTFREQ FORCE_ROTATION USE_CAVITY)
     set(options MPI_TEST)
     set(oneValueArgs NP TIMEOUT)
-    set(multiValueArgs COMMAND_ARGS)
+    # EXTRA_SUCCESS_MARKERS: literal strings that must ALL appear in the run log for
+    # the test to pass, on top of the clean-exit marker. Use these to pin behaviour
+    # that would otherwise rot silently -- a diagnostic block that stops being
+    # printed is a regression no artifact check can see.
+    set(multiValueArgs COMMAND_ARGS EXTRA_SUCCESS_MARKERS)
     cmake_parse_arguments(FESOM_TEST "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     
+    # Assemble the success-marker list: the clean-exit marker is mandatory, callers
+    # may pin additional ones. Each is quoted separately so markers may contain spaces.
+    set(_SUCCESS_MARKERS_ARG "\"fesom should stop with exit status = 0\"")
+    foreach(_m IN LISTS FESOM_TEST_EXTRA_SUCCESS_MARKERS)
+        string(APPEND _SUCCESS_MARKERS_ARG " \"${_m}\"")
+    endforeach()
+
     # Set defaults
     if(NOT DEFINED FESOM_TEST_NP)
         set(FESOM_TEST_NP 1)
@@ -430,7 +441,7 @@ function(add_fesom_test_with_options TEST_NAME MESH_NAME STEP_PER_DAY RUN_LENGTH
                 RESULT \"\${test_result}\"
                 OUTPUT_LOG \"${TEST_RUN_DIR}/test_output.log\"
                 ERROR_LOG \"${TEST_RUN_DIR}/test_error.log\"
-                SUCCESS_MARKERS \"fesom should stop with exit status = 0\"
+                SUCCESS_MARKERS ${_SUCCESS_MARKERS_ARG}
                 REQUIRED_ARTIFACTS \"${RESULT_DIR}/sst.fesom.1948.nc\"
             )
         ")
@@ -462,7 +473,7 @@ function(add_fesom_test_with_options TEST_NAME MESH_NAME STEP_PER_DAY RUN_LENGTH
                 RESULT \"\${test_result}\"
                 OUTPUT_LOG \"${TEST_RUN_DIR}/test_output.log\"
                 ERROR_LOG \"${TEST_RUN_DIR}/test_error.log\"
-                SUCCESS_MARKERS \"fesom should stop with exit status = 0\"
+                SUCCESS_MARKERS ${_SUCCESS_MARKERS_ARG}
                 REQUIRED_ARTIFACTS \"${RESULT_DIR}/sst.fesom.1948.nc\"
             )
         ")


### PR DESCRIPTION
## Why

`check_fesom_run` already accepts an arbitrary `SUCCESS_MARKERS` list, but
`add_fesom_test` / `add_fesom_test_with_options` hard-code it to the single clean-exit
marker. So a test can assert **exit code**, **failure signatures** and **artifacts**, but
nothing about what the run actually printed.

That leaves a real gap: **log output has no artifact behind it**, so a diagnostic that
silently stops being emitted fails nothing. The suite stays green while the information is
gone. This is not hypothetical — the `sprod(2)` defect in the SSH solver survived unnoticed
in exactly this blind spot until `af17e849`, because nothing exercised or asserted it.

## What this adds

`EXTRA_SUCCESS_MARKERS` on `add_fesom_test` / `add_fesom_test_with_options`: literal strings
that must **all** appear in the combined stdout+stderr for the test to pass, on top of the
clean-exit marker. Each is quoted separately so markers may contain spaces. Wired into both
the MPI and the serial generated scripts.

```cmake
add_fesom_test(integration_pi_mpi2
    MPI_TEST
    NP 2
    EXTRA_SUCCESS_MARKERS
        "some label that must appear in the log"
)
```

## This PR changes no test behaviour

**It is the capability only — no test uses it here.** With no caller, the assembled marker
list is exactly what it was before.

Verified rather than asserted: the generated `run_test.cmake` for `integration_pi_mpi2` is
character-for-character identical to the one `main` produces, on the same line —

```
SUCCESS_MARKERS "fesom should stop with exit status = 0"
```

and the full local suite passes 7/7.

## Why separate from the work that motivated it

This is a change to how CI decides pass/fail, which is worth reviewing on its own terms
rather than inside a solver PR. The solver PRs stacked on top of this one register the actual
markers; if this lands and those don't (or vice versa), neither is left broken.

## Useful beyond the solver

Any run-log invariant currently checked by eye can be pinned this way: a scheme reporting
that it is active, a banner that must appear (the SP/DP precision banner is an existing
example), or a warning that must **not**. Prefer stable labels over volatile wording or
numbers, so the assertion survives mesh, rank-count and precision changes.
