### PR TITLE
ci: fix the YAML syntax error that has broken the Intel workflow since June

### DIFF
--- a/.github/workflows/fesom2_intel_tests.yml
+++ b/.github/workflows/fesom2_intel_tests.yml
@@ -16,6 +16,7 @@ jobs:
   intel_test:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     # Intel compiler container
     container: ghcr.io/suvarchal/fesom2-ci-intel
 
@@ -46,7 +47,7 @@ jobs:
       run: |
         test -x bin/fesom.x
         echo "Intel build OK (integration tests skipped)"
-    
+
         # TODO issues with netcdf: cd build
--       # ctest -R "integration_*" --output-on-failure --verbose
+        # ctest -R "integration_*" --output-on-failure --verbose
 


### PR DESCRIPTION
`fesom2_intel_tests.yml` has not parsed as YAML since aa45fa46 (2026-06-23): line 51 starts with a stray `-` at column 0, so the file fails to load, GitHub cannot read its `name:`, and it has posted a red check on every PR since — 28 of 28 runs failed in an 18 h window.

Turns that line into the comment it was meant to be, drops the whitespace-only line from the same commit, and adds the 12 min cap the other container workflows got in #999. All 16 workflows now parse under `yaml.safe_load`; it was 15 of 16 before.

Fixes the parse only — the Intel build has not run since June, so this PR's own run of the workflow is the first real signal.
