### PR TITLE
Drop the obsolete _AB tracer restart variable

### DIFF
--- a/src/io_restart.F90
+++ b/src/io_restart.F90
@@ -224,12 +224,10 @@ subroutine ini_ocean_io(dynamics, tracers, partit, mesh)
      else
         call oce_files%def_node_var(trim(trname), trim(longname), trim(units), tracers%data(j)%values(:,:), mesh, partit)
      endif
+     ! NOTE: valuesAB is not part of the restart. init_tracers_AB recomputes it
+     ! from values and valuesold at the start of every tracer solve, before any
+     ! consumer reads it, so a restarted run reconstructs it from _M1 (and _M2).
      longname=trim(longname)//', Adams-Bashforth'
-     if ((tracers%data(j)%ID==101) .or. (tracers%data(j)%ID==102) .or. (tracers%data(j)%ID==103) .or. (tracers%data(j)%ID==304)) then
-        call oce_files%def_node_var_optional(trim(trname)//'_AB', trim(longname), trim(units), tracers%data(j)%valuesAB(:,:),    mesh, partit)
-     else
-        call oce_files%def_node_var(trim(trname)//'_AB', trim(longname), trim(units), tracers%data(j)%valuesAB(:,:),    mesh, partit)
-     endif
      call oce_files%def_node_var_optional(trim(trname)//'_M1', trim(longname), trim(units), tracers%data(j)%valuesold(1,:,:), mesh, partit)
      if (tracers%data(j)%AB_order==3) &
      call oce_files%def_node_var_optional(trim(trname)//'_M2', trim(longname), trim(units), tracers%data(j)%valuesold(2,:,:), mesh, partit)
@@ -599,8 +597,8 @@ subroutine write_initial_conditions(istep, nstart, ntotal, which_readr, ice, dyn
 
   ! --> synchronizes tracer data within fesom groups
 
-! kh 09.01.26 merging of valuesold and valuesAB between all fesom groups is only necessary here, immediately before writing the corresponding restart files
-! this will give better performance than merging valuesold and valuesAB in each simulation step in the main loop over all tracers in solve_tracers_ale in oce_ale_tracers.F90
+! kh 09.01.26 merging of valuesold between all fesom groups is only necessary here, immediately before writing the corresponding restart files
+! this will give better performance than merging valuesold in each simulation step in the main loop over all tracers in solve_tracers_ale in oce_ale_tracers.F90
 
 #if defined(__recom) && defined(__usetp)
     if(num_fesom_groups > 1) then
@@ -614,8 +612,6 @@ subroutine write_initial_conditions(istep, nstart, ntotal, which_readr, ice, dyn
 
 ! kh 09.01.26 also handle additional dimension of valuesold for AB_order
                 call MPI_Bcast(tracers%data(tr_num)%valuesold(:,:,:), tr_arr_slice_count_fix_1 * (tracers%data(tr_num)%AB_order - 1), MPI_DOUBLE_PRECISION, group_i, partit%MPI_COMM_FESOM_SAME_RANK_IN_GROUPS, partit%mpierr)
-
-                call MPI_Bcast(tracers%data(tr_num)%valuesAB(:,:), tr_arr_slice_count_fix_1, MPI_DOUBLE_PRECISION, group_i, partit%MPI_COMM_FESOM_SAME_RANK_IN_GROUPS, partit%mpierr)
             end do
         end do
     end if


### PR DESCRIPTION
Closes #841.

### The `_AB` restart variable is dead

`init_tracers_AB` recomputes `valuesAB` from scratch out of `values` and `valuesold`, in `src/oce_tracer_mod.F90:52-68`, and then shifts `valuesold` at lines 100-116. It is called from exactly one place, `src/oce_ale_tracer.F90:303`, at the top of the per-tracer loop in `solve_tracers_ale`, ahead of `do_oce_adv_tra`. The only consumer of `valuesAB` is `ttfAB` in `src/oce_adv_tra_driver.F90:93`, inside that advection call.

So the array restored from the restart file is unconditionally overwritten before anything reads it. The only other references are a diagnostic print in `write_step_info.F90` and a commented-out line in `io_blowup.F90`.

It went stale in 7bfdc6e0 "implementing restarts for AB3" (2023-04-27), which added `_M1` and `_M2` alongside the existing `_AB` rather than in place of it. Those hold the tracer at n-1 and n-2, which is what the interpolant is actually rebuilt from.

Supporting detail: `_M1` and `_M2` are declared `def_node_var_optional` while `_AB` was mandatory. A restart predating 7bfdc6e0 therefore already comes back with `valuesold = 0` and a wrong first AB step regardless of `_AB` being present, which is further evidence that `_AB` has not been load-bearing for a while.

### On the compatibility question in the issue

Smaller than feared. The portable restart is one netCDF file per variable, with the path built from the varname in `io_restart.F90:957-958`. Dropping the definition means `<tracer>_AB.nc` stops being written and stops being opened.

- Old restart directory, new executable: the `_AB.nc` files are still there and simply go unread. Works.
- New restart directory, old executable: fails, because `_AB` was mandatory on read there. This is the usual one-way caveat for any restart change.

### Also removed

The `MPI_Bcast` of `valuesAB` at `io_restart.F90:618`, in the `__recom`/`__usetp` path. Per the comment above it, that merge existed only to fill the restart file, so it is now dead. Saves one 3D broadcast per tracer per restart write, which is not nothing with REcoM's tracer count.

### Deliberately left alone

The raw binary restart in `MOD_TRACER.F90:123` and `:147` still writes and reads `valuesAB`. It is a positional dump, write and read stay symmetric, dropping it would break raw restarts of runs already in flight, and keeping it costs nothing.

### Testing

Builds clean on levante with the default `configure.sh` environment: `io_restart.F90.o` compiles and `fesom.x` links with no errors or warnings from the touched code.

I have not run a restart-continuity experiment. The CI "Check restarts" step exercises exactly this path, so it should be the real gate here. Results ought to be bit-identical, since `valuesAB` is reconstructed either way.
