### PR TITLE
ale: accumulate the SSH stiffness matrix in full precision (single precision only)

### DIFF
--- a/src/MOD_MESH.F90
+++ b/src/MOD_MESH.F90
@@ -3,7 +3,7 @@ MODULE MOD_MESH
 USE O_PARAM
 USE MOD_WRITE_BINARY_ARRAYS
 USE MOD_READ_BINARY_ARRAYS
-USE,     intrinsic    :: ISO_FORTRAN_ENV, only : int32
+USE,     intrinsic    :: ISO_FORTRAN_ENV, only : int32, real64
 IMPLICIT NONE
 SAVE
 integer, parameter    :: MAX_ADJACENT=32 ! Max allowed number of adjacent nodes
@@ -17,6 +17,19 @@ TYPE SPARSE_MATRIX
      integer(int32), allocatable,   dimension(:) :: colind_loc
      integer(int32), allocatable,   dimension(:) :: rowptr_loc
      real(kind=WP),  allocatable,   dimension(:) :: pr_values !preconditioner values
+#if defined(USE_SINGLE_PRECISION)
+     ! Full-precision accumulator for the SSH stiffness matrix, single precision only.
+     ! update_stiff_mat_ale adds a per-step increment whose size relative to the
+     ! entry is ~1e-7..1e-6 -- at or below float32 eps (1.19e-7), so in SP the
+     ! update is partly or wholly swallowed and the matrix drifts. Accumulate here
+     ! and round into %values once per step; the solver's SpMV keeps WP bandwidth.
+     ! Sized to size(%values) (the LOCAL nnz), never to %nza -- see the comment at
+     ! the allocation site in oce_ale.F90.
+     real(kind=real64), allocatable, dimension(:) :: values_full
+#if defined(DIAG_STIFF_DRIFT)
+     real(kind=WP),  allocatable,   dimension(:) :: values_wp_drift
+#endif
+#endif
 END TYPE SPARSE_MATRIX
 
 TYPE T_MESH

--- a/src/oce_ale.F90
+++ b/src/oce_ale.F90
@@ -1,18 +1,4 @@
 
-#if defined(USE_SINGLE_PRECISION) && defined(DIAG_STIFF_DRIFT)
-module report_stiff_drift_interface
-    interface
-        subroutine report_stiff_drift(partit, mesh)
-        use mod_mesh
-        USE MOD_PARTIT
-        USE MOD_PARSUP
-        type(t_partit), intent(inout), target :: partit
-        type(t_mesh)  , intent(inout), target :: mesh
-        end subroutine report_stiff_drift
-    end interface
-end module report_stiff_drift_interface
-#endif
-
 module compute_CFLz_interface
     interface
         subroutine compute_CFLz(dynamics, partit, mesh)
@@ -1697,9 +1683,10 @@ end subroutine init_stiff_mat_ale
 subroutine update_stiff_mat_ale(partit, mesh)
     use, intrinsic :: iso_fortran_env, only: real64
 #if defined(USE_SINGLE_PRECISION) && defined(DIAG_STIFF_DRIFT)
-    use report_stiff_drift_interface
-#endif
+    use g_config,only: dt, logfile_outfreq
+#else
     use g_config,only: dt
+#endif
     use o_PARAM
     use MOD_MESH
     use MOD_TRACER
@@ -1715,6 +1702,10 @@ subroutine update_stiff_mat_ale(partit, mesh)
     integer                             :: elem, npos(3), offset, nini, nend
     real(kind=WP)                       :: factor 
     real(kind=WP)                       :: fx(3), fy(3)
+#if defined(USE_SINGLE_PRECISION) && defined(DIAG_STIFF_DRIFT)
+    integer, save                       :: drift_ncall = 0
+    real(kind=real64)                   :: drift_d, drift_r, drift_s(4), drift_g(4)
+#endif
     !___________________________________________________________________________
     ! pointer on necessary derived types
 #include "associate_part_def.h"
@@ -1834,7 +1825,35 @@ subroutine update_stiff_mat_ale(partit, mesh)
     ! bandwidth -- only the accumulator is wider.
     SSH_stiff%values = real(SSH_stiff%values_full, WP)
 #if defined(DIAG_STIFF_DRIFT)
-    call report_stiff_drift(partit, mesh)
+    !___________________________________________________________________________
+    ! Instrument: how far has the WP-accumulated matrix drifted from the real64
+    ! one? Inlined rather than a subroutine because a separate routine needs an
+    ! explicit interface (target dummies), and CMake's Fortran dependency scanner
+    ! does not evaluate the preprocessor -- it would demand the interface .mod in
+    ! builds where the module is guarded out. In DP both accumulators are the same
+    ! arithmetic, so the drift is 0.0 by construction; that is the control, and it
+    ! is why this is single-precision only.
+    drift_ncall = drift_ncall + 1
+    if (mod(drift_ncall, max(1,logfile_outfreq)) == 0) then
+        drift_s = 0.0_real64
+        do n = 1, myDim_nod2D
+            do k = ssh_stiff%rowptr_loc(n), ssh_stiff%rowptr_loc(n+1)-1
+                drift_d = real(ssh_stiff%values_wp_drift(k), real64) - ssh_stiff%values_full(k)
+                drift_r = ssh_stiff%values_full(k)
+                if (ssh_stiff%colind_loc(k) == n) then
+                    drift_s(1) = drift_s(1) + drift_d*drift_d
+                    drift_s(2) = drift_s(2) + drift_r*drift_r
+                else
+                    drift_s(3) = drift_s(3) + drift_d*drift_d
+                    drift_s(4) = drift_s(4) + drift_r*drift_r
+                end if
+            end do
+        end do
+        call MPI_AllREDUCE(drift_s, drift_g, 4, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_FESOM, MPIerr)
+        if (mype == 0) write(*,'(a,i8,a,es12.5,a,es12.5)') ' [STIFFDRIFT] update ', drift_ncall, &
+            '  relL2(diag)= ',    sqrt(drift_g(1)/max(drift_g(2), tiny(1.0_real64))),            &
+            '  relL2(offdiag)= ', sqrt(drift_g(3)/max(drift_g(4), tiny(1.0_real64)))
+    end if
 #endif
 #endif
 
@@ -1852,55 +1871,6 @@ subroutine update_stiff_mat_ale(partit, mesh)
 !DS
 
 end subroutine update_stiff_mat_ale
-
-#if defined(USE_SINGLE_PRECISION) && defined(DIAG_STIFF_DRIFT)
-!
-!_______________________________________________________________________________
-! Report how far the WP-accumulated stiffness matrix has drifted from the
-! real64-accumulated one. Build with -DDIAG_STIFF_DRIFT (single precision only;
-! in DP the two accumulations are the same arithmetic and the drift is 0 by
-! construction, which is the control this measurement needs).
-subroutine report_stiff_drift(partit, mesh)
-    use, intrinsic :: iso_fortran_env, only: real64
-    use MOD_MESH
-    USE MOD_PARTIT
-    USE MOD_PARSUP
-    use g_config, only: logfile_outfreq
-    implicit none
-    type(t_partit), intent(inout), target :: partit
-    type(t_mesh)  , intent(inout), target :: mesh
-    integer            :: k, row, nini, nend
-    integer, save      :: ncall = 0
-    real(kind=real64)  :: d, r, s(4), g4(4)
-#include "associate_part_def.h"
-#include "associate_mesh_def.h"
-#include "associate_part_ass.h"
-#include "associate_mesh_ass.h"
-    ncall = ncall + 1
-    if (mod(ncall, max(1,logfile_outfreq)) /= 0) return
-    ! s = (diag sum d^2, diag sum ref^2, offdiag sum d^2, offdiag sum ref^2)
-    s = 0.0_real64
-    do row = 1, myDim_nod2D
-        nini = ssh_stiff%rowptr_loc(row)
-        nend = ssh_stiff%rowptr_loc(row+1)-1
-        do k = nini, nend
-            d = real(ssh_stiff%values_wp_drift(k), real64) - ssh_stiff%values_full(k)
-            r = ssh_stiff%values_full(k)
-            if (ssh_stiff%colind_loc(k) == row) then
-                s(1) = s(1) + d*d;  s(2) = s(2) + r*r
-            else
-                s(3) = s(3) + d*d;  s(4) = s(4) + r*r
-            end if
-        end do
-    end do
-    call MPI_AllREDUCE(s, g4, 4, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_FESOM, MPIerr)
-    if (mype == 0) then
-        write(*,'(a,i8,a,es12.5,a,es12.5)') ' [STIFFDRIFT] update ', ncall,   &
-            '  relL2(diag)= ', sqrt(g4(1)/max(g4(2), tiny(1.0_real64))),      &
-            '  relL2(offdiag)= ', sqrt(g4(3)/max(g4(4), tiny(1.0_real64)))
-    end if
-end subroutine report_stiff_drift
-#endif
 !
 !
 !===============================================================================

--- a/src/oce_ale.F90
+++ b/src/oce_ale.F90
@@ -1,4 +1,18 @@
 
+#if defined(USE_SINGLE_PRECISION) && defined(DIAG_STIFF_DRIFT)
+module report_stiff_drift_interface
+    interface
+        subroutine report_stiff_drift(partit, mesh)
+        use mod_mesh
+        USE MOD_PARTIT
+        USE MOD_PARSUP
+        type(t_partit), intent(inout), target :: partit
+        type(t_mesh)  , intent(inout), target :: mesh
+        end subroutine report_stiff_drift
+    end interface
+end module report_stiff_drift_interface
+#endif
+
 module compute_CFLz_interface
     interface
         subroutine compute_CFLz(dynamics, partit, mesh)
@@ -1681,6 +1695,10 @@ end subroutine init_stiff_mat_ale
 !   = ssh_rhs                                                             in the update of the stiff matrix
 !
 subroutine update_stiff_mat_ale(partit, mesh)
+    use, intrinsic :: iso_fortran_env, only: real64
+#if defined(USE_SINGLE_PRECISION) && defined(DIAG_STIFF_DRIFT)
+    use report_stiff_drift_interface
+#endif
     use g_config,only: dt
     use o_PARAM
     use MOD_MESH
@@ -1705,6 +1723,31 @@ subroutine update_stiff_mat_ale(partit, mesh)
 #include "associate_mesh_ass.h"
 
     !___________________________________________________________________________
+#if defined(USE_SINGLE_PRECISION)
+    !___________________________________________________________________________
+    ! Seed the full-precision accumulator on first use. Deliberately here and not
+    ! in init_stiff_mat_ale: init runs on every start, but on a restart the
+    ! restored %values (which carries every increment the previous segment
+    ! accumulated -- it is in the binary dump, see MOD_MESH) overwrites what init
+    ! assembled. Seeding here, on the first update after all of that, is the one
+    ! point correct for a cold start and a restart alike.
+    !
+    ! SIZE: size(%values), NOT %nza. init_stiff_mat_ale sets %nza to the LOCAL nnz
+    ! and allocates %values with it, then later REPLACES %nza with the global sum
+    ! (sum(rpnza(1:npes))) because the solver wants a global count. Allocating
+    ! here with %nza would therefore over-allocate by ~npes per rank and make the
+    ! whole-array assignments below nonconforming -- reading past the end of
+    ! %values. size(%values) is the array we are shadowing, by construction.
+    if (.not. allocated(ssh_stiff%values_full)) then
+        allocate(ssh_stiff%values_full(size(ssh_stiff%values)))
+        ssh_stiff%values_full = real(ssh_stiff%values, real64)
+#if defined(DIAG_STIFF_DRIFT)
+        allocate(ssh_stiff%values_wp_drift(size(ssh_stiff%values)))
+        ssh_stiff%values_wp_drift = ssh_stiff%values
+#endif
+    end if
+#endif
+
     ! update secod term of lhs od equation (18) of "FESOM2 from finite element 
     ! to finite volumes" --> stiff matrix part
     ! loop over lcal edges
@@ -1766,7 +1809,14 @@ subroutine update_stiff_mat_ale(partit, mesh)
 #else
 !$OMP ORDERED
 #endif
+#if defined(USE_SINGLE_PRECISION)
+                   SSH_stiff%values_full(npos)=SSH_stiff%values_full(npos) + real(fy*factor, real64)
+#if defined(DIAG_STIFF_DRIFT)
+                   SSH_stiff%values_wp_drift(npos)=SSH_stiff%values_wp_drift(npos) + fy*factor
+#endif
+#else
                    SSH_stiff%values(npos)=SSH_stiff%values(npos) + fy*factor
+#endif
 #if defined(_OPENMP)  && !defined(__openmp_reproducible)
                    call omp_unset_lock(partit%plock(row))
 #else
@@ -1776,6 +1826,18 @@ subroutine update_stiff_mat_ale(partit, mesh)
         end do ! --> do j=1,2 
     end do ! --> do ed=1,myDim_edge2D 
 !$OMP END PARALLEL DO
+#if defined(USE_SINGLE_PRECISION)
+    !___________________________________________________________________________
+    ! Refresh the working copy the CG solver and preconditioner read. The
+    ! accumulation above ran in real64, so this rounds once per step instead of
+    ! letting the rounding compound over the run. The solver's SpMV keeps WP
+    ! bandwidth -- only the accumulator is wider.
+    SSH_stiff%values = real(SSH_stiff%values_full, WP)
+#if defined(DIAG_STIFF_DRIFT)
+    call report_stiff_drift(partit, mesh)
+#endif
+#endif
+
 !DS this check will work only on 0pe because SSH_stiff%rowptr contains global pointers
 !if (mype==0) then
 !do row=1, myDim_nod2D
@@ -1790,6 +1852,55 @@ subroutine update_stiff_mat_ale(partit, mesh)
 !DS
 
 end subroutine update_stiff_mat_ale
+
+#if defined(USE_SINGLE_PRECISION) && defined(DIAG_STIFF_DRIFT)
+!
+!_______________________________________________________________________________
+! Report how far the WP-accumulated stiffness matrix has drifted from the
+! real64-accumulated one. Build with -DDIAG_STIFF_DRIFT (single precision only;
+! in DP the two accumulations are the same arithmetic and the drift is 0 by
+! construction, which is the control this measurement needs).
+subroutine report_stiff_drift(partit, mesh)
+    use, intrinsic :: iso_fortran_env, only: real64
+    use MOD_MESH
+    USE MOD_PARTIT
+    USE MOD_PARSUP
+    use g_config, only: logfile_outfreq
+    implicit none
+    type(t_partit), intent(inout), target :: partit
+    type(t_mesh)  , intent(inout), target :: mesh
+    integer            :: k, row, nini, nend
+    integer, save      :: ncall = 0
+    real(kind=real64)  :: d, r, s(4), g4(4)
+#include "associate_part_def.h"
+#include "associate_mesh_def.h"
+#include "associate_part_ass.h"
+#include "associate_mesh_ass.h"
+    ncall = ncall + 1
+    if (mod(ncall, max(1,logfile_outfreq)) /= 0) return
+    ! s = (diag sum d^2, diag sum ref^2, offdiag sum d^2, offdiag sum ref^2)
+    s = 0.0_real64
+    do row = 1, myDim_nod2D
+        nini = ssh_stiff%rowptr_loc(row)
+        nend = ssh_stiff%rowptr_loc(row+1)-1
+        do k = nini, nend
+            d = real(ssh_stiff%values_wp_drift(k), real64) - ssh_stiff%values_full(k)
+            r = ssh_stiff%values_full(k)
+            if (ssh_stiff%colind_loc(k) == row) then
+                s(1) = s(1) + d*d;  s(2) = s(2) + r*r
+            else
+                s(3) = s(3) + d*d;  s(4) = s(4) + r*r
+            end if
+        end do
+    end do
+    call MPI_AllREDUCE(s, g4, 4, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_FESOM, MPIerr)
+    if (mype == 0) then
+        write(*,'(a,i8,a,es12.5,a,es12.5)') ' [STIFFDRIFT] update ', ncall,   &
+            '  relL2(diag)= ', sqrt(g4(1)/max(g4(2), tiny(1.0_real64))),      &
+            '  relL2(offdiag)= ', sqrt(g4(3)/max(g4(4), tiny(1.0_real64)))
+    end if
+end subroutine report_stiff_drift
+#endif
 !
 !
 !===============================================================================


### PR DESCRIPTION
**Stacked on #995** (`sp/precond-default-variant1`), which targets `support_sp`. Review that first.

`update_stiff_mat_ale` rebuilds the SSH stiffness matrix every timestep by **accumulating** an increment into `SSH_stiff%values`. That increment is ~1e-7–1e-6 of the entry it lands on, and float32 eps is **1.19e-7** — so in single precision the update sits at or below the ULP and is partly or wholly swallowed, and the matrix the solver is handed drifts from what it should be.

This accumulates into a `real64` shadow and rounds into `%values` once per step. The CG's SpMV and the preconditioner still read the WP array, so **bandwidth is unchanged** — only the accumulator is wider.

### Measured, at production resolution

CORE2 (126,858 nodes), NP=16, `spd=32`, variant 1, built with `-DDIAG_STIFF_DRIFT`. relL2 of the WP-accumulated matrix against the real64 one:

| update | relL2(diag) | relL2(offdiag) |
|---|---|---|
| 8 | 2.33e-07 | 1.34e-07 |
| 48 | 7.66e-07 | 3.72e-07 |
| 96 | 1.73e-06 | 6.23e-07 |
| 144 | **3.91e-06** | 9.20e-07 |

**The diagonal does not saturate** — doubling 72 → 144 updates multiplies it by 3.4×, and it is still climbing at 4.5 model days.

This is why the measurement was repeated at CORE2. On the `pi` mesh the same drift *saturates* around 3.3e-6 by update 90, which had made this fix look like it bought nothing. A mesh that small cannot show the behaviour.

### What the number is, and is not

It compares two accumulators **inside the same SP run** — same seed, same increments, differing only in accumulator precision. It is not a comparison against a DP model run. In a DP build the two are the same arithmetic and the drift is `0.0` by construction; that is the control, and it is why this is single-precision only.

It establishes that the matrix drifts and that the drift is unbounded on this horizon. It does **not** establish that the model solution is meaningfully different — that needs an SP-with-shadow vs SP-without run over a longer horizon, which has not been done. For scale: the CG's own true-residual floor in SP is ~3.3e-5 relative, so at update 144 the matrix drift is still ~8× below it. The argument here is the trend, not the present magnitude.

### Double precision is untouched

Excluded by the preprocessor, not by a runtime test, so a DP build compiles exactly the source it compiled before — no shadow field, no extra memory, no per-step copy, no branch in the edge loop. Verified **bitwise-identical** on `integration_pi_mpi2`.

### Two notes for reviewers

**The shadow is allocated with `size(ssh_stiff%values)`, deliberately not with `ssh_stiff%nza`.** `init_stiff_mat_ale` sets `%nza` to the *local* nnz and allocates `%values` with it, then later replaces `%nza` with the global sum over all ranks (*"replace local nza with a global one"*) because the solver wants a global count. Allocating here with `%nza` would over-allocate by ≈`npes` per rank and make the whole-array assignments nonconforming, reading past the end of `%values`.

**Seeding happens on the first update, not in `init_stiff_mat_ale`.** Init runs on every start, but on a restart the restored `%values` — which already carries every increment the previous segment accumulated — overwrites what init assembled. The first update is the one point correct for a cold start and a restart alike. The restart case still costs one rounding at the segment boundary; a continuous-vs-chained restart test does not exist yet, so that remains an assumption.

### The instrument

`-DDIAG_STIFF_DRIFT` builds the diagnostic used above. Inlined rather than a separate subroutine: a separate routine needs an explicit interface (target dummies), and CMake's Fortran dependency scanner does not evaluate the preprocessor — it demanded the interface `.mod` in every build where the module was guarded out. Absent from a normal build.

### Verification

- DP **10/10**, SP **10/10** on the full local suite
- DP **bitwise-identical** to the parent commit (`nc_diff.py`, clean single runs)
- Clean under `-fcheck=bounds` (which also turned up an unrelated pre-existing bug, filed separately as #996)
- Inlined instrument reproduces the subroutine version digit for digit
