### PR TITLE
oce: use generic max/min instead of dmax1/dmin1 in the FCT limiter

### DIFF
--- a/src/oce_adv_tra_fct.F90
+++ b/src/oce_adv_tra_fct.F90
@@ -206,8 +206,8 @@ subroutine oce_tra_adv_fct(dt, ttf, lo, adf_h, adf_v, fct_ttf_min, fct_ttf_max, 
           tvert_min(nz, n) = AUX(2,nz, nod_in_elem2D(1, n))
           !$ACC LOOP SEQ
           do elem=2,nod_in_elem2D_num(n)
-              tvert_max(nz, n) = dmax1(tvert_max(nz, n), AUX(1,nz, nod_in_elem2D(elem,n)))
-              tvert_min(nz, n) = dmin1(tvert_min(nz, n), AUX(2,nz, nod_in_elem2D(elem,n)))
+              tvert_max(nz, n) = max(tvert_max(nz, n), AUX(1,nz, nod_in_elem2D(elem,n)))
+              tvert_min(nz, n) = min(tvert_min(nz, n), AUX(2,nz, nod_in_elem2D(elem,n)))
           end do
           !$ACC END LOOP
        end do
@@ -236,8 +236,8 @@ subroutine oce_tra_adv_fct(dt, ttf, lo, adf_h, adf_v, fct_ttf_min, fct_ttf_max, 
        ! solution at layer nz
        !$ACC LOOP VECTOR
        do nz=nu1+1,nl1-2
-          fct_ttf_max(nz,n)=dmax1(tvert_max(nz-1, n), tvert_max(nz, n), tvert_max(nz+1, n))-LO(nz,n)
-          fct_ttf_min(nz,n)=dmin1(tvert_min(nz-1, n), tvert_min(nz, n), tvert_min(nz+1, n))-LO(nz,n)
+          fct_ttf_max(nz,n)=max(tvert_max(nz-1, n), tvert_max(nz, n), tvert_max(nz+1, n))-LO(nz,n)
+          fct_ttf_min(nz,n)=min(tvert_min(nz-1, n), tvert_min(nz, n), tvert_min(nz+1, n))-LO(nz,n)
        end do
        !$ACC END LOOP
        ! calc max,min increment of bottom layer -1 with respect to low order


### PR DESCRIPTION
Four lines in `src/oce_adv_tra_fct.F90`.

`dmax1`/`dmin1` are the legacy double-precision-*specific* intrinsics. Handing them `real(WP)` operands is fine while `WP` is `real64`, but in a single-precision build it triggers Intel warning #7742 and a silent promote-to-double inside the FCT limiter's hot loop. The generic `max`/`min` work for any real kind with neither.

### Why this is safe

`max`/`min` are exact selections, not arithmetic — they return one of their operands unchanged. So this is **bit-identical in both precisions**; in DP, `max` over `real64` operands *is* `dmax1`.

### Scope

These four were the only double-specific intrinsics left in `src/`. After this change:

```
grep -rniE "\b(dmax1|dmin1|dsqrt|dabs|dexp|dlog|dsin|dcos|dtan|datan2?|dsign|dmod|dnint|dprod)[[:space:]]*\(" src/ --include=*.F90 --include=*.f90
```

comes back empty (the `recom` submodule is a separate repo and was not audited).

### Verification

Full DP build from a clean tree at `main` + this commit: configure and `cmake --build` both clean, no new warnings.

Split out of the single-precision work (#940) because it stands on its own and is not SP-specific — it removes a latent portability wart from `main` regardless of what happens to SP.