### PR TITLE
ci: run the CTest framework job in the existing CI image

### DIFF
--- a/.github/workflows/fesom2_ctest_runner.yml
+++ b/.github/workflows/fesom2_ctest_runner.yml
@@ -49,9 +49,12 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   ctest_framework:
-    # Run directly on Ubuntu runner
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 12
+    # Same image fesom2_build_tests.yml uses. It already provides gcc/gfortran
+    # 11.4, cmake 3.22, OpenMPI 4.1.2 and netCDF 4.8.1 / netCDF-Fortran 4.5.4
+    # under /usr, which is what NETCDF_ROOT below expects.
+    container: ghcr.io/fesom/fesom2_docker:fesom2_ci-master
     
     env:
       # Set environment variables for the build
@@ -64,50 +67,11 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE
       - name: Checkout repository
         uses: actions/checkout@v4
-      
-      - name: Install system dependencies
-        timeout-minutes: 22
+
+      - name: Git safe directory
         run: |
-          cat > /tmp/install_deps.sh <<'SCRIPT'
-          set -eux
-          # Acquire::*::Timeout is the important part: the classic apt hang is a
-          # stalled connection that otherwise never times out at all.
-          APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
-          sudo apt-get $APT_OPTS update
-          sudo apt-get $APT_OPTS install -y \
-            gcc gfortran g++ cmake make \
-            openmpi-bin libopenmpi-dev \
-            libnetcdf-dev libnetcdff-dev \
-            pkg-config git wget ca-certificates
-          SCRIPT
+          git config --global --add safe.directory ${PWD}
 
-          ok=0
-          for attempt in 1 2; do
-            echo "::group::dependency install attempt $attempt"
-            if timeout 10m bash /tmp/install_deps.sh; then ok=1; fi
-            echo "::endgroup::"
-            [ "$ok" = 1 ] && break
-            echo "::warning::dependency install attempt $attempt timed out or failed; retrying"
-            # a killed apt leaves locks and a half-configured dpkg behind,
-            # which would make the next attempt fail for a different reason
-            sudo pkill -9 -f apt-get 2>/dev/null || true
-            sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock \
-                       /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend || true
-            sudo dpkg --configure -a || true
-            sleep 20
-          done
-          if [ "$ok" != 1 ]; then
-            echo "::error::dependency install failed after 2 attempts of 10 min each"
-            exit 1
-          fi
-
-          echo "Verifying installations..."
-          gcc --version
-          gfortran --version
-          mpirun --version
-          cmake --version
-          pkg-config --modversion netcdf
-          pkg-config --modversion netcdf-fortran
       - name: Set up environment variables
         run: |
           echo "Setting up environment for FESOM2 build..."


### PR DESCRIPTION
The job spends more time installing dependencies than doing work:

```
8.62 min  ctest_framework
  4.90 min  Install system dependencies   <- 57%
  1.68 min  Build FESOM2
  1.68 min  Run CTest framework
  0.20 min  Configure
  0.07 min  Checkout
```

`fesom2_build_tests.yml` already builds and ctests FESOM inside `ghcr.io/fesom/fesom2_docker:fesom2_ci-master`. I pulled that image and looked inside rather than assuming — every package this job installs by hand is already present:

```
gcc/g++/gfortran 11.4.0, cmake 3.22.1, make, git, wget, pkg-config,
OpenMPI 4.1.2 (mpicc/mpicxx/mpif90), netCDF 4.8.1, netCDF-Fortran 4.5.4
```

and `nc-config --prefix` is `/usr`, exactly what the `NETCDF_ROOT` / `NETCDF_Fortran_ROOT` this workflow exports already assume. So the install step is **deleted**, not optimised: **8.6 min -> ~4.9 min**, with the 4.9 min replaced by the container pull.

## Changes

- run in `ghcr.io/fesom/fesom2_docker:fesom2_ci-master`, drop the whole `Install system dependencies` step
- add the `Git safe directory` step the other container-based workflows carry — the image runs as root and the build reads the git SHA for `fesom_version_info`
- job cap 30 -> 12 min, matching the other container workflows now the slow step is gone

Net: **8 insertions, 42 deletions**, one file.

## Worth knowing

**The compiler changes for this job**, from the runner default (Ubuntu 24.04, gcc 13) to the image's **gcc 11.4**. That is the same compiler `fesom2_build_tests.yml` already uses, so this moves the two build workflows onto a common toolchain rather than apart. It does mean this job could surface warnings or failures the 24.04 toolchain did not — that is the thing to watch on the first run.

**`ecbundle_release.yml` stays on the bare runner.** It needs `python3` and `pip` for `ecbundle`, and this image has neither. Not an oversight — folding it in needs an image change, tracked in FESOM/FESOM2_Docker#7 along with the wider question of unifying the two images onto a shared base.

## Verified

Workflow parses under `yaml.safe_load`; job resolves to the expected container, 12 min cap, and 7 steps with no `sudo` or `apt-get` left anywhere in the file (the image has no `sudo`, so any leftover would fail immediately). Compilers named by the configure step — `gcc`, `g++`, `gfortran`, `mpicc`, `mpicxx` — all confirmed present in the image.
