### PR TITLE
ice: do not run the cold start when the run restarts

### DIFF
--- a/src/ice_setup_step.F90
+++ b/src/ice_setup_step.F90
@@ -497,7 +497,16 @@ end if
     !___________________________________________________________________________
     ! switch for making sea-ice initialisation from regular gridded files and 
     ! do interpolation to fesom grid or to initialise them with a constant value
-    if (.not. ini_ice_from_file) then
+    if (r_restart) then
+        ! The ice arrays were zeroed above and read_initial_conditions overwrites
+        ! them from the restart a little later in fesom_runloop. Neither the
+        ! constant-value fill nor the interpolation from file would survive that,
+        ! so skip both and say what is actually happening. Zeroing still runs, so
+        ! any field the restart does not carry stays at zero rather than becoming
+        ! whatever the cold start would have guessed.
+        if(mype==0) write(*,*) 'initialize the sea ice: from restart'
+
+    else if (.not. ini_ice_from_file) then
         if(mype==0) write(*,*) 'initialize the sea ice: cold start'
         !___________________________________________________________________________
         do i=1,myDim_nod2D+eDim_nod2D


### PR DESCRIPTION
Fixes #898.

`ice_initial_state` filled the sea ice with cold start values and printed `initialize the sea ice: cold start` on every run. `read_initial_conditions` runs about a hundred lines later in `fesom_runloop` and overwrites them from the restart, so on a restart the fill was thrown away and the message said the opposite of what happened.

`ini_ice_from_file` is a `&tracer_init2d` entry in `namelist.tra`, defaulting to `.false.`. It only selects which cold start you get, a constant value or interpolation from a gridded file, and has nothing to do with restarts, which is why the message appeared either way.

The guard goes inside the routine rather than at the call site in `ice_setup`. `ice_initial_state` zeroes `a_ice`, `m_ice`, `m_snow`, `u_ice`, `v_ice` and the iceberg copies before it reaches the initialisation branches, so skipping the call would leave those arrays holding whatever was in memory after allocation.

That zeroing is also the part with consequences beyond the message. A field the restart does not carry, from an older restart or a different ice configuration, previously kept its cold start value silently. Now it stays at zero.

`r_restart` comes from `g_CONFIG`, which the routine already uses. Builds clean on levante.