### PR TITLE
Drop the dead tracer_init3d block from namelist.oce

### DIFF
--- a/config/namelist.oce
+++ b/config/namelist.oce
@@ -76,17 +76,6 @@ use_global_tides   = .false. ! enable global tidal potential forcing
 /
 
 ! ===================================================================
-! Initial conditions for tracers
-! ===================================================================
-&tracer_init3d
-n_ic3d    = 2
-idlist    = 1, 0
-filelist  = 'phc3.0_winter.nc', 'phc3.0_winter.nc'
-varlist   = 'salt', 'temp'
-t_insitu  = .true.
-/
-
-! ===================================================================
 ! Initial condition perturbation settings
 ! ===================================================================
 ! This section controls random perturbation of initial temperature

--- a/src/gen_model_setup.F90
+++ b/src/gen_model_setup.F90
@@ -112,9 +112,6 @@ subroutine setup_model(partit)
   read (fileunit, NML=oce_dyn, iostat=istat)
   if (istat /= 0) call check_namelist_read(fileunit, 'oce_dyn', nmlfile, partit)
   
-  read (fileunit, NML=tracer_init3d, iostat=istat)
-  if (istat /= 0) call check_namelist_read(fileunit, 'tracer_init3d', nmlfile, partit)
-  
   ! Optional reading of oce_perturb namelist for backward compatibility
   read (fileunit, NML=oce_perturb, iostat=istat)
   if (istat /= 0) then


### PR DESCRIPTION
Closes #928.

`&tracer_init3d` exists twice. `namelist.tra` is read in `tracer_init` at [oce_setup_step.F90:361](https://github.com/FESOM/fesom2/blob/5194bfb8baded6ab7615227f554dcc9a44d60e50/src/oce_setup_step.F90#L361); `namelist.oce` was read in `setup_model` at [gen_model_setup.F90:115](https://github.com/FESOM/fesom2/blob/5194bfb8baded6ab7615227f554dcc9a44d60e50/src/gen_model_setup.F90#L115). Both write the same module-level `save` variables in `gen_ic3d`, and the consumer `do_ic3d` runs later still, so whichever read happens last decides. `setup_model` is called at [fesom_module.F90:360](https://github.com/FESOM/fesom2/blob/5194bfb8baded6ab7615227f554dcc9a44d60e50/src/fesom_module.F90#L360) and `tracer_init` at [:455](https://github.com/FESOM/fesom2/blob/5194bfb8baded6ab7615227f554dcc9a44d60e50/src/fesom_module.F90#L455), so `namelist.tra` always wins and the `namelist.oce` copy has never had an effect.

The two copies also disagree. `namelist.tra` has `idlist = 2, 1` against the `1, 0` removed here, while both list `varlist = 'salt', 'temp'`. `0` is not a tracer ID, so anyone who edited the `oce` copy expecting it to take effect was working from a block that was both ignored and wrong.

Both were added together in 0d6b73d9 (#886), which needed a sequential read to reach `&oce_perturb` further down `namelist.oce`. Removing the `tracer_init3d` read leaves the `oce_perturb` read starting earlier in the file, which only widens the region it scans, and that group ships commented out so it is not found either way. The startup line `INFO: oce_perturb namelist not found, using defaults (no perturbations)` is unchanged.

`namelist.oce.core2`, `.toy_dbgyre`, `.toy_neverworld2` and `.toy_soufflet` never carried the block, so only the default `config/namelist.oce` changes. An existing setup whose `namelist.oce` still has the block keeps working, since the group is simply no longer read.