### PR TITLE
Remove the duplicated tracer gradient computation in init_tracers_AB

### DIFF
--- a/src/oce_tracer_mod.F90
+++ b/src/oce_tracer_mod.F90
@@ -138,8 +138,6 @@ end do
     call fill_up_dn_grad(tracers%work, partit, mesh)
     call exchange_nod_end(partit)       ! tr_z halos should have arrived by now.
 
-    if (flag_debug .and. partit%mype==0)  print *, achar(27)//'[38m'//'             --> call tracer_gradient_elements'//achar(27)//'[0m'
-    call tracer_gradient_elements(tracers%data(tr_num)%values, partit, mesh) !redefine tr_arr to the current timestep
     call exchange_elem(tr_xy, partit)
 
 END SUBROUTINE init_tracers_AB


### PR DESCRIPTION
Refs #860. Opened to let CI answer the bit-identity question rather than argue it from the source alone.

`init_tracers_AB` called `tracer_gradient_elements` twice with the same argument:

https://github.com/FESOM/fesom2/blob/5194bfb8baded6ab7615227f554dcc9a44d60e50/src/oce_tracer_mod.F90#L127-L143

Nothing between the two calls writes either the input or the output:

| line | call | writes |
|---|---|---|
| 127 | `tracer_gradient_elements(values)` | `tr_xy(1:2,nz,elem)` for `elem=1..myDim_elem2D` |
| 131 | `tracer_gradient_z(values)` | `tr_z` only |
| 138 | `fill_up_dn_grad(tracers%work)` | `twork%edge_up_dn_grad`; reads `tr_xy`, never assigns it |
| 142 | `tracer_gradient_elements(values)` | the same `tr_xy` from the same inputs |

`tracers%data(tr_num)%values` is not assigned anywhere in 127-142, so the second call recomputed bit-identical numbers into the array the first call had already filled. This removes it, one gradient sweep over all elements and levels per tracer per timestep.

Why it was there is visible one line above the first call, and is still in the file:

```fortran
!PS     call tracer_gradient_elements(tracers%data(tr_num)%valuesAB, partit, mesh)
    call tracer_gradient_elements(tracers%data(tr_num)%values, partit, mesh)
```

The first call used to take `valuesAB`, so the two had different arguments and the second did what its trailing comment `!redefine tr_arr to the current timestep` claims. Once the first call was switched to `values`, the second had nothing left to redefine and the comment became a fossil.

The `call exchange_elem(tr_xy, partit)` that followed is redundant on the same grounds, since `exchange_elem_begin` on 128 and `exchange_elem_end` on 132 already exchanged that array and nothing invalidated it. It is deliberately left in place so this PR isolates the duplicated computation and CI attributes any difference to one change. Dropping the exchange as well would remove a global communication per tracer per timestep and is worth a follow-up once this is confirmed.

This does not answer the question underneath #860, which is whether lines 127 and 131 were meant to stay on `values` or go back to `valuesAB`; the `!WHY NOT AB HERE? DSIDOREN!` on 131 is from the same unfinished change. That decision changes results and is separate from this one, which should not.

Builds clean locally with Intel 2021.5, Release, `RECOM_COUPLED=OFF`.