### PR TITLE
ci: bound job runtime and stop the apt install from hanging

### DIFF
--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -14,6 +14,8 @@ jobs:
   stale:
 
     runs-on: ubuntu-latest
+
+    timeout-minutes: 12
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/ecbundle_release.yml
+++ b/.github/workflows/ecbundle_release.yml
@@ -48,6 +48,7 @@ jobs:
   ecbundle_ctest_framework:
     # Run directly on Ubuntu runner
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     
     env:
       # Set environment variables for the build
@@ -62,42 +63,43 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Install system dependencies
+        timeout-minutes: 22
         run: |
-          echo "Installing FESOM2 dependencies..."
-          sudo apt-get update
-          sudo apt-get install -y \
-            gcc \
-            gfortran \
-            g++ \
-            cmake \
-            make \
-            openmpi-bin \
-            libopenmpi-dev \
-            libnetcdf-dev \
-            libnetcdff-dev \
-            pkg-config \
-            git \
-            wget \
-            ca-certificates \
-            gnupg \
-            lsb-release \
-            python3 \
-            python3-pip
-          
-          echo "Installing CMake 3.25+ from Kitware repository..."
-          # Add Kitware's signing key
-          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-          
-          # Add Kitware repository
-          echo "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
-          
-          # Update package list and install latest CMake
-          sudo apt-get update
-          sudo apt-get install -y cmake
-          
-          echo "Installing ecbundle..."
-          pip install ecbundle
-          
+          cat > /tmp/install_deps.sh <<'SCRIPT'
+          set -eux
+          # Acquire::*::Timeout is the important part: the classic apt hang is a
+          # stalled connection that otherwise never times out at all.
+          APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
+          sudo apt-get $APT_OPTS update
+          sudo apt-get $APT_OPTS install -y \
+            gcc gfortran g++ cmake make \
+            openmpi-bin libopenmpi-dev \
+            libnetcdf-dev libnetcdff-dev \
+            pkg-config git wget ca-certificates \
+            python3 python3-pip
+          pip install --retries 3 --timeout 30 ecbundle
+          SCRIPT
+
+          ok=0
+          for attempt in 1 2; do
+            echo "::group::dependency install attempt $attempt"
+            if timeout 10m bash /tmp/install_deps.sh; then ok=1; fi
+            echo "::endgroup::"
+            [ "$ok" = 1 ] && break
+            echo "::warning::dependency install attempt $attempt timed out or failed; retrying"
+            # a killed apt leaves locks and a half-configured dpkg behind,
+            # which would make the next attempt fail for a different reason
+            sudo pkill -9 -f apt-get 2>/dev/null || true
+            sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock \
+                       /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend || true
+            sudo dpkg --configure -a || true
+            sleep 20
+          done
+          if [ "$ok" != 1 ]; then
+            echo "::error::dependency install failed after 2 attempts of 10 min each"
+            exit 1
+          fi
+
           echo "Verifying installations..."
           gcc --version
           gfortran --version
@@ -106,7 +108,6 @@ jobs:
           pkg-config --modversion netcdf
           pkg-config --modversion netcdf-fortran
           ecbundle --version
-          
       - name: Set up environment variables
         run: |
           echo "Setting up environment for FESOM2 build..."

--- a/.github/workflows/fesom2_build_tests.yml
+++ b/.github/workflows/fesom2_build_tests.yml
@@ -30,6 +30,7 @@ jobs:
 
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     # FESOM-org-owned CI image: ubuntu 22.04 + GCC/MPI/NetCDF/HDF5/LAPACK,
     # OASIS3-MCT pre-built at /oasis. Built and published from
     # FESOM/FESOM2_Docker (fesom2_ci/Dockerfile).

--- a/.github/workflows/fesom2_cavities.yml
+++ b/.github/workflows/fesom2_cavities.yml
@@ -15,6 +15,7 @@ jobs:
   general_test:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     # Docker Hub image that `container-job` executes in
     container: ghcr.io/fesom/fesom2_docker:fesom2_test_refactoring-master
 

--- a/.github/workflows/fesom2_channel.yml
+++ b/.github/workflows/fesom2_channel.yml
@@ -15,6 +15,7 @@ jobs:
   general_test:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     # Docker Hub image that `container-job` executes in
     container: ghcr.io/fesom/fesom2_docker:fesom2_test_refactoring-master
 

--- a/.github/workflows/fesom2_ctest_runner.yml
+++ b/.github/workflows/fesom2_ctest_runner.yml
@@ -51,6 +51,7 @@ jobs:
   ctest_framework:
     # Run directly on Ubuntu runner
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     
     env:
       # Set environment variables for the build
@@ -65,37 +66,41 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Install system dependencies
+        timeout-minutes: 22
         run: |
-          echo "Installing FESOM2 dependencies..."
-          sudo apt-get update
-          sudo apt-get install -y \
-            gcc \
-            gfortran \
-            g++ \
-            cmake \
-            make \
-            openmpi-bin \
-            libopenmpi-dev \
-            libnetcdf-dev \
-            libnetcdff-dev \
-            pkg-config \
-            git \
-            wget \
-            ca-certificates \
-            gnupg \
-            lsb-release
-          
-          echo "Installing CMake 3.25+ from Kitware repository..."
-          # Add Kitware's signing key
-          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-          
-          # Add Kitware repository
-          echo "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
-          
-          # Update package list and install latest CMake
-          sudo apt-get update
-          sudo apt-get install -y cmake
-          
+          cat > /tmp/install_deps.sh <<'SCRIPT'
+          set -eux
+          # Acquire::*::Timeout is the important part: the classic apt hang is a
+          # stalled connection that otherwise never times out at all.
+          APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
+          sudo apt-get $APT_OPTS update
+          sudo apt-get $APT_OPTS install -y \
+            gcc gfortran g++ cmake make \
+            openmpi-bin libopenmpi-dev \
+            libnetcdf-dev libnetcdff-dev \
+            pkg-config git wget ca-certificates
+          SCRIPT
+
+          ok=0
+          for attempt in 1 2; do
+            echo "::group::dependency install attempt $attempt"
+            if timeout 10m bash /tmp/install_deps.sh; then ok=1; fi
+            echo "::endgroup::"
+            [ "$ok" = 1 ] && break
+            echo "::warning::dependency install attempt $attempt timed out or failed; retrying"
+            # a killed apt leaves locks and a half-configured dpkg behind,
+            # which would make the next attempt fail for a different reason
+            sudo pkill -9 -f apt-get 2>/dev/null || true
+            sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock \
+                       /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend || true
+            sudo dpkg --configure -a || true
+            sleep 20
+          done
+          if [ "$ok" != 1 ]; then
+            echo "::error::dependency install failed after 2 attempts of 10 min each"
+            exit 1
+          fi
+
           echo "Verifying installations..."
           gcc --version
           gfortran --version
@@ -103,7 +108,6 @@ jobs:
           cmake --version
           pkg-config --modversion netcdf
           pkg-config --modversion netcdf-fortran
-          
       - name: Set up environment variables
         run: |
           echo "Setting up environment for FESOM2 build..."

--- a/.github/workflows/fesom2_icebergs.yml
+++ b/.github/workflows/fesom2_icebergs.yml
@@ -14,6 +14,7 @@ jobs:
   general_test:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     # Docker Hub image that `container-job` executes in
     container: ghcr.io/fesom/fesom2_docker:fesom2_test_refactoring-master
 

--- a/.github/workflows/fesom2_icepack.yml
+++ b/.github/workflows/fesom2_icepack.yml
@@ -11,6 +11,7 @@ jobs:
   icepack_test:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     # Docker Hub image that `container-job` executes in
     container: koldunovn/fesom2_test:refactoring2
 

--- a/.github/workflows/fesom2_main.yml
+++ b/.github/workflows/fesom2_main.yml
@@ -15,6 +15,7 @@ jobs:
   general_test:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     # Docker Hub image that `container-job` executes in
     container: ghcr.io/fesom/fesom2_docker:fesom2_test_refactoring-master
 

--- a/.github/workflows/fesom2_neverworld2.yml
+++ b/.github/workflows/fesom2_neverworld2.yml
@@ -15,6 +15,7 @@ jobs:
   general_test:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     # Docker Hub image that `container-job` executes in
     container: ghcr.io/fesom/fesom2_docker:fesom2_test_refactoring-master
 

--- a/.github/workflows/fesom2_openmp.yml
+++ b/.github/workflows/fesom2_openmp.yml
@@ -15,6 +15,7 @@ jobs:
   openmp_test:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     # Docker Hub image that `container-job` executes in
     container: ghcr.io/fesom/fesom2_docker:fesom2_test_refactoring-master
 

--- a/.github/workflows/fesom2_recom.yml
+++ b/.github/workflows/fesom2_recom.yml
@@ -15,6 +15,7 @@ jobs:
   general_test:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     # Docker Hub image that `container-job` executes in
     container: ghcr.io/fesom/fesom2_docker:fesom2_test_refactoring-master
 

--- a/.github/workflows/fesom2_xios.yml
+++ b/.github/workflows/fesom2_xios.yml
@@ -14,6 +14,7 @@ jobs:
   general_test:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     # Image with mkfesom + XIOS 2.5 prebuilt at /xios (see FESOM/FESOM2_Docker
     # fesom2_test_refactoring/Dockerfile).
     container: ghcr.io/fesom/fesom2_docker:fesom2_test_refactoring-master

--- a/.github/workflows/ifs_interface.yml
+++ b/.github/workflows/ifs_interface.yml
@@ -15,6 +15,7 @@ jobs:
   general_test:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     # Docker Hub image that `container-job` executes in
     container: ghcr.io/fesom/fesom2_docker:fesom2_test_refactoring-master
 

--- a/.github/workflows/metis.yml
+++ b/.github/workflows/metis.yml
@@ -14,6 +14,7 @@ jobs:
   general_test:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     # Docker Hub image that `container-job` executes in
     container: ghcr.io/fesom/fesom2_docker:fesom2_test_refactoring-master
 


### PR DESCRIPTION
Fixes #998.

## The measurement

The job in the issue ran 118.6 min, of which **118.5 min was one step** (`Install system dependencies`); every later step was skipped.

Two causes:

1. **No workflow set `timeout-minutes`** (all 16 checked), so the only bound was GitHub's 360 min default.
2. **`ecbundle_release.yml` and `fesom2_ctest_runner.yml` are the only build workflows on a bare runner** — the other 12 use the prebuilt container with dependencies baked in. These two `apt-get` ~16 packages *and* add the Kitware repo.

Over an 18 h window (300 runs): ecbundle ran 16 times and **hung twice (12.5%)**; of 4 jobs >= 10 min, 3 were cancelled. One hung run was re-run and **both attempts hung**, which is why this PR does not rely on retrying alone.

## Changes

| | |
|---|---|
| `timeout-minutes` on every job | **12 min** for the 13 container workflows (slowest observed 10.5 min), **30 min** for the 2 bare-runner ones (slowest 18.1 min) |
| Install retry | 2 attempts x 10 min, 22 min step cap, apt locks + `dpkg --configure -a` cleaned in between |
| apt hardening | `Acquire::Retries=3`, `Acquire::http/https::Timeout=30` |
| Kitware/CMake bootstrap | removed — FESOM needs 3.16, `ubuntu-latest` ships newer |

The retry has to live *inside* one step: a step that trips `timeout-minutes` fails the job, so Actions has no native step retry. `Acquire::*::Timeout` is the line most likely to prevent the hang rather than merely cap it, since the failure mode is a stalled connection that never times out on its own.

**The 10 min attempt cap needed the root-cause fix in the same PR.** The longest successful job is 18.1 min, 14.5 min of which is this same apt step — capping alone would have turned a slow success into a failure.

## Effect

Install worst case goes from **unbounded (360 min ceiling)** to **~22 min**. Any hung job anywhere is now capped at 12 or 30 min.

## Verified

The 15 edited workflows parse under `yaml.safe_load`. The retry loop was exercised with stand-ins for all three paths: first-try success, fail-twice-then-succeed, and hang-every-attempt. Budget is coherent: 2 x 10 = 20 min < 22 min step cap < 30 min job cap.

## Not addressed

`fesom2_intel_tests.yml` is left untouched here. Worth flagging separately though: it **does not parse as YAML** — `yaml.safe_load` fails at line 51, where a commented-out line reads `-       # ctest -R ...` instead of `#       ctest ...`. That matches it failing **28 of 28 runs** in the window and being displayed by filename rather than its `name:`. It still triggers on every PR and posts a red check. Fixed separately in #1000.
