### PR TITLE
integration: match the MPI datatype to the WP_full global-integral buffers

### DIFF
--- a/src/gen_support.F90
+++ b/src/gen_support.F90
@@ -331,7 +331,7 @@ subroutine integrate_nod_2D(data, int2D, partit, mesh)
   ! surface node in the domain (~1e5 on CORE2, ~7e6 on NG5). Its relative error
   ! grows like eps*sqrt(N), and the result is used to *balance* global fluxes to
   ! zero -- so any error here becomes a systematic net source, not noise.
-  real(kind=WP_full) :: lval
+  real(kind=WP_full) :: lval, gval
 #include "associate_part_def.h"
 #include "associate_mesh_def.h"
 #include "associate_part_ass.h"
@@ -350,8 +350,12 @@ lval=0.0_WP_full
 !$OMP END PARALLEL
 #endif
   int2D=0.0_WP
-  call MPI_AllREDUCE(lval, int2D, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+  gval=0.0_WP_full
+  ! reduce into a WP_full buffer and round once: MPI must not write a real64
+  ! into the caller's real(WP) argument when WP is single precision.
+  call MPI_AllREDUCE(lval, gval, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
        MPI_COMM_FESOM, MPIerr)
+  int2D=real(gval, WP)
 end subroutine integrate_nod_2D
 !
 !--------------------------------------------------------------------------------------------
@@ -370,7 +374,7 @@ subroutine integrate_nod_3D(data, int3D, partit, mesh)
   integer       :: k, row
   ! See the note in the 2D version: global integrals accumulate in WP_full so
   ! they cannot degrade with WP.
-  real(kind=WP_full) :: lval
+  real(kind=WP_full) :: lval, gval
   real(kind=WP_full) :: lval_row
 
 
@@ -397,8 +401,12 @@ subroutine integrate_nod_3D(data, int3D, partit, mesh)
 !$OMP END PARALLEL DO
 
   int3D=0.0_WP
-  call MPI_AllREDUCE(lval, int3D, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+  gval=0.0_WP_full
+  ! reduce into a WP_full buffer and round once: MPI must not write a real64
+  ! into the caller's real(WP) argument when WP is single precision.
+  call MPI_AllREDUCE(lval, gval, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
        MPI_COMM_FESOM, MPIerr)
+  int3D=real(gval, WP)
 end subroutine integrate_nod_3D
 !
 !--------------------------------------------------------------------------------------------
@@ -662,7 +670,7 @@ subroutine integrate_elem_3D(data, int3D, partit, mesh)
   integer       :: k, row
   ! See the note in the 2D version: global integrals accumulate in WP_full so
   ! they cannot degrade with WP.
-  real(kind=WP_full) :: lval
+  real(kind=WP_full) :: lval, gval
   real(kind=WP_full) :: lval_row
 
 #include "associate_part_def.h"
@@ -689,8 +697,12 @@ subroutine integrate_elem_3D(data, int3D, partit, mesh)
 !$OMP END PARALLEL DO
 
   int3D=0.0_WP
-  call MPI_AllREDUCE(lval, int3D, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+  gval=0.0_WP_full
+  ! reduce into a WP_full buffer and round once: MPI must not write a real64
+  ! into the caller's real(WP) argument when WP is single precision.
+  call MPI_AllREDUCE(lval, gval, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
        MPI_COMM_FESOM, MPIerr)
+  int3D=real(gval, WP)
 end subroutine integrate_elem_3D
 !
 !--------------------------------------------------------------------------------------------
@@ -709,7 +721,7 @@ subroutine integrate_elem_2D(data, int2D, partit, mesh)
   integer       :: row
   ! See the note in integrate_nod_2D: global integrals accumulate in WP_full so
   ! they cannot degrade with WP.
-  real(kind=WP_full) :: lval
+  real(kind=WP_full) :: lval, gval
 
 #include "associate_part_def.h"
 #include "associate_mesh_def.h"
@@ -731,8 +743,12 @@ subroutine integrate_elem_2D(data, int2D, partit, mesh)
 !$OMP END PARALLEL DO
 
   int2D=0.0_WP
-  call MPI_AllREDUCE(lval, int2D, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+  gval=0.0_WP_full
+  ! reduce into a WP_full buffer and round once: MPI must not write a real64
+  ! into the caller's real(WP) argument when WP is single precision.
+  call MPI_AllREDUCE(lval, gval, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
        MPI_COMM_FESOM, MPIerr)
+  int2D=real(gval, WP)
 end subroutine integrate_elem_2D
 
 

--- a/src/oce_mesh.F90
+++ b/src/oce_mesh.F90
@@ -2195,6 +2195,8 @@ SUBROUTINE mesh_areas(partit, mesh)
 
     integer                                   :: n,j,q, elnodes(3), ed(2), elem, nz,nzmin, nzmax
     real(kind=WP)                             :: a(2), b(2), ax, ay, lon, lat, vol, vol2
+    ! full-precision accumulators for the total ocean areas (see below)
+    real(kind=WP_full)                        :: area_acc, area_acc2, area_glob, area_glob2
     real(kind=WP), allocatable,dimension(:)   :: work_array
     integer, allocatable,dimension(:,:)       :: cavity_contribut
     real(kind=WP)                             :: t0, t1
@@ -2403,22 +2405,36 @@ type(t_partit), intent(inout), target :: partit
     deallocate(work_array)
 
     !___compute total ocean areas with/without cavity___________________________
-    vol = 0.0_WP
-    vol2= 0.0_WP
+    ! Accumulate the total areas in WP_full rather than WP. These are sums over
+    ! every surface node in the domain (~1e5 on CORE2, ~7e6 on NG5) reaching
+    ! ~3.6e14 m^2, and they are the DENOMINATOR of every global-mean flux
+    ! correction: freshwater, virtual salt, SSS restoring, icebergs and water
+    ! isotopes all form net = integrate_nod(flux)/ocean_area and subtract it so
+    ! the domain integral vanishes. A relative error here is therefore a
+    ! systematic net source applied to every surface node, not noise that
+    ! averages out. In float32 a single ulp at 3.6e14 is ~3.4e7 m^2, and the
+    ! uncompensated sum's error is far larger than that.
+    ! Dedicated WP_full locals rather than retyping vol/vol2, which are shared
+    ! with the mesh-resolution loop above. mesh%ocean_area keeps its WP type, so
+    ! nothing ripples to its consumers.
+    area_acc  = 0.0_WP_full
+    area_acc2 = 0.0_WP_full
     do n=1, myDim_nod2D
 !!PS         vol2=vol2+mesh%area(mesh%ulevels_nod2D(n), n) ! area also under cavity
 !!PS         if (mesh%ulevels_nod2D(n)>1) cycle
 !!PS         vol=vol+mesh%area(1, n) ! area only surface
-        vol2=vol2+mesh%areasvol(mesh%ulevels_nod2D(n), n) ! area also under cavity
+        area_acc2 = area_acc2 + real(mesh%areasvol(mesh%ulevels_nod2D(n), n), WP_full) ! area also under cavity
         if (mesh%ulevels_nod2D(n)>1) cycle
-        vol=vol+mesh%areasvol(1, n) ! area only surface  
+        area_acc  = area_acc  + real(mesh%areasvol(1, n), WP_full) ! area only surface
     end do
-    mesh%ocean_area=0.0_WP
-    mesh%ocean_areawithcav=0.0_WP
-    call MPI_AllREDUCE(vol, mesh%ocean_area, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+    area_glob  = 0.0_WP_full
+    area_glob2 = 0.0_WP_full
+    call MPI_AllREDUCE(area_acc,  area_glob,  1, MPI_DOUBLE_PRECISION, MPI_SUM, &
         MPI_COMM_FESOM, MPIerr)
-    call MPI_AllREDUCE(vol2, mesh%ocean_areawithcav, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+    call MPI_AllREDUCE(area_acc2, area_glob2, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
         MPI_COMM_FESOM, MPIerr)
+    mesh%ocean_area        = real(area_glob,  WP)
+    mesh%ocean_areawithcav = real(area_glob2, WP)
     
     !___write mesh statistics___________________________________________________
     if (mype==0) then


### PR DESCRIPTION
Two commits, two files. This is a **correctness fix, not a precision improvement**: as
merged, `main` has an MPI datatype/buffer-kind mismatch that is harmless today only because
`WP` happens to be `real64`.

### The problem

`#992` introduced `WP_full` (always `real64`) alongside `WP`, and `#993` made the global
integrals accumulate in it. But there is no `MPI_WP_FULL` constant, so nothing connects a
`WP_full` buffer to the MPI datatype that describes it. Two sites on `main` are currently
mismatched:

- **`gen_support.F90`** (4 sites) — `lval` is `real(kind=WP_full)`, reduced with
  `MPI_DOUBLE_PRECISION` **straight into the `int2D`/`int3D` dummies**, which are declared
  `real(kind=WP)`. MPI writes eight bytes into a four-byte variable as soon as `WP` is
  `real32`.
- **`oce_mesh.F90:2418`** — worse in both directions: `vol`/`vol2` are `real(kind=WP)`
  *send* buffers reduced as `MPI_DOUBLE_PRECISION`, so MPI also reads eight bytes out of a
  four-byte variable, and the receive side writes eight into
  `mesh%ocean_area`/`ocean_areawithcav`, which are `real(kind=WP)` too.

### Why it matters beyond the type error

`mesh%ocean_area` is not a diagnostic. It is the **denominator of every global-mean flux
correction** in the model — freshwater, virtual salt, cavity virtual salt, SSS restoring,
icebergs and water isotopes all form

```
net = integrate_nod(flux) / ocean_area
```

and subtract `net` so the domain integral vanishes. An error in the denominator is a
systematic net source or sink applied uniformly to every surface node, every step, in
proportion to whatever the flux is doing — not noise that averages out. And it is a sum over
every surface node in the domain (~1e5 on CORE2, ~7e6 on NG5) reaching ~3.6e14 m^2, where a
single float32 ulp is already ~3.4e7 m^2.

The two commits are therefore companions: `integrate_nod_2D/3D` is the numerator of that same
expression, `ocean_area` the denominator.

### The fix

Reduce into a `WP_full` buffer with `MPI_DOUBLE_PRECISION`, then round once into the existing
`WP` result. Public interfaces are unchanged; `mesh%ocean_area` keeps its type, so nothing
ripples to its consumers. Dedicated locals are used rather than retyping `vol`/`vol2`, which
are shared with the mesh-resolution loop earlier in the same routine.

### Validation

- Local CTest suite (`-E '^(remote_|ecbundle_)'`): **7/7 passed**.
- `tests/perf/nc_diff.py` against a pristine `main` build, both DP:
  `WORST_REL=0.000e+00  NAN=0  (BITWISE-IDENTICAL)` on `integration_pi_mpi2` and
  `integration_pi_cavity_mpi2`.

No effect while `WP` is `real64`, by construction.

Note that `main` has no `USE_SINGLE_PRECISION` switch, so the single-precision path cannot be
exercised here — configuring `main` with `-DUSE_SINGLE_PRECISION=ON` silently produces a DP
binary. On the branch where it *can* be exercised, the unfixed version fails immediately:

```
WARNING: ssh CG breakdown at iter 1 : p.Ap=NaN is not positive
WARNING: ssh CG did not converge in 2000 iters; target rtol=NaN
```

because the corrupted global integrals feed `water_flux` through the freshwater and
virtual-salt balancing and drive `eta_n` out of bounds.

### Follow-up (not in this PR)

A named `MPI_WP_FULL` beside `MPI_WP` in `MOD_PARTIT.F90` would make this structural rather
than something each merge has to remember. There are further sites that pair
`MPI_DOUBLE_PRECISION` with `real(kind=WP)` buffers — `gen_modules_cmor_diag.F90` (9),
`oce_ale_tracer.F90` (6), `io_restart.F90:614`, `io_tracks.F90`, `icb_coupling.F90:348`,
`toy_channel_neverworld2.F90:251` — all latent for the same reason. Happy to open an issue
for those separately.
