### PR TITLE
recom: stop double counting Benthos under tracer parallelisation

### DIFF
--- a/src/oce_ale_tracer.F90
+++ b/src/oce_ale_tracer.F90
@@ -171,6 +171,7 @@ subroutine solve_tracers_ale(ice, dynamics, tracers, partit, mesh)
 ! multi FESOM group loop parallelization
     integer             :: num_tracers
     integer             :: tr_num_start_memo
+    integer             :: tr_num_end_memo
 
     integer             :: group_i
     integer             :: tr_num_start
@@ -270,6 +271,7 @@ subroutine solve_tracers_ale(ice, dynamics, tracers, partit, mesh)
     Benthos_tr_slice_count_fix_1 = 1 * (myDim_nod2D + eDim_nod2D) * benthos_num
 
     tr_num_start_memo = tr_num_start
+    tr_num_end_memo   = tr_num_end
 
     request_count = 0
 #endif
@@ -460,6 +462,16 @@ subroutine solve_tracers_ale(ice, dynamics, tracers, partit, mesh)
 #if defined(__recom) && defined(__usetp)
 ! SinkFlx and Benthos values are buffered per tracer index in the loop above and now summed up to
 ! avoid non bit identical results regarding global sums when running the tracer loop in parallel
+! ver_sinking_recom_benthos adds each contribution to Benthos directly AND
+! buffers the same value in Benthos_tr. Summing the buffers below would
+! therefore count this group's own tracers twice. Remove that slice again
+! first, so Benthos ends up with every tracer exactly once. Where the
+! buffers are not filled (use_MEDUSA with sedflx_num /= 0) they are zero
+! and both loops are a no-op, leaving the previous behaviour untouched.
+        do tr_num = tr_num_start_memo, tr_num_end_memo
+            Benthos = Benthos - Benthos_tr(:, :, tr_num)
+        end do
+
         do tr_num = 1, num_tracers
             if(use_MEDUSA) then
                 SinkFlx = SinkFlx + SinkFlx_tr(:, :, tr_num)


### PR DESCRIPTION
Fixes #1003.

**What.** `ver_sinking_recom_benthos` adds each sinking contribution to `Benthos` directly and also buffers the same value in `Benthos_tr`. Under `__usetp`, `oce_ale_tracer.F90` then rebuilds `Benthos` by summing `Benthos_tr` over all tracers, so every tracer a group owns lands in `Benthos` twice. The fix subtracts this group's own slice before the summation, so each tracer contributes exactly once.

**Why it matters.** This is not a multi-group problem. With one group it is a straight factor of two on all four benthic pools, and `RECOM_COUPLED=ON` sets `__usetp` unconditionally, so it affects every REcoM run. With more groups the error becomes `(1 + f) / 2` of the correct value, where `f` is the share of a pool's flux coming from that group's own tracers, which is why some pools looked exactly halved and others did not.

**Result.** Pi mesh, 1 day, 32 steps/day, base REcoM configuration. Domain mean of each pool on 2 ranks, before and after:

| pool | before | after | ratio |
|---|---|---|---|
| `BenN` | 1.259452e+08 | 6.297261e+07 | 0.500000 |
| `BenC` | 6.297274e+08 | 3.148637e+08 | 0.500000 |
| `BenSi` | 3.160345e+08 | 1.580172e+08 | 0.500000 |
| `BenCalc` | 9.811391e+01 | 4.905695e+01 | 0.500000 |

And 1 group against 2 groups, max relative deviation over all nodes:

| pool | before | after |
|---|---|---|
| `BenN` | 2.53e-01 | 1.66e-09 |
| `BenC` | 2.54e-01 | 6.07e-09 |
| `BenSi` | 5.00e-01 | 7.62e-09 |
| `BenCalc` | 5.01e-01 | 9.13e-04 |

The `BenCalc` outlier is one node where the pool is around 1e-4 in absolute terms, so it is cancellation rather than a real disagreement.

**Note.** Benthic pools feed the bottom fluxes for silicate and for DIC and alkalinity, so `test_pi_recom` truth values will move and need updating with this.