### PR TITLE
forcing: implement runoff_data_source='NONE' and stop the misleading runoff path error

### DIFF
--- a/config/namelist.forcing
+++ b/config/namelist.forcing
@@ -126,7 +126,8 @@ age_start_year    = 2000     ! year to start age tracer (tracer age = 0 at this 
 
    ! --- Runoff configuration ---
    runoff_data_source = 'JRA55'       ! runoff data source: 'Dai09', 'JRA55', 'CORE1', 'CORE2' or 'NONE'
-   nm_runoff_file     = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/friver.'  ! for Dai09/JRA55 this is a prefix, year and '.nc' are appended
+   nm_runoff_file     = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/friver.'  ! Dai09/JRA55 with runoff_climatology=.false.: prefix, year and '.nc' are appended (friver.1958.nc).
+                                        ! with runoff_climatology=.true., and for CORE1/CORE2, give the complete file name instead
 
    ! --- Sea surface salinity restoring ---
    sss_data_source  = 'CORE2'  ! SSS restoring data source: 'CORE2', 'WOA', or 'NONE'

--- a/config/namelist.forcing
+++ b/config/namelist.forcing
@@ -125,8 +125,8 @@ age_start_year    = 2000     ! year to start age tracer (tracer age = 0 at this 
    l_snow        = .true.     ! use snow precipitation forcing
 
    ! --- Runoff configuration ---
-   runoff_data_source = 'JRA55'       ! runoff data source: 'Dai09', 'JRA55, 'CORE2', or 'NONE'
-   nm_runoff_file     = '<add path>'  ! path to runoff data
+   runoff_data_source = 'JRA55'       ! runoff data source: 'Dai09', 'JRA55', 'CORE1', 'CORE2' or 'NONE'
+   nm_runoff_file     = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/friver.'  ! for Dai09/JRA55 this is a prefix, year and '.nc' are appended
 
    ! --- Sea surface salinity restoring ---
    sss_data_source  = 'CORE2'  ! SSS restoring data source: 'CORE2', 'WOA', or 'NONE'

--- a/config/namelist.forcing
+++ b/config/namelist.forcing
@@ -125,9 +125,10 @@ age_start_year    = 2000     ! year to start age tracer (tracer age = 0 at this 
    l_snow        = .true.     ! use snow precipitation forcing
 
    ! --- Runoff configuration ---
-   runoff_data_source = 'JRA55'       ! runoff data source: 'Dai09', 'JRA55', 'CORE1', 'CORE2' or 'NONE'
-   nm_runoff_file     = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/friver.'  ! Dai09/JRA55 with runoff_climatology=.false.: prefix, year and '.nc' are appended (friver.1958.nc).
-                                        ! with runoff_climatology=.true., and for CORE1/CORE2, give the complete file name instead
+   runoff_climatology=.true.
+   runoff_data_source = 'CORE2'       ! runoff data source: 'Dai09', 'JRA55', 'CORE1', 'CORE2' or 'NONE'
+   nm_runoff_file     = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/CORE2_runoff.nc'  ! CORE2 monthly climatology with runoff_climatology=.true.
+   !nm_runoff_file     = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/friver.'  ! Dai09/JRA55 with runoff_climatology=.false.: prefix, year and '.nc' are appended (friver.1958.nc).
 
    ! --- Sea surface salinity restoring ---
    sss_data_source  = 'CORE2'  ! SSS restoring data source: 'CORE2', 'WOA', or 'NONE'

--- a/src/gen_surface_forcing.F90
+++ b/src/gen_surface_forcing.F90
@@ -1297,7 +1297,14 @@ CONTAINS
     ! when used runoff_data_source='CORE1' or 'CORE2' we use a total climatological 
     ! runoff, so only one runoff time slice for the entire simulation is used. 
     ! This part is only read ones when the forcing is first time initialized
-    if (runoff_data_source=='CORE1' .or. runoff_data_source=='CORE2' ) then
+    if (runoff_data_source=='NONE') then
+        if (mype==0) then
+            write(*,*) ' --> river runoff is switched off (runoff_data_source=''NONE'') '
+            write(*,*)
+        end if
+        ! runoff was allocated and set to zero in forcing_array_setup, nothing to read
+
+    elseif (runoff_data_source=='CORE1' .or. runoff_data_source=='CORE2' ) then
         if (mype==0) then 
             write(*,*) ' --> using total longterm runoff climatology (only 1 time slice) '
             write(*,*) '     runoff_data_source = ', runoff_data_source
@@ -1318,11 +1325,13 @@ CONTAINS
                 write(error_unit,*)
                 write(error_unit,*) achar(27)//'[31m'
                 write(error_unit,*) '____________________________________________________________________'
-                write(error_unit,*) ' ERROR: file not found: ', trim(make_full_path(nm_runoff_file))
-                write(error_unit,*) '        --> check your namelist.focing'
-                write(error_unit,*) '            ...'
-                write(error_unit,*) '            nm_runoff_file    =...'
-                write(error_unit,*) '            ...'
+                write(error_unit,*) ' ERROR: runoff file not found: ', trim(make_full_path(nm_runoff_file))
+                write(error_unit,*) '        --> check your namelist.forcing'
+                write(error_unit,*) '            runoff_data_source = ', trim(runoff_data_source)
+                write(error_unit,*) '            nm_runoff_file     = ', trim(nm_runoff_file)
+                write(error_unit,*) '        a nm_runoff_file without a leading ''/'' is taken as relative and gets'
+                write(error_unit,*) '        ClimateDataPath prepended, which is why an unrelated path may appear'
+                write(error_unit,*) '        above. give an absolute path to avoid this.'
                 write(error_unit,*) '____________________________________________________________________'
                 write(error_unit,*) achar(27)//'[0m'
                 write(error_unit,*)
@@ -1350,11 +1359,13 @@ CONTAINS
                 write(error_unit,*)
                 write(error_unit,*) achar(27)//'[31m'
                 write(error_unit,*) '____________________________________________________________________'
-                write(error_unit,*) ' ERROR: file not found: ', trim(make_full_path(nm_runoff_file))
-                write(error_unit,*) '        --> check your namelist.focing'
-                write(error_unit,*) '            ...'
-                write(error_unit,*) '            nm_runoff_file    =...'
-                write(error_unit,*) '            ...'
+                write(error_unit,*) ' ERROR: runoff file not found: ', trim(make_full_path(nm_runoff_file))
+                write(error_unit,*) '        --> check your namelist.forcing'
+                write(error_unit,*) '            runoff_data_source = ', trim(runoff_data_source)
+                write(error_unit,*) '            nm_runoff_file     = ', trim(nm_runoff_file)
+                write(error_unit,*) '        a nm_runoff_file without a leading ''/'' is taken as relative and gets'
+                write(error_unit,*) '        ClimateDataPath prepended, which is why an unrelated path may appear'
+                write(error_unit,*) '        above. give an absolute path to avoid this.'
                 write(error_unit,*) '____________________________________________________________________'
                 write(error_unit,*) achar(27)//'[0m'
                 write(error_unit,*)
@@ -1375,6 +1386,7 @@ CONTAINS
             write(error_unit,*) '                                  this can be done as a monthly climatology (runoff_climatology=.true.) or '
             write(error_unit,*) '                                  as a transient monthly climatology (runoff_climatology=.false.) than each'
             write(error_unit,*) '                                  month and each year have differnt runoff'
+            write(error_unit,*) '        - ''NONE''             : no river runoff is applied                                 '
             write(error_unit,*) ''
             write(error_unit,*) '        --> please check your namelist.forcing'
             write(error_unit,*) '            ...'


### PR DESCRIPTION
Closes #853.

Two independent problems in the runoff configuration, both reachable from a stock `namelist.forcing`.

## `'NONE'` was documented but never implemented

`config/namelist.forcing` listed `'NONE'` as a valid `runoff_data_source`. There was no branch for it, so it fell through to the `else` and aborted with "you choose an unknown runoff_data_source", and that error's own list of supported values did not mention `'NONE'` either. The namelist offered a way to run without runoff and the code refused it.

This adds the branch. It reads nothing and leaves `runoff` at the zero it is already given by `allocate`/`runoff=0.0_WP` in `gen_forcing_init.F90:148-149`, and `sbc_do` never updates it because the transient path keys on `Dai09`/`JRA55`. `'NONE'` is now also listed where unknown values are rejected.

## The file-not-found error pointed at the T/S climatology directory

`make_full_path` prepends `ClimateDataPath` to any path without a leading `/`, so an unset `nm_runoff_file` resolved under the PHC directory and produced the error in the issue:

```
ERROR: file not found: /pool/data/AWICM/FESOM2/INITIAL/phc3.0/1958.nc
```

The message only ever printed the resolved path, so there was nothing to connect that directory to what the user had actually written. It now prints the configured `runoff_data_source` and `nm_runoff_file` as well, and says why an unrelated directory can appear:

```
 ERROR: runoff file not found: /pool/data/AWICM/FESOM2/INITIAL/phc3.0/1958.nc
        --> check your namelist.forcing
            runoff_data_source = JRA55
            nm_runoff_file     =
        a nm_runoff_file without a leading '/' is taken as relative and gets
        ClimateDataPath prepended, which is why an unrelated path may appear
        above. give an absolute path to avoid this.
```

Both copies of that message are updated, at the CORE1/CORE2 branch and at the Dai09/JRA55 one. The `namelist.focing` typo in them is fixed while there.

The `'<add path>'` placeholder is replaced with the JRA55 file the default `runoff_data_source = 'JRA55'` actually needs, verified present on Levante as `friver.1958.nc`, so a fresh `namelist.forcing` no longer fails on a path the user never wrote. The unterminated quote around `'JRA55'` in that comment is corrected and the supported `'CORE1'` added.

## Scope

This deliberately does not change how paths are resolved. Resolving forcing files against `ClimateDataPath` is wrong in principle regardless of the placeholder, but fixing it properly means introducing a `ForcingDataPath` and reducing `namelist.forcing` to bare file names, which touches every `nm_*_file` and every shipped forcing namelist. That is a separate change and gets its own issue.

Builds clean with Intel 2021.5, Release, `RECOM_COUPLED=OFF`. No behaviour change for any run that already sets a valid `nm_runoff_file`.