### PR TITLE
Document what the Arctic gateway restoring boxes actually cover

### DIFF
--- a/src/oce_setup_step.F90
+++ b/src/oce_setup_step.F90
@@ -1246,6 +1246,8 @@ SUBROUTINE oce_initial_state(tracers, partit, mesh)
 #endif
 
     ! count the passive tracers which require 3D source (ptracers_restore_total)
+    ! Every ID with a restoring box below has to be listed here too, or
+    ! ptracers_restore is allocated too short.
     ptracers_restore_total=0
     DO i=3, tracers%num_tracers
         id=tracers%data(i)%ID
@@ -1459,7 +1461,13 @@ SUBROUTINE oce_initial_state(tracers, partit, mesh)
          end if
 ! Transient tracers end
 
-        !_______________________________________________________________________            
+        !_______________________________________________________________________
+        ! Fram Strait 3d restored passive tracer. The box (77.5-78.0N, 0-10E)
+        ! marks the Atlantic inflow branch on purpose, not the full strait; a
+        ! whole-gateway tracer needs its own ID, see issue #846. The bounds
+        ! appear twice below, to count nodes and to fill ind2, and both copies
+        ! have to stay identical. oce_ale_tracer.F90 resets the box to 1.0 each
+        ! timestep, so the 1.0 here and the 0.0 in 302/303 behave alike.
         CASE (301) !Fram Strait 3d restored passive tracer
             tracers%data(i)%values(:,:)=0.0_WP
             rcounter3    =rcounter3+1
@@ -1489,6 +1497,8 @@ SUBROUTINE oce_initial_state(tracers, partit, mesh)
             end if
             
         !_______________________________________________________________________
+        ! Bering Strait 3d restored passive tracer. The box (65.6-66.0N,
+        ! 172-166W) spans the strait, unlike the inflow-only boxes 301 and 303.
         CASE (302) !Bering Strait 3d restored passive tracer
             tracers%data(i)%values(:,:)=0.0_WP
             rcounter3    =rcounter3+1
@@ -1517,7 +1527,10 @@ SUBROUTINE oce_initial_state(tracers, partit, mesh)
                 write(*,*) 'initializing '//trim(i_string)//'th tracer with ID='//trim(id_string)
             end if
             
-        !_______________________________________________________________________            
+        !_______________________________________________________________________
+        ! Barents Sea Opening 3d restored passive tracer. The box (69.5-74.5N,
+        ! 19-20E) covers the southern inflow part only, as in case 301; see
+        ! issue #846. The bounds appear twice below and must stay identical.
         CASE (303) !BSO 3d restored passive tracer
             tracers%data(i)%values(:,:)=0.0_WP
             rcounter3    =rcounter3+1


### PR DESCRIPTION
Comments only, no behaviour change.

Issue #846 reports the Fram Strait (301) and BSO (303) restoring boxes as misdefined. Per @koldunovn in https://github.com/FESOM/fesom2/issues/846#issuecomment-3772922181 they mark the inflow branch on purpose and a full-gateway tracer should get its own ID. Nothing in the code said so, so the next reader reaches the same conclusion @vasmue did.

The comments record that intent, plus the two traps for whoever adds the full-gateway IDs: each box's bounds are duplicated between the counting loop and the `ind2` loop, and the `SELECT CASE` building `ptracers_restore_total` has to list every restored ID or the array is allocated short.

This does not close #846.