### PR TITLE
io: initialise the meandata flip flag

### DIFF
--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -76,7 +76,7 @@ module io_MEANDATA
     real(kind=WP)                                      :: rtime_per_stream=0._WP   !< cumulative wall in this stream's write_mean dispatch over the run; printed sorted at finalize
     logical                                            :: is_in_use=.false.
     logical :: is_elem_based = .false.
-    logical :: flip
+    logical :: flip = .false.
     class(data_strategy_type), allocatable :: data_strategy
     integer :: comm
     type(thread_type) thread


### PR DESCRIPTION
One word. `t_meandata%flip` has no default initialiser, and only `def_stream3D` ever assigns it — `def_stream2D` does not. So **every 2D output stream carries an uninitialised logical**.

Its two neighbours in the type both have one; this was simply missed:

```fortran
logical :: is_in_use = .false.
logical :: is_elem_based = .false.
logical :: flip                     ! <- no initialiser
```

### Why it matters

In `update_means` that flag selects between

```fortran
entry%ptr3(I,J)      ! normal
entry%ptr3(J,I)      ! flipped
```

For a 2D stream `ptr3` is shaped `(1, N)`. If the uninitialised flag happens to read `.true.`, the flipped branch indexes `ptr3(J,I)` with `J` running over the second extent of `local_values` — past the end of `ptr3`'s first dimension. A bounds-checked build aborts:

```
io_meandata.F90:2768
Fortran runtime error: Index '2' of dimension 1 of array 'entry%ptr3' above upper bound of 1
```

Without bounds checking **there is no abort**. The accumulator silently reads whatever lies past the end of the array, and that value lands in the time-mean written to file.

It has stayed latent because the memory is usually zero, so the correct branch is taken by accident. That is not something to rely on.

### How it was found

Running the integration suite with `-fcheck=bounds`, which does not appear to have been done before — the DP and SP suites are green without it, and this reproduces in both. With the initialiser, `integration_pi_mpi2` and `integration_pi_mpi8` pass **2/2 under `-fcheck=bounds` with zero runtime errors**.

### Verification

- Bounds-checked build: 2/2, no runtime errors (fails without this change)
- Normal build, full local suite: 7/7
- No behaviour change in any run where the flag already happened to read `.false.`

Found while working on the single-precision branch, but it is not SP-specific — it affects every 2D output stream in every build.