### PR TITLE
Run the Icepack CI on pull requests only

### DIFF
--- a/.github/workflows/fesom2_icepack.yml
+++ b/.github/workflows/fesom2_icepack.yml
@@ -1,9 +1,17 @@
 
 name: FESOM2 Icepack
 
-# Controls when the action will run. Triggers the workflow on push or pull request. 
+# Controls when the action will run. Triggers the workflow on pull request.
 
-on: [push, pull_request]
+on:
+  workflow_dispatch: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - main
 
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel


### PR DESCRIPTION
`fesom2_icepack.yml` was the only workflow left triggering on `push`:

```yaml
on: [push, pull_request]
```

So every commit pushed to any branch in the repo spent a full Icepack download, build and two test runs, on top of the identical run the pull request already triggers.

This switches it to the same trigger block the other 13 workflows in `.github/workflows/` use:

```yaml
on:
  workflow_dispatch: {}
  pull_request:
    types: [opened, synchronize, reopened]
    branches: [main]
```

Two behaviour changes beyond dropping `push`:

- The `branches: [main]` filter means PRs targeting a branch other than `main` no longer trigger it. That matches every other workflow here.
- `workflow_dispatch` allows a manual Icepack run from the Actions tab without opening a PR.
