### PR TITLE
ci: run the ecbundle job in the existing CI image

### DIFF
--- a/.github/workflows/ecbundle_release.yml
+++ b/.github/workflows/ecbundle_release.yml
@@ -46,9 +46,12 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   ecbundle_ctest_framework:
-    # Run directly on Ubuntu runner
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 12
+    # Image used by the ten mkrun-based workflows. It already provides gcc,
+    # gfortran, OpenMPI, netCDF under /usr and python3-pip, which is all this
+    # job installed by hand - see FESOM/FESOM2_Docker#7.
+    container: ghcr.io/fesom/fesom2_docker:fesom2_test_refactoring-master
     
     env:
       # Set environment variables for the build
@@ -62,44 +65,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       
-      - name: Install system dependencies
-        timeout-minutes: 22
+      - name: Git safe directory
         run: |
-          cat > /tmp/install_deps.sh <<'SCRIPT'
-          set -eux
-          # Acquire::*::Timeout is the important part: the classic apt hang is a
-          # stalled connection that otherwise never times out at all.
-          APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
-          sudo apt-get $APT_OPTS update
-          sudo apt-get $APT_OPTS install -y \
-            gcc gfortran g++ cmake make \
-            openmpi-bin libopenmpi-dev \
-            libnetcdf-dev libnetcdff-dev \
-            pkg-config git wget ca-certificates \
-            python3 python3-pip
+          git config --global --add safe.directory ${PWD}
+
+      - name: Install ecbundle
+        timeout-minutes: 5
+        run: |
           pip install --retries 3 --timeout 30 ecbundle
-          SCRIPT
-
-          ok=0
-          for attempt in 1 2; do
-            echo "::group::dependency install attempt $attempt"
-            if timeout 10m bash /tmp/install_deps.sh; then ok=1; fi
-            echo "::endgroup::"
-            [ "$ok" = 1 ] && break
-            echo "::warning::dependency install attempt $attempt timed out or failed; retrying"
-            # a killed apt leaves locks and a half-configured dpkg behind,
-            # which would make the next attempt fail for a different reason
-            sudo pkill -9 -f apt-get 2>/dev/null || true
-            sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock \
-                       /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend || true
-            sudo dpkg --configure -a || true
-            sleep 20
-          done
-          if [ "$ok" != 1 ]; then
-            echo "::error::dependency install failed after 2 attempts of 10 min each"
-            exit 1
-          fi
-
           echo "Verifying installations..."
           gcc --version
           gfortran --version
@@ -108,6 +81,7 @@ jobs:
           pkg-config --modversion netcdf
           pkg-config --modversion netcdf-fortran
           ecbundle --version
+
       - name: Set up environment variables
         run: |
           echo "Setting up environment for FESOM2 build..."


### PR DESCRIPTION
Closes the loop on #998. This was the last workflow still installing dependencies with `apt` on a bare runner — and the one the issue was actually filed about.

## Why it is still slow

#999 hardened it (apt timeouts, 2 x 10 min retry, 30 min job cap) and #1001 moved the *other* bare-runner job into a container. **ecbundle was deliberately left behind**, because it needs `python3`/`pip` for `ecbundle` and `fesom2_ci-master` has neither.

So the hang is bounded now, but not gone — it still sat in `Install system dependencies` for 7+ min on a run earlier today. Removing the Kitware repo in #999 took out one external host; Ubuntu's mirrors and PyPI remained.

## The image already has what it needs

`fesom2_test_refactoring-master` is what the ten `mkrun` workflows already use. I pulled it and checked rather than trusting the Dockerfile:

```
gcc / gfortran / cmake 3.28.3 / make / git / pkg-config / mpirun  ->  /usr/bin
python3 -> /opt/miniconda3/bin/python3   (3.14.6)
pip     -> /opt/miniconda3/bin/pip
netCDF 4.9.2 / netCDF-Fortran 4.5.4
sudo    -> absent   (fine: the only step using it is deleted)
```

`pkg-config` resolves netCDF under `/usr`, so the `NETCDF_ROOT=/usr` this workflow already exports stays correct. **No image change is needed** — just the `container:` line.

## Changes

- run in `ghcr.io/fesom/fesom2_docker:fesom2_test_refactoring-master`
- delete the whole apt install step, including the retry/lock-cleanup scaffolding #999 added
- keep `pip install ecbundle` (not baked into the image), under a 5 min step cap
- add the `Git safe directory` step the other container workflows carry
- job cap 30 -> 12 min

Net **12 insertions, 37 deletions**, and **zero `apt-get` or `sudo` left in the file**.

## Verified

Because Python 3.14 is unusually new and ecbundle is an ECMWF tool, I checked the one thing that could plausibly break — that ecbundle installs on it:

```
Collecting ecbundle
  Downloading ecbundle-2.5.0-py3-none-any.whl.metadata (14 kB)
Requirement already satisfied: ruamel.yaml ... (0.18.16)
Successfully installed ecbundle-2.5.0 pathlib-1.0.1
```

`ruamel.yaml` is already in the image; only `pathlib` is pulled in. The entry-point directory is `/opt/miniconda3/bin`, which is on `PATH`, so `ecbundle-create` will resolve in CI.

**Caveat, stated plainly:** that install test ran under singularity with `--user`, where the container filesystem is read-only, so it proves the resolve/download/metadata path on 3.14 but not the final on-disk layout. In CI the job runs as root on a writable filesystem, which is the normal case. This PR's own ecbundle run is the real check.

## Effect

Removes the last `apt-get` from FESOM's CI. The #998 failure mode becomes structurally impossible rather than merely time-boxed, and the retry scaffolding in #999 becomes dead code for this workflow (the equivalent code in `fesom2_ctest_runner.yml` already went with #1001).
