### PR TITLE
ci: point the Intel job at the FESOM-owned image

### DIFF
--- a/.github/workflows/fesom2_intel_tests.yml
+++ b/.github/workflows/fesom2_intel_tests.yml
@@ -17,8 +17,10 @@ jobs:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
     timeout-minutes: 12
-    # Intel compiler container
-    container: ghcr.io/suvarchal/fesom2-ci-intel
+    # FESOM-owned Intel image. Carries ifx + Intel MPI and the ifx-built
+    # HDF5/netCDF stack, without the rest of intel-hpckit that this build
+    # never invokes - see FESOM/FESOM2_Docker#8.
+    container: ghcr.io/fesom/fesom2_docker:fesom2_intel-master
 
     steps:
     # Checkout repository with latest git action


### PR DESCRIPTION
Follow-up to FESOM/FESOM2_Docker#8. One line:

```diff
-    container: ghcr.io/suvarchal/fesom2-ci-intel
+    container: ghcr.io/fesom/fesom2_docker:fesom2_intel-master
```

## Why

Measured on [job 96059504160](https://github.com/FESOM/fesom2/actions/runs/32250282150/job/96059504160):

```
6.62 min  intel_test
  4.07 min  Initialize containers    <- 61% of the job
  2.30 min  Configure and build
  0.08 min  checkout
```

The old image is 4.27 GB compressed, 97% of it a single layer installing `intel-hpckit` plus the Intel GPU runtime. This build uses only `ifx` and Intel MPI — `env/ubuntu/shell.intel` sets `I_MPI_CC=gcc` and `I_MPI_CXX=g++`, so even C and C++ go through GCC.

## Measured, now that the image is published

| | compressed | layers |
|---|---:|---:|
| `suvarchal/fesom2-ci-intel` | 4.27 GB | 18 |
| `fesom/fesom2_docker:fesom2_intel-master` | **1.38 GB** | 11 |

**68% smaller.** Dropped along the way: VTune (551 MB), the DPC++ debugger (444 MB), Advisor (210 MB), DPC++ (158 MB), MKL (~497 MB), and the OpenCL / Level Zero packages.

The remaining 1.15 GB layer is `intel-oneapi-compiler-fortran` + Intel MPI, which is the irreducible part — `ifx` is what the job exists to exercise.

## Compatibility

The ifx-built HDF5 1.14.3 / netCDF-C 4.9.2 / netCDF-Fortran 4.6.1 stack is carried over unchanged, `-assume byterecl` included, still installed to `/usr/local` — so `NETCDF_ROOT` and the rest of the workflow are untouched.

One difference worth noting: the old image baked the full oneAPI environment into image `ENV` (PATH, `LD_LIBRARY_PATH`, `MKLROOT`, ~40 others); the new one leaves that to `setvars.sh`. That is fine here because `configure.sh ubuntu+intel` sources `env/ubuntu/shell.intel`, which sources `setvars.sh` before anything is compiled.

Incidentally, the `Verify Intel compiler` step echoes `$CC`/`$FC`, and those were **already empty** under the old image — GitHub Actions bypasses a container `ENTRYPOINT` for job steps, and that is where the old image set them. No regression, but that step has never actually verified anything.

## What to check on this PR

The Intel job here is the only check that exercises the change. Two things to read off it:

1. `Initialize containers` should drop from 4.07 min towards ~1.5 min, taking the job from 6.6 min to ~4.
2. That the build still succeeds with only `ifx` and Intel MPI present. If some part of it quietly relied on a header from the wider toolkit, this is where it surfaces.

Also moves the image out of a personal namespace into one FESOM maintainers can rebuild — one of the two cases in FESOM/FESOM2_Docker#7.
