### PR TITLE
Hardcode the def_stream rank instead of skipping the check on nvfortran

### DIFF
--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -3406,8 +3406,9 @@ subroutine def_stream3D(glsize, lcsize, name, description, units, data, freq, fr
 
  
     !___________________________________________________________________________
-#if !defined(__PGI)  
-    do i = 1, rank(data)
+    ! data is rank 2 here; the rank is hardcoded because nvfortran implements
+    ! the rank() intrinsic only since 25.1
+    do i = 1, 2
         if ((ubound(data, dim = i)<=0)) then
             if (partit%mype==0) then
                 write(*,*) 'WARNING: adding I/O stream for ', trim(name), ' failed (contains 0 dimension)'
@@ -3416,7 +3417,6 @@ subroutine def_stream3D(glsize, lcsize, name, description, units, data, freq, fr
             return
         end if    
     end do
-#endif
 
     !___________________________________________________________________________
     if (partit%mype==0) then
@@ -3487,8 +3487,9 @@ subroutine def_stream2D(glsize, lcsize, name, description, units, data, freq, fr
   integer i
 
     !___________________________________________________________________________
-#if !defined(__PGI)   
-    do i = 1, rank(data)
+    ! data is rank 1 here; the rank is hardcoded because nvfortran implements
+    ! the rank() intrinsic only since 25.1
+    do i = 1, 1
         if ((ubound(data, dim = i)<=0)) then
         if (partit%mype==0) then
             write(*,*) 'WARNING: adding I/O stream for ', trim(name), ' failed (contains 0 dimension)'
@@ -3497,7 +3498,6 @@ subroutine def_stream2D(glsize, lcsize, name, description, units, data, freq, fr
         return
         end if    
     end do
-#endif
 
     !___________________________________________________________________________
     if (partit%mype==0) then


### PR DESCRIPTION
Closes #269.

The zero-dimension guard in `def_stream3D` and `def_stream2D` was wrapped in `#if !defined(__PGI)` by 56179e26, because nvfortran did not implement the `rank()` intrinsic. The consequence is that nvhpc builds never ran the check at all: no `contains 0 dimension` warning and no early `return`, so a stream with an empty dimension went on to be defined.

That is still true today. nvfortran 25.7 defines `__PGI`, so the guard fires even on the versions that handle `rank()` perfectly well. I tested a minimal reproducer against the nvhpc modules on levante:

| nvfortran | `rank()` |
|---|---|
| 21.11, 22.5, 23.7, 24.7, 24.9, 24.11 | `NVFORTRAN-S-0038-Symbol, rank, has not been explicitly declared` |
| 25.1, 25.3, 25.5, 25.7 | compiles and runs correctly |

So the intrinsic arrived in 25.1, but keying the guard on the compiler version would only move the problem, since the `__PGI` macro does not tell you the version.

This takes @dsidoren's own suggestion from the issue. The rank is known statically at both sites, 2 for `data(:,:)` at src/io_meandata.F90:3396 and 1 for `data(:)` at src/io_meandata.F90:3478, so the loop bound is written out and the preprocessor branch is gone. Every compiler now runs the same code, and there is no version floor to remember.

`def_stream0D` takes a scalar and has no such loop, so it is untouched.

Verified by compiling `src/io_meandata.F90` against an existing build tree with the Intel toolchain on levante, and by checking that the resulting `do i = 1, 2` form is accepted by nvfortran 21.11 through 25.7.
