### PR TITLE
ice: drop the ice_temp floor, report the divergence instead

### DIFF
--- a/src/ice_thermo_oce.F90
+++ b/src/ice_thermo_oce.F90
@@ -79,6 +79,8 @@ subroutine cut_off(ice, partit, mesh)
     type(t_partit), intent(inout), target :: partit
     type(t_ice),    intent(inout), target :: ice
     integer                               :: n
+    integer                               :: n_coldice
+    integer, save                         :: n_coldwarn = 0
     !___________________________________________________________________________
     ! pointer on necessary derived types
     real(kind=WP), dimension(:), pointer  :: a_ice, m_ice, m_snow
@@ -96,9 +98,11 @@ subroutine cut_off(ice, partit, mesh)
     ice_temp => ice%data(4)%values(:)
 #endif /* (__oifs) */
 
+    n_coldice = 0
+
     !___________________________________________________________________________
     ! upper cutoff: a_ice
-!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(n)
+!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(n) REDUCTION(+:n_coldice)
 DO n=1, myDim_nod2D+eDim_nod2D
    if (a_ice(n) > 1.0_WP)   a_ice(n)=1.0_WP
     ! lower cutoff: a_ice
@@ -128,10 +132,25 @@ DO n=1, myDim_nod2D+eDim_nod2D
 #endif /* (__oifs) */
 
 #if defined (__oifs) || defined (__ifsinterface)
-    if (ice_temp(n) < 173.15_WP .and. a_ice(n) >= 0.1e-8_WP) ice_temp(n)=271.35_WP
+    ! No lower clamp. A surface temperature this far below anything physical
+    ! means the skin solve has diverged, and silently resetting it to the
+    ! seawater freezing point hides the divergence instead of reporting it.
+    ! Count and report below.
+    if (ice_temp(n) < 173.15_WP .and. a_ice(n) >= 0.1e-8_WP) n_coldice = n_coldice + 1
 #endif /* (__oifs) */
 END DO
 !$OMP END PARALLEL DO
+
+#if defined (__oifs) || defined (__ifsinterface)
+    ! Rate limited: a diverging skin solve usually diverges every step.
+    if (n_coldice > 0) then
+        n_coldwarn = n_coldwarn + 1
+        if (n_coldwarn <= 5 .or. mod(n_coldwarn, 100) == 0) then
+            write(*,*) 'WARNING: ice_temp below 173.15 K on ', n_coldice, &
+                       ' node(s), rank ', mype, ', occurrence ', n_coldwarn
+        end if
+    end if
+#endif /* (__oifs) */
 end subroutine cut_off
 
 #if !defined (__oasis) && !defined (__ifsinterface) && !defined (__yac)


### PR DESCRIPTION
Fixes #877. Stacked on #957, which is what makes the floor unnecessary, so this targets that branch rather than `main`.

## The number is not a typo

#877 asks whether `173.15` was meant to be `273.15`. It was not, and making that substitution would be a serious bug. 173.15 K is -100 C, a nonphysical-value guard, matching the issue's own title. With `273.15` the condition becomes "ice colder than freezing, with ice present", which is the normal state of sea ice, so every sub-zero ice surface temperature in every `__oifs`/`__ifsinterface` run would be overwritten with 271.35 K.

The line has read `173.15` since it was introduced in June 2020, so there is no earlier value that was mistyped.

## The real problem is that the floor exists at all

```fortran
if (ice_temp(n) < 173.15_WP .and. a_ice(n) >= 0.1e-8_WP) ice_temp(n)=271.35_WP
```

This repairs a diverged state silently. Nothing is written, so the question in the issue thread, whether this has ever fired in practice, is unanswerable from a run's output.

The clamp existed because the explicit skin solve could run away cold under insulating snow, where `con/zsniced` becomes small and nothing bounds the surface update. #957 replaces that with an implicit solve:

```fortran
zlam = 4.0_WP*emiss_ice*boltzmann*tref**3 + zlam_turb
t = (zcpdte*t + a2ihf + zlam*tref + zicefl) / (zcpdte + con/zsniced + zlam)
```

`zlam` sits in the denominator with `zlam >= zlam_turb = 16 W/m2/K`, so the response is bounded independently of the snow insulation. That is precisely the property the explicit form lacked, and it closes the path the floor was catching.

## What this changes

The clamp is deleted. The same condition now increments a counter reported once per call after the OMP loop, rate limited to the first five occurrences and every hundredth after that, since a diverging solve diverges every step:

```
WARNING: ice_temp below 173.15 K on <n> node(s), rank <mype>, occurrence <k>
```

The counter is accumulated with `REDUCTION(+:n_coldice)` rather than written per node, because `cut_off` is an OMP parallel loop.

The upper cap at 273.15 K is kept. Ice cannot exceed its melting point, so that one is a physical constraint rather than a bug mask.

## Verified

Compiles with `-DENABLE_IFS_INTERFACE=ON`, exit 0, no errors. That matters here because a default build never reaches these lines, so I checked the define actually landed rather than assuming: `-D__ifsinterface` is present in `build.ifs/src/CMakeFiles/fesom.dir/flags.make`, and the new string appears in the compiled object:

```
$ strings build.ifs/.../ice_thermo_oce.F90.o | grep "ice_temp below"
WARNING: ice_temp below 173.15 K on
```

## Note on the base

#957 is currently `mergeable_state: dirty` and needs resolving against `main` regardless. This branch inherits that, and should be retargeted at `main` if #957 merges first.
