### PR TITLE
solver: always-on SSH CG diagnostics, breakdown guard, allocate guards

### DIFF
--- a/src/MOD_DYN.F90
+++ b/src/MOD_DYN.F90
@@ -19,6 +19,20 @@ TYPE T_SOLVERINFO
     real(kind=WP) :: droptol = 1.e-8
     real(kind=WP)  :: soltol  = 1e-5
     real(kind=WP), allocatable   :: rr(:), zz(:), pp(:), App(:)
+    !___________________________________________________________________________
+    ! Per-run solver diagnostics. Deliberately NOT in WRITE/READ_T_SOLVERINFO
+    ! below: these are transients, and adding them to the dump would change the
+    ! restart record layout and silently break every existing restart file (the
+    ! read would just consume the wrong bytes).
+    ! The iteration count is identical on every rank -- the CG exit test is on a
+    ! globally reduced sprod -- so none of this needs an MPI reduction.
+    integer       :: iters_last = 0     ! iterations taken by the last solve
+    integer       :: iters_max  = 0     ! worst solve so far
+    integer       :: iters_sum  = 0     ! for the running mean
+    integer       :: nsolves    = 0
+    integer       :: nonconv    = 0     ! solves that hit maxiter
+    real(kind=WP) :: resid_last = 0.0_WP ! rms residual at exit
+    real(kind=WP) :: rtol_last  = 0.0_WP ! target it was compared against
     contains
     procedure WRITE_T_SOLVERINFO
     procedure READ_T_SOLVERINFO

--- a/src/MOD_DYN.F90
+++ b/src/MOD_DYN.F90
@@ -31,6 +31,8 @@ TYPE T_SOLVERINFO
     integer       :: iters_sum  = 0     ! for the running mean
     integer       :: nsolves    = 0
     integer       :: nonconv    = 0     ! solves that hit maxiter
+    integer       :: nbreakdown = 0     ! solves where p.Ap was not positive
+    integer       :: nnegrz     = 0     ! iterations with r.z < 0 (M^-1 not SPD)
     real(kind=WP) :: resid_last = 0.0_WP ! rms residual at exit
     real(kind=WP) :: rtol_last  = 0.0_WP ! target it was compared against
     contains

--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -1461,6 +1461,22 @@ contains
         44 format (a33,i15)        !Format OMP threads
         45 format (a33,f15.4,a4)   !Format runtime
 
+        !_______________________________________________________________________
+        ! SSH CG solver summary. Always on -- fesom.stats only exists when
+        ! FESOM_PROFILING is compiled in, and it defaults OFF, so this table is
+        ! the one place a normal run reports how the solver behaved.
+        ! No reduce: the iteration count is identical on every rank, since the CG
+        ! exit test is on a globally reduced quantity.
+        if (.not. f%dynamics%use_ssh_se_subcycl .and. f%dynamics%solverinfo%nsolves > 0) then
+            write(*,*)
+            write(*,*) '___SSH CG SOLVER_____________________________________'
+            print 43, '    solves :                     ', f%dynamics%solverinfo%nsolves
+            print 45, '    iterations mean :            ',                                &
+                 real(f%dynamics%solverinfo%iters_sum)/real(f%dynamics%solverinfo%nsolves), '    '
+            print 43, '    iterations max :             ', f%dynamics%solverinfo%iters_max
+            print 43, '    non-convergences (maxiter) : ', f%dynamics%solverinfo%nonconv
+        end if
+
         write(*,*)
         write(*,*) '======================================================'
         write(*,*) '================ BENCHMARK RUNTIME ==================='

--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -1475,6 +1475,8 @@ contains
                  real(f%dynamics%solverinfo%iters_sum)/real(f%dynamics%solverinfo%nsolves), '    '
             print 43, '    iterations max :             ', f%dynamics%solverinfo%iters_max
             print 43, '    non-convergences (maxiter) : ', f%dynamics%solverinfo%nonconv
+            print 43, '    breakdowns (p.Ap<=0) :       ', f%dynamics%solverinfo%nbreakdown
+            print 43, '    iters with r.z<0 (not SPD) : ', f%dynamics%solverinfo%nnegrz
         end if
 
         write(*,*)

--- a/src/fesom_profiler.F90
+++ b/src/fesom_profiler.F90
@@ -14,6 +14,7 @@
 
 module fesom_profiler
     use g_config, only: runid, ResultPath
+    use fesom_rtdiagnostics, only: diag_init, diag_reset, diag_report
     use mpi
 #ifdef _OPENMP
     use omp_lib
@@ -93,7 +94,10 @@ contains
         if (present(enable_profiling)) then
             profiler_enabled = enable_profiling
         endif
-        
+
+        ! Scalar-diagnostics facility rides along with profiling
+        call diag_init(profiler_enabled)
+
         if (.not. profiler_enabled) return
 
         ! Detect OpenMP thread count
@@ -312,6 +316,10 @@ contains
         ! either a range/4 approximation or, rarely, uninitialised garbage.)
         call MPI_Allreduce(local_data(4::4), global_data(4::4), num_profiles, &
                           MPI_DOUBLE_PRECISION, MPI_SUM, mpi_comm, ierr)
+        
+        ! Scalar diagnostics (collective: all ranks reduce, rank 0 writes the block
+        ! above the timing table). Must be outside the rank-0 guard below.
+        call diag_report(unit, mpi_comm, mpi_rank)
 
         ! Only rank 0 prints the report
         if (mpi_rank == 0) then
@@ -853,6 +861,7 @@ contains
         end do
         
         call_stack_depth = 0
+        call diag_reset()
     end subroutine fesom_profiler_reset
 
     !=========================================================================

--- a/src/fesom_rtdiagnostics.F90
+++ b/src/fesom_rtdiagnostics.F90
@@ -1,0 +1,196 @@
+!=============================================================================!
+!                   FESOM2 Scalar-Diagnostics Module
+!=============================================================================!
+! Lightweight, reusable facility to record arbitrary per-call SCALAR quantities
+! (solver iterations, residuals, CFL numbers, event counts, ...) and report
+! them, MPI-reduced, into fesom.stats next to the timing table.
+!
+! It mirrors the fesom_profiler patterns (name->index registry, per-entry
+! accumulation, reduce-then-print) but accumulates VALUES rather than wall time.
+! Storage is double precision (PROF_WP) regardless of the model working
+! precision WP, so SP and DP diagnostics are directly comparable.
+!
+! Usage (guard call sites with #if defined(FESOM_PROFILING) for zero cost when
+! profiling is compiled out, matching the profiler's call sites):
+!     use fesom_rtdiagnostics
+!     call diag_count("ssh_cg_iters", iter)          ! integer
+!     call diag_count("ssh_cg_resid", real(res,8))   ! real
+!
+! Report is emitted by diag_report(), called from fesom_profiler_report().
+!=============================================================================!
+
+! Runtime (rt) diagnostics: counters and scalar statistics about how the model
+! RAN -- solver iterations, residuals, event counts. Deliberately distinct from the
+! physical diagnostics in gen_modules_diag.F90 (module 'diagnostics', the ldiag_*
+! family in namelist.io), which compute geophysical quantities. The rt- prefix keeps
+! the two namespaces apart.
+module fesom_rtdiagnostics
+    use mpi
+    use, intrinsic :: iso_fortran_env, only: real32, real64
+    implicit none
+    private
+
+    integer, parameter :: PROF_WP = selected_real_kind(15, 307)  ! double precision
+    integer, parameter :: MAX_DIAGS = 64
+
+    type :: diag_stat
+        character(len=100) :: name = ""
+        real(kind=PROF_WP) :: sum_val   = 0.0_PROF_WP
+        real(kind=PROF_WP) :: sumsq_val = 0.0_PROF_WP
+        real(kind=PROF_WP) :: min_val   = HUGE(1.0_PROF_WP)
+        real(kind=PROF_WP) :: max_val   = -HUGE(1.0_PROF_WP)
+        integer            :: count     = 0
+    end type diag_stat
+
+    type(diag_stat), save :: diags(MAX_DIAGS)
+    integer, save :: num_diags = 0
+    logical, save :: diag_on   = .false.
+
+    public :: diag_init, diag_enabled, diag_reset, diag_count, diag_report
+
+    ! Generic: pass an integer, a real(real32), or a real(real64) with no cast
+    interface diag_count
+        module procedure diag_count_i
+        module procedure diag_count_r4
+        module procedure diag_count_r8
+    end interface diag_count
+
+contains
+
+    subroutine diag_init(enabled)
+        logical, intent(in) :: enabled
+        diag_on = enabled
+        call diag_reset()
+    end subroutine diag_init
+
+    logical function diag_enabled()
+        diag_enabled = diag_on
+    end function diag_enabled
+
+    subroutine diag_reset()
+        integer :: i
+        do i = 1, MAX_DIAGS
+            diags(i)%name      = ""
+            diags(i)%sum_val   = 0.0_PROF_WP
+            diags(i)%sumsq_val = 0.0_PROF_WP
+            diags(i)%min_val   =  HUGE(1.0_PROF_WP)
+            diags(i)%max_val   = -HUGE(1.0_PROF_WP)
+            diags(i)%count     = 0
+        end do
+        num_diags = 0
+    end subroutine diag_reset
+
+    !------------------------------------------------------------------ generics
+    subroutine diag_count_i(name, value)
+        character(len=*), intent(in) :: name
+        integer,          intent(in) :: value
+        call accumulate(name, real(value, PROF_WP))
+    end subroutine diag_count_i
+
+    subroutine diag_count_r4(name, value)
+        character(len=*),   intent(in) :: name
+        real(kind=real32),  intent(in) :: value
+        call accumulate(name, real(value, PROF_WP))
+    end subroutine diag_count_r4
+
+    subroutine diag_count_r8(name, value)
+        character(len=*),   intent(in) :: name
+        real(kind=real64),  intent(in) :: value
+        call accumulate(name, real(value, PROF_WP))
+    end subroutine diag_count_r8
+
+    !--------------------------------------------------------------- accumulate
+    subroutine accumulate(name, val)
+        character(len=*),   intent(in) :: name
+        real(kind=PROF_WP), intent(in) :: val
+        integer :: i
+        if (.not. diag_on) return
+        i = find_or_create_diag(trim(name))
+        if (i < 1) return
+        diags(i)%sum_val   = diags(i)%sum_val   + val
+        diags(i)%sumsq_val = diags(i)%sumsq_val + val*val
+        diags(i)%min_val   = min(diags(i)%min_val, val)
+        diags(i)%max_val   = max(diags(i)%max_val, val)
+        diags(i)%count     = diags(i)%count + 1
+    end subroutine accumulate
+
+    integer function find_or_create_diag(name) result(index)
+        character(len=*), intent(in) :: name
+        integer :: i
+        index = -1
+        do i = 1, num_diags
+            if (trim(diags(i)%name) == name) then
+                index = i
+                return
+            endif
+        end do
+        if (num_diags < MAX_DIAGS) then
+            num_diags = num_diags + 1
+            index = num_diags
+            diags(index)%name = trim(name)
+        endif
+    end function find_or_create_diag
+
+    !------------------------------------------------------------------- report
+    ! Reduce across ranks and (on rank 0) append a PER-CALL DIAGNOSTICS block.
+    ! Assumes all ranks created the same diagnostics in the same order (the same
+    ! assumption fesom_profiler_report makes for timing sections); true for
+    ! diagnostics recorded on a globally-collective code path (e.g. the SSH CG).
+    subroutine diag_report(unit, mpi_comm, mpi_rank)
+        integer, intent(in) :: unit, mpi_comm, mpi_rank
+        integer :: ierr, i, gnmax
+        real(kind=PROF_WP), allocatable :: lsum(:), lmin(:), lmax(:), lsq(:)
+        real(kind=PROF_WP), allocatable :: gsum(:), gmin(:), gmax(:), gsq(:)
+        integer, allocatable :: lcnt(:), gcnt(:)
+        real(kind=PROF_WP) :: mean, var, std
+
+        if (.not. diag_on) return
+
+        ! Guard against ranks disagreeing on the diagnostic count.
+        call MPI_Allreduce(num_diags, gnmax, 1, MPI_INTEGER, MPI_MAX, mpi_comm, ierr)
+        if (gnmax == 0) return
+        if (num_diags /= gnmax) return  ! inconsistent registries -> skip safely
+
+        allocate(lsum(num_diags), lmin(num_diags), lmax(num_diags), lsq(num_diags), lcnt(num_diags))
+        allocate(gsum(num_diags), gmin(num_diags), gmax(num_diags), gsq(num_diags), gcnt(num_diags))
+        do i = 1, num_diags
+            lsum(i) = diags(i)%sum_val
+            lsq(i)  = diags(i)%sumsq_val
+            lmin(i) = diags(i)%min_val
+            lmax(i) = diags(i)%max_val
+            lcnt(i) = diags(i)%count
+        end do
+
+        call MPI_Allreduce(lsum, gsum, num_diags, MPI_DOUBLE_PRECISION, MPI_SUM, mpi_comm, ierr)
+        call MPI_Allreduce(lsq,  gsq,  num_diags, MPI_DOUBLE_PRECISION, MPI_SUM, mpi_comm, ierr)
+        call MPI_Allreduce(lcnt, gcnt, num_diags, MPI_INTEGER,          MPI_SUM, mpi_comm, ierr)
+        call MPI_Allreduce(lmin, gmin, num_diags, MPI_DOUBLE_PRECISION, MPI_MIN, mpi_comm, ierr)
+        call MPI_Allreduce(lmax, gmax, num_diags, MPI_DOUBLE_PRECISION, MPI_MAX, mpi_comm, ierr)
+
+        if (mpi_rank == 0) then
+            write(unit, '(A)') ''
+            write(unit, '(A)') repeat('=', 90)
+            write(unit, '(A)') '================ PER-CALL DIAGNOSTICS (scalar counters) ================'
+            write(unit, '(A)') 'Mean/call = sum over all calls & ranks / total call count.'
+            write(unit, '(A)') 'Min/Max across ranks & calls; for a globally-identical value Min==Max.'
+            write(unit, '(A)') repeat('=', 90)
+            write(unit, '(A28,A14,A12,A12,A12,A12)') &
+                'Name', 'Mean/call', 'Min', 'Max', 'Std', 'Count'
+            write(unit, '(A)') repeat('-', 90)
+            do i = 1, num_diags
+                if (gcnt(i) <= 0) cycle
+                mean = gsum(i) / real(gcnt(i), PROF_WP)
+                var  = gsq(i) / real(gcnt(i), PROF_WP) - mean*mean
+                if (var < 0.0_PROF_WP) var = 0.0_PROF_WP
+                std  = sqrt(var)
+                write(unit, '(A28,F14.4,F12.4,F12.4,F12.4,I12)') &
+                    adjustl(diags(i)%name), mean, gmin(i), gmax(i), std, gcnt(i)
+            end do
+            write(unit, '(A)') repeat('-', 90)
+            write(unit, '(A)') ''
+        endif
+
+        deallocate(lsum, lmin, lmax, lsq, lcnt, gsum, gmin, gmax, gsq, gcnt)
+    end subroutine diag_report
+
+end module fesom_rtdiagnostics

--- a/src/solver.F90
+++ b/src/solver.F90
@@ -288,10 +288,35 @@ sprod(1:2)=0.0_WP
   call diag_count("ssh_cg_iters", min(iter, solverinfo%maxiter))
   if (.not. converged) call diag_count("ssh_cg_nonconv", 1)
 #endif
-  ! Safety-net log line (always on): a silent stall at maxiter used to be invisible.
+
+  !_____________________________________________________________________________
+  ! Always-on counters. FESOM_PROFILING defaults OFF, so the block above is
+  ! invisible in a normal run; these feed the per-step line in write_step_info
+  ! and the end-of-run summary, which are not gated on anything.
+  ! No MPI needed: every rank exits on the same iteration, because the exit test
+  ! above is on the globally reduced sprod.
+  solverinfo%iters_last = min(iter, solverinfo%maxiter)
+  solverinfo%iters_max  = max(solverinfo%iters_max, solverinfo%iters_last)
+  solverinfo%iters_sum  = solverinfo%iters_sum + solverinfo%iters_last
+  solverinfo%nsolves    = solverinfo%nsolves + 1
+  solverinfo%resid_last = sqrt(sprod(2)/nod2D)
+  solverinfo%rtol_last  = rtol
+  if (.not. converged) solverinfo%nonconv = solverinfo%nonconv + 1
+
+  !_____________________________________________________________________________
+  ! Safety-net log line: a stall at maxiter used to be completely silent. Unlike
+  ! cfl_z, which has check_blowup as a hard backstop, non-convergence has none --
+  ! we deliberately do not abort, because a stall on step 1 is legitimate in some
+  ! configurations, so this line is the only thing between a silently
+  ! under-converged run and nobody noticing. Rate-limited because a stalled
+  ! solver usually stalls every step, and one line per step would bury the
+  ! surrounding diagnostics.
   if (.not. converged .and. partit%mype==0) then
-     write(*,*) 'WARNING: ssh CG did not converge in ', solverinfo%maxiter, &
-                ' iters; rms(resid)=', sqrt(sprod(2)/nod2D), ' target rtol=', rtol
+     if (solverinfo%nonconv <= 5 .or. mod(solverinfo%nonconv, 100) == 0) then
+        write(*,*) 'WARNING: ssh CG did not converge in ', solverinfo%maxiter, &
+                   ' iters; rms(resid)=', solverinfo%resid_last,               &
+                   ' target rtol=', rtol, ' (occurrence ', solverinfo%nonconv, ')'
+     endif
   endif
 
  ! At the end: The result is in X, but it needs a halo exchange.

--- a/src/solver.F90
+++ b/src/solver.F90
@@ -60,7 +60,11 @@ subroutine ssh_solve_preconditioner(solverinfo, partit, mesh)
 #include "associate_mesh_ass.h"
 
     nend=ssh_stiff%rowptr(myDim_nod2D+1)-ssh_stiff%rowptr(1)
-    allocate(mesh%ssh_stiff%pr_values(nend))     ! Will store the values of inverse preconditioner matrix 
+    ! Guarded: building the preconditioner twice (a restart path can do this)
+    ! otherwise aborts with "allocatable array is already allocated".
+    if (.not. allocated(mesh%ssh_stiff%pr_values)) then
+        allocate(mesh%ssh_stiff%pr_values(nend))  ! values of the inverse preconditioner matrix
+    end if
     pr_values=>mesh%ssh_stiff%pr_values
     cind     =>mesh%ssh_stiff%colind_loc
     rptr     =>mesh%ssh_stiff%rowptr_loc
@@ -87,7 +91,9 @@ subroutine ssh_solve_preconditioner(solverinfo, partit, mesh)
    deallocate(diag_values)
 
    n=myDim_nod2D+eDim_nod2D
-   allocate(solverinfo%rr(n), solverinfo%zz(n), solverinfo%pp(n), solverinfo%App(n))
+   if (.not. allocated(solverinfo%rr)) then
+      allocate(solverinfo%rr(n), solverinfo%zz(n), solverinfo%pp(n), solverinfo%App(n))
+   end if
    solverinfo%rr =0.0_WP
    solverinfo%zz =0.0_WP
    solverinfo%pp =0.0_WP
@@ -225,6 +231,24 @@ subroutine ssh_solve_cg(x, rhs, solverinfo, partit, mesh)
 
   call MPI_Allreduce(MPI_IN_PLACE, s_aux, 1, MPI_DOUBLE, MPI_SUM, partit%MPI_COMM_FESOM, MPIerr)
 
+     ! ===========
+     ! Breakdown guard. An equivalent check existed until 4eb2f21d ("Removed
+     ! debug output in solver."). p.Ap must be positive for an SPD system; if it
+     ! reaches zero or NaN then al = s_old/s_aux poisons the entire d_eta vector
+     ! with Inf/NaN, and that surfaces several stages downstream -- typically as
+     ! a NaN in Wvel -- with nothing pointing back here. Keep the current X and
+     ! leave the loop; do not abort, and do not mark the solve converged.
+     ! Evaluated on the already-reduced value, so every rank branches alike.
+     ! ===========
+  if (s_aux <= 0.0_WP .or. s_aux /= s_aux) then
+     solverinfo%nbreakdown = solverinfo%nbreakdown + 1
+     if (partit%mype==0 .and. solverinfo%nbreakdown <= 5) then
+        write(*,*) 'WARNING: ssh CG breakdown at iter ', iter, ': p.Ap= ', s_aux, &
+                   ' is not positive; keeping current solution and leaving the loop'
+     endif
+     exit
+  endif
+
   al=s_old/s_aux
      ! ===========
      ! New X and residual r
@@ -269,6 +293,26 @@ sprod(1:2)=0.0_WP
      ! ===========
   if (sqrt(sprod(2)/nod2D)< rtol) then
      converged = .true.
+     exit
+  endif
+     ! ===========
+     ! SPD sensor. r.z cannot be negative for an SPD preconditioner, so any count
+     ! here is direct evidence that M^-1 is not SPD. Cheap, and evaluated on the
+     ! already-reduced value so all ranks agree.
+     ! ===========
+  if (sprod(1) < 0.0_WP) then
+     solverinfo%nnegrz = solverinfo%nnegrz + 1
+     if (partit%mype==0 .and. solverinfo%nnegrz == 1) then
+        write(*,*) 'WARNING: ssh CG r.z < 0 at iter ', iter, ': r.z= ', sprod(1), &
+                   ' -- preconditioner is not symmetric positive definite'
+     endif
+  endif
+
+  if (s_old == 0.0_WP) then
+     solverinfo%nbreakdown = solverinfo%nbreakdown + 1
+     if (partit%mype==0 .and. solverinfo%nbreakdown <= 5) then
+        write(*,*) 'WARNING: ssh CG breakdown at iter ', iter, ': previous r.z is zero'
+     endif
      exit
   endif
   be=sprod(1)/s_old

--- a/src/solver.F90
+++ b/src/solver.F90
@@ -107,15 +107,19 @@ subroutine ssh_solve_cg(x, rhs, solverinfo, partit, mesh)
   USE MOD_PARSUP
   USE MOD_DYN
   USE g_comm_auto
+#if defined(FESOM_PROFILING)
+  USE fesom_rtdiagnostics, only: diag_count
+#endif
   IMPLICIT NONE
   type(t_solverinfo),  intent(inout), target :: solverinfo
   type(t_partit),      intent(inout), target :: partit
   type(t_mesh),        intent(inout), target :: mesh
   real(kind=WP),       intent(inout)         :: x(partit%myDim_nod2D+partit%eDim_nod2D)
   real(kind=WP),       intent(in)            :: rhs(partit%myDim_nod2D+partit%eDim_nod2D)
-  integer                      :: row, nini, nend, iter 
+  integer                      :: row, nini, nend, iter
   real(kind=WP)                :: sprod(2), s_old, s_aux, al, be, rtol
   integer                      :: req
+  logical                      :: converged
   real(kind=WP), pointer       :: pr_values(:), rr(:), zz(:), pp(:), App(:)
   integer,       pointer       :: rptr(:), cind(:)
 
@@ -193,6 +197,7 @@ subroutine ssh_solve_cg(x, rhs, solverinfo, partit, mesh)
   ! ===============
   ! Iterations
   ! ===============
+  converged = .false.
   Do iter=1, solverinfo%maxiter
      ! ============
      ! Compute Ap
@@ -263,6 +268,7 @@ sprod(1:2)=0.0_WP
      ! Exit if tolerance is achieved
      ! ===========
   if (sqrt(sprod(2)/nod2D)< rtol) then
+     converged = .true.
      exit
   endif
   be=sprod(1)/s_old
@@ -276,10 +282,22 @@ sprod(1:2)=0.0_WP
   END DO
 !$OMP END PARALLEL DO
   END DO
+
+  ! Record SSH-CG iteration count (and non-convergence) for fesom.stats.
+#if defined(FESOM_PROFILING)
+  call diag_count("ssh_cg_iters", min(iter, solverinfo%maxiter))
+  if (.not. converged) call diag_count("ssh_cg_nonconv", 1)
+#endif
+  ! Safety-net log line (always on): a silent stall at maxiter used to be invisible.
+  if (.not. converged .and. partit%mype==0) then
+     write(*,*) 'WARNING: ssh CG did not converge in ', solverinfo%maxiter, &
+                ' iters; rms(resid)=', sqrt(sprod(2)/nod2D), ' target rtol=', rtol
+  endif
+
  ! At the end: The result is in X, but it needs a halo exchange.
   call exchange_nod(x, partit)
 !$OMP BARRIER
-end subroutine ssh_solve_cg 
+end subroutine ssh_solve_cg
 
 ! ===================================================================
 

--- a/src/write_step_info.F90
+++ b/src/write_step_info.F90
@@ -271,6 +271,21 @@ subroutine write_step_info(istep, outfreq, ice, dynamics, tracers, partit, mesh)
        if (use_ice)  then
        write(*,"(A, A     , A, ES10.3, A, A)")      '     m_ice= ',' N.A.     ',' | ',max_m_ice  ,' | ','N.A.'
        end if
+       !________________________________________________________________________
+       ! SSH CG solver. A named quantity in every standard block, like cfl_z
+       ! above -- not something that only shows up when it misbehaves. The
+       ! cumulative non-convergence count is here so a run that is quietly
+       ! stalling is visible in a log people already read.
+       ! Skipped on the split-explicit barotropic path, which has no solver.
+       if (.not. dynamics%use_ssh_se_subcycl) then
+       write(*,*)
+       write(*,"(A, I6, A, I6, A, F8.2)")           '   ssh_cg iters= ', dynamics%solverinfo%iters_last, &
+            '  | max= ', dynamics%solverinfo%iters_max,                                                  &
+            '  | mean= ', real(dynamics%solverinfo%iters_sum)/real(max(dynamics%solverinfo%nsolves,1))
+       write(*,"(A, ES10.3, A, ES10.3, A, I6)")     '   ssh_cg rms(r)= ', dynamics%solverinfo%resid_last, &
+            '  | rtol= ', dynamics%solverinfo%rtol_last,                                                 &
+            '  | nonconv= ', dynamics%solverinfo%nonconv
+       end if
      end if
      endif ! --> if (mod(istep,logfile_outfreq)==0) then
 end subroutine write_step_info

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -12,10 +12,22 @@
 # (build-only verification).
 if(ENABLE_MPI_TESTS AND NOT FESOM_COUPLED AND NOT OIFS_COUPLED AND NOT USE_YAC)
     # Basic integration test with PI mesh and 2 processes (minimum required for mesh partitioning)
+    #
+    # The EXTRA_SUCCESS_MARKERS pin the always-on SSH-CG solver diagnostics. Both the
+    # end-of-run summary and the per-step line are plain writes with no artifact behind
+    # them, so if either stops being emitted nothing else in the suite would notice --
+    # which is exactly how the sprod(2) defect in this solver survived unfixed. Matching
+    # the labels (not the numbers) keeps this stable across meshes and precisions.
     add_fesom_test(integration_pi_mpi2
         MPI_TEST
         NP 2
         TIMEOUT ${TEST_TIMEOUT}
+        EXTRA_SUCCESS_MARKERS
+            "___SSH CG SOLVER"            # end-of-run summary block
+            "non-convergences (maxiter)"  # the stall counter is reported
+            "breakdowns (p.Ap<=0)"        # the breakdown guard is wired up
+            "ssh_cg iters="               # per-step line, beside cfl_z
+            "ssh_cg rms(r)="              # per-step residual vs its target
     )
     
     # PI mesh test with 8 processes


### PR DESCRIPTION
> Stacked on #980 (the `EXTRA_SUCCESS_MARKERS` test hook) — please review/merge that first.

## Why

The SSH conjugate-gradient solver is entirely unobservable, depending on mesh when convergence 
is not hit it wastage is not reported. this is needed for single precision port performance too.
 `FESOM_PROFILING` is **OFF** by default and `fesom.stats` is
only written by the profiler, so in a normal production run there is **no** record of how
many CG iterations a step took, whether the solver converged, or whether it broke down.

Three consequences, all silent today:

* **A solver that stalls at `maxiter` prints nothing.** The loop simply ends and the
  unconverged `d_eta` feeds the barotropic and baroclinic dynamics. Unlike `cfl_z`, which
  has `check_blowup` as a hard backstop, non-convergence has **no** backstop at all.
* **A breakdown poisons the solution with no trace.** The guard on `al = s_old/s_aux` was
  removed in `4eb2f21d` ("Removed debug output in solver."). If `p·Ap` reaches zero or NaN,
  `al` fills the entire `d_eta` vector with Inf/NaN, which surfaces several stages
  downstream — typically as a NaN in `Wvel` — with nothing pointing back at the solver.
  Debugging that from the symptom is expensive; we did exactly that.
* **Cost is invisible.** Iteration count per solve is the quantity that determines how
  expensive the barotropic solve is, and it cannot currently be seen without a special build.

This matters most during **spin-up**, which is precisely when the state is furthest from
equilibrium, SSH gradients are largest, and the solver is most likely to need many
iterations or to hit the cap. A spin-up that is quietly running under-converged solves is
indistinguishable, in today's logs, from a healthy one.

## What this adds

* `src/fesom_rtdiagnostics.F90` — a small registry for per-call scalar quantities
  (iterations, residuals, event counts), MPI-reduced and reported in `fesom.stats`. Mirrors
  the `fesom_profiler` patterns; stores in double precision regardless of the model `WP` so
  SP and DP numbers are directly comparable. Reusable for future counters, not solver-specific.
  The `rt-` prefix is deliberate: this is **runtime** diagnostics (how the model *ran*), kept
  clearly apart from the physical diagnostics in `gen_modules_diag.F90` (`module diagnostics`,
  the `ldiag_*` family in `namelist.io`) which compute geophysical quantities.
* **Always-on counters** on `T_SOLVERINFO`: iterations (last/max/sum), solves,
  non-convergences, breakdowns, last residual and target tolerance.
* **A per-step line in `write_step_info`**, beside the existing `cfl_z` line and reusing its
  `logfile_outfreq` gate — so iteration count is a named quantity in the standard diagnostic
  block, not something that only appears when it misbehaves.
* **An end-of-run summary** in the always-on runtime table:

  ```
   ___SSH CG SOLVER_____________________________________
      solves :                                  96
      iterations mean :                    12.2708
      iterations max :                          16
      non-convergences (maxiter) :               0
      breakdowns (p.Ap<=0) :                     0
      iters with r.z<0 (not SPD) :               0
  ```

* **A rate-limited `WARNING:` at the maxiter hit itself**, carrying `rms(resid)` and the
  target `rtol`. The per-step line only prints every `logfile_outfreq` steps, so a stall in
  between would otherwise still be invisible. Rate-limited (first 5, then every 100th)
  because a stalled solver usually stalls every step.
* **The breakdown guard restored**, counted and logged. It keeps the current `X` and leaves
  the loop — deliberately **no abort**, since a stall on step 1 is legitimate in some
  configurations and an abort would turn a diagnostic case red. Never aborting is exactly
  why the logging is obligatory rather than optional.
* **Two unguarded allocates fixed** in `ssh_solve_preconditioner`, which abort with
  "allocatable array is already allocated" if it is ever built twice.

* **Test coverage, so this cannot rot.** Using the `EXTRA_SUCCESS_MARKERS` hook from #PR0,
  `integration_pi_mpi2` pins five labels
  (`___SSH CG SOLVER`, `non-convergences (maxiter)`, `breakdowns (p.Ap<=0)`, `ssh_cg iters=`,
  `ssh_cg rms(r)=`). These are plain writes with no artifact behind them, so without this a
  diagnostic that stopped being printed would fail nothing — which is exactly how the
  `sprod(2)` defect in this same routine survived. Labels, not numbers, so it stays stable
  across meshes, rank counts and precisions.

  Verified the assertion has teeth: removing the summary block makes the test fail with
  `missing success marker`, and pass again once restored.

## Cost and safety

**Results are unchanged.** Verified bitwise-identical to `main` on `integration_pi_mpi2`
(`nc_diff.py`: `WORST_REL=0.000e+00`). The counters are integer increments on values the
solver already computes; no new MPI. The exit test is on a globally reduced `sprod`, so
every rank exits on the same iteration and the count needs no reduction of its own.

The `FESOM_PROFILING` path costs nothing when compiled out. Full local CTest suite passes.

## A note on the SPD sensor

The `r·z < 0` counter is included because `r·z` cannot be negative for an SPD
preconditioner, so a non-zero count would be direct evidence of a defective `M⁻¹`. It reads
**zero** on both pi and core2, in both precisions — so it currently confirms nothing. It is
kept because it is two lines on an already-reduced value and makes a real failure mode
visible, not because it has found anything.
