### PR TITLE
oce: make ssh CG soltol and maxiter configurable via namelist.dyn

### DIFF
--- a/config/namelist.dyn
+++ b/config/namelist.dyn
@@ -65,6 +65,13 @@ AB_order           = 2           ! Adams-Bashforth time stepping order (2 or 3)
 
 ! --- SSH elliptic solver ---
 soltol             = 1e-5        ! ssh CG relative tolerance (optional; default 1e-5 if omitted)
+                                 ! NOTE applied on a COLD START only: both this and
+                                 ! maxiter live in the derived-type restart dump, which
+                                 ! is read after the namelist, so a restart keeps the
+                                 ! value the experiment was started with
+                                 ! in SINGLE PRECISION do not go below ~1e-6: the test is
+                                 ! a ratio and cannot see the float32 residual floor, so
+                                 ! the solver will report success it has not achieved
 maxiter            = 2000        ! ssh CG iteration cap (optional; default 2000 if omitted)
                                  ! hitting the cap does not abort -- it is reported as
                                  ! 'non-convergences' in the end-of-run solver summary

--- a/config/namelist.dyn
+++ b/config/namelist.dyn
@@ -63,6 +63,9 @@ ldiag_KE           = .false.     ! enable kinetic energy diagnostics (requires a
 ! --- Time Stepping ---
 AB_order           = 2           ! Adams-Bashforth time stepping order (2 or 3)
 
+! --- SSH elliptic solver ---
+soltol             = 1e-5        ! ssh CG relative tolerance (optional; default 1e-5 if omitted)
+
 ! --- Split-Explicit Barotropic Subcycling ---
 use_ssh_se_subcycl = .false.     ! enable split-explicit subcycling for barotropic mode
                                  ! (faster time stepping for sea surface height)

--- a/config/namelist.dyn
+++ b/config/namelist.dyn
@@ -65,6 +65,9 @@ AB_order           = 2           ! Adams-Bashforth time stepping order (2 or 3)
 
 ! --- SSH elliptic solver ---
 soltol             = 1e-5        ! ssh CG relative tolerance (optional; default 1e-5 if omitted)
+maxiter            = 2000        ! ssh CG iteration cap (optional; default 2000 if omitted)
+                                 ! hitting the cap does not abort -- it is reported as
+                                 ! 'non-convergences' in the end-of-run solver summary
 
 ! --- Split-Explicit Barotropic Subcycling ---
 use_ssh_se_subcycl = .false.     ! enable split-explicit subcycling for barotropic mode

--- a/src/MOD_DYN.F90
+++ b/src/MOD_DYN.F90
@@ -231,6 +231,11 @@ subroutine READ_T_SOLVERINFO(tsolverinfo, unit)
     integer                              :: iostat
     character(len=1024)                  :: iomsg
     read(unit, iostat=iostat, iomsg=iomsg) tsolverinfo%ident
+    ! NOTE maxiter and soltol are configurable from namelist.dyn, but this read
+    ! runs after dynamics_init, so on a restart these dumped values override what
+    ! the namelist asked for. Reading them into throwaway locals would make the
+    ! namelist authoritative while preserving the byte layout exactly; deferred
+    ! until there is a restart-vs-continuous test to verify it against.
     read(unit, iostat=iostat, iomsg=iomsg) tsolverinfo%maxiter
     read(unit, iostat=iostat, iomsg=iomsg) tsolverinfo%restart
     read(unit, iostat=iostat, iomsg=iomsg) tsolverinfo%fillin

--- a/src/oce_setup_step.F90
+++ b/src/oce_setup_step.F90
@@ -556,6 +556,7 @@ SUBROUTINE dynamics_init(dynamics, partit, mesh)
     integer        :: AB_order     = 2
     logical        :: check_opt_visc=.true.
     real(kind=WP)  :: wsplit_maxcfl
+    real(kind=WP)  :: soltol = 1.e-5_WP  ! ssh CG rel. tolerance; default matches T_SOLVERINFO
     logical        :: use_ssh_se_subcycl=.false.
     integer        :: se_BTsteps
     real(kind=WP)  :: se_BTtheta
@@ -568,11 +569,11 @@ SUBROUTINE dynamics_init(dynamics, partit, mesh)
                                 uke_scaling, uke_scaling_factor, uke_advection, &
                                 rosb_dis, smooth_back, smooth_dis, smooth_back_tend, K_back, c_back
 
-    namelist /dynamics_general/ momadv_opt, use_freeslip, use_wsplit, wsplit_maxcfl, & 
+    namelist /dynamics_general/ momadv_opt, use_freeslip, use_wsplit, wsplit_maxcfl, &
                                 ldiag_KE, AB_order,                                  &
                                 use_ssh_se_subcycl, se_BTsteps, se_BTtheta,          &
                                 se_bottdrag, se_bdrag_si, se_visc, se_visc_gamma0,   &
-                                se_visc_gamma1, se_visc_gamma2
+                                se_visc_gamma1, se_visc_gamma2, soltol
 
     !___________________________________________________________________________
     ! pointer on necessary derived types
@@ -642,8 +643,14 @@ nl => mesh%nl
             write(*,*) "     se_visc_gamma0 = ", dynamics%se_visc_gamma0
             write(*,*) "     se_visc_gamma1 = ", dynamics%se_visc_gamma1
             write(*,*) "     se_visc_gamma2 = ", dynamics%se_visc_gamma2
-        end if 
-    end if 
+        end if
+    end if
+
+    ! ssh CG solver tolerance (optional, backward compatible): if 'soltol' is
+    ! absent from namelist.dyn the namelist read leaves it at the default above,
+    ! matching the previous hard-coded T_SOLVERINFO value.
+    dynamics%solverinfo%soltol = soltol
+    if (mype==0) write(*,*) '     ssh CG soltol  = ', dynamics%solverinfo%soltol
 
     !___________________________________________________________________________
     ! define local vertice & elem array size

--- a/src/oce_setup_step.F90
+++ b/src/oce_setup_step.F90
@@ -650,6 +650,19 @@ nl => mesh%nl
     ! ssh CG solver tolerance (optional, backward compatible): if 'soltol' is
     ! absent from namelist.dyn the namelist read leaves it at the default above,
     ! matching the previous hard-coded T_SOLVERINFO value.
+    !
+    ! KNOWN LIMITATION -- these two settings are honoured on a COLD START only.
+    ! soltol and maxiter are both members of T_SOLVERINFO, which is serialized into
+    ! the derived-type (bin) restart dump, and READ_T_SOLVERINFO runs *after* this
+    ! routine (fesom_module.F90: dynamics_init -> ... -> read_initial_conditions).
+    ! So on a bin restart the dumped values silently replace whatever the namelist
+    ! asked for, while the echo below still prints the namelist value.
+    ! Measured on pi: cold start at soltol=1e-5 takes 8.60 iterations/solve; restart
+    ! with soltol=1e-2 in the namelist still takes 8.95 -- i.e. it is still solving to
+    ! 1e-5 -- although the log reports 1.0E-002. The raw-restart path is unaffected.
+    ! Not fixed here: the fix is to read these into throwaway locals so the byte
+    ! layout is preserved, and that needs the restart-vs-continuous regression test,
+    ! which does not exist yet. Set them on the cold start of an experiment.
     dynamics%solverinfo%soltol = soltol
     if (mype==0) write(*,*) '     ssh CG soltol  = ', dynamics%solverinfo%soltol
 
@@ -657,10 +670,7 @@ nl => mesh%nl
     ! apart from a truncation when sweeping soltol: raise it and a solver that is
     ! merely slow still converges, while one that has hit its residual floor
     ! plateaus instead.
-    ! NOTE both of these are also read back from the binary dump in
-    ! READ_T_SOLVERINFO, which runs after this, so on a RESTART the dumped value
-    ! still wins over the namelist. Cold starts honour the namelist. Fixing that
-    ! is deferred until the restart-vs-continuous test exists.
+    ! Same cold-start-only caveat as soltol above; see the note there.
     dynamics%solverinfo%maxiter = maxiter
     if (mype==0) write(*,*) '     ssh CG maxiter = ', dynamics%solverinfo%maxiter
 

--- a/src/oce_setup_step.F90
+++ b/src/oce_setup_step.F90
@@ -557,6 +557,7 @@ SUBROUTINE dynamics_init(dynamics, partit, mesh)
     logical        :: check_opt_visc=.true.
     real(kind=WP)  :: wsplit_maxcfl
     real(kind=WP)  :: soltol = 1.e-5_WP  ! ssh CG rel. tolerance; default matches T_SOLVERINFO
+    integer        :: maxiter = 2000     ! ssh CG iteration cap; default matches T_SOLVERINFO
     logical        :: use_ssh_se_subcycl=.false.
     integer        :: se_BTsteps
     real(kind=WP)  :: se_BTtheta
@@ -573,7 +574,7 @@ SUBROUTINE dynamics_init(dynamics, partit, mesh)
                                 ldiag_KE, AB_order,                                  &
                                 use_ssh_se_subcycl, se_BTsteps, se_BTtheta,          &
                                 se_bottdrag, se_bdrag_si, se_visc, se_visc_gamma0,   &
-                                se_visc_gamma1, se_visc_gamma2, soltol
+                                se_visc_gamma1, se_visc_gamma2, soltol, maxiter
 
     !___________________________________________________________________________
     ! pointer on necessary derived types
@@ -651,6 +652,17 @@ nl => mesh%nl
     ! matching the previous hard-coded T_SOLVERINFO value.
     dynamics%solverinfo%soltol = soltol
     if (mype==0) write(*,*) '     ssh CG soltol  = ', dynamics%solverinfo%soltol
+
+    ! ssh CG iteration cap, same contract as soltol above. Needed to tell a stall
+    ! apart from a truncation when sweeping soltol: raise it and a solver that is
+    ! merely slow still converges, while one that has hit its residual floor
+    ! plateaus instead.
+    ! NOTE both of these are also read back from the binary dump in
+    ! READ_T_SOLVERINFO, which runs after this, so on a RESTART the dumped value
+    ! still wins over the namelist. Cold starts honour the namelist. Fixing that
+    ! is deferred until the restart-vs-continuous test exists.
+    dynamics%solverinfo%maxiter = maxiter
+    if (mype==0) write(*,*) '     ssh CG maxiter = ', dynamics%solverinfo%maxiter
 
     !___________________________________________________________________________
     ! define local vertice & elem array size

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -28,6 +28,8 @@ if(ENABLE_MPI_TESTS AND NOT FESOM_COUPLED AND NOT OIFS_COUPLED AND NOT USE_YAC)
             "breakdowns (p.Ap<=0)"        # the breakdown guard is wired up
             "ssh_cg iters="               # per-step line, beside cfl_z
             "ssh_cg rms(r)="              # per-step residual vs its target
+            "ssh CG soltol"               # the namelist knobs are read and echoed
+            "ssh CG maxiter"
     )
     
     # PI mesh test with 8 processes


### PR DESCRIPTION
> Stacked on #981 (which is stacked on #980) — please review/merge those first.

## Why

`soltol` (the CG convergence tolerance) and `maxiter` (the iteration cap) are hard-coded in
`T_SOLVERINFO`. Changing either means editing source and rebuilding, which makes two
ordinary things unnecessarily hard:

* **Tuning the barotropic solve per configuration.** Iteration count is the cost of the SSH
  solve; the tolerance that sets it is not adjustable from the namelist like every other
  numerical knob in the model. And this hurt in single precision port.
* **Telling a stall apart from a truncation.** With `maxiter` fixed you cannot distinguish
  "the solver converged in 200 iterations" from "the solver gave up at 200". Raising the cap
  and re-running is the standard diagnostic, and it currently requires a rebuild.

## What this adds

Two optional keys in the **existing** `&dynamics_general` group of `namelist.dyn`:

| key | default | meaning |
|---|---|---|
| `soltol` | `1e-5` | SSH CG relative tolerance |
| `maxiter` | `2000` | SSH CG iteration cap |

Both defaults match the previously hard-coded values, and both are echoed at setup
(`ssh CG soltol = ...`).

## Backward compatibility

Verified, not assumed:

* A `namelist.dyn` taken from `main` — carrying **neither** key — runs unchanged and falls
  back to `1e-5` / `2000`. Output is **bitwise-identical** to `main`
  (`nc_diff.py`: `WORST_REL=0.000e+00`).
* These are locals with defaults added to an existing group, so absent keys are a no-op.

## Known limitation: cold start only

Both fields are members of `T_SOLVERINFO`, which is serialized into the derived-type (bin)
restart dump, and `READ_T_SOLVERINFO` runs **after** `dynamics_init`. So on a bin restart the
dumped values silently replace what the namelist asked for — and the setup echo still prints
the namelist value, so the log misreports it.

Measured on pi, forcing the bin path with `raw_restart_length_unit='off'`:

| | namelist `soltol` | log echoes | iterations actually taken |
|---|---|---|---|
| cold start | `1e-5` | `1.0E-005` | 8.6042 |
| **bin restart** | **`1e-2`** | `1.0E-002` | **8.9479** ← still solving to `1e-5` |
| raw restart | `1e-2` | `1.0E-002` | 1.9375 ← honoured |

Raw has precedence over bin when both exist, which is why this is easy to miss.

This is **pre-existing** — both fields are in the dump on `main` too — but it only becomes
observable now that the namelist can set them. **This PR documents it rather than fixing it**,
at all three places someone would look (the read site, the assignment, and `namelist.dyn`).
The fix is to read them into throwaway locals, preserving the byte layout exactly; that wants
a restart-vs-continuous regression test, which does not exist in the tree yet. Until then:
set these on the cold start of an experiment.

Two further pre-existing caveats, neither introduced here:

* `read(nm_unit, nml=dynamics_general, iostat=iost)` in `oce_setup_step.F90` does not check
  `iost`. An **older** binary given a **newer** `namelist.dyn` fails that read silently and
  falls back to *all* defaults for the group.
* There is no restart-vs-continuous reproducibility test at all, which is why the above is
  documented rather than fixed.

`integration_pi_mpi2` pins `ssh CG soltol` and `ssh CG maxiter` as success markers, so the
knobs cannot silently stop being read.

## Guidance for single-precision runs

Do not tighten `soltol` below ~`1e-6` in an SP build. The convergence test is a **ratio**,
so it cannot see the float32 residual floor: the solver will happily report success at any
tolerance you ask for while the true residual has stopped improving.

Measured on pi — ratio of the true residual (`b − Ax`, recomputed) to the recursively
updated one the solver actually tests:

| `soltol` | true / recursive |
|---|---|
| `1e-8`  | ~20× |
| `1e-10` | ~1769× |

with the true residual stalled near float32 epsilon. The default `1e-5` sits comfortably
above the floor; below ~`1e-6` an SP run reports a convergence it has not achieved.

This SP issues are further addressed in #940
