### PR TITLE
cmake: opt-in runtime and build-time diagnostic flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,66 @@ if(BUILD_YAC)
     include(cmake/BuildYAC.cmake)
 endif()
 
+# Compile-time diagnostics. "strict" stops suppressing argument mismatches, which
+# gfortran >=10 then reports as errors.
+set(FESOM_BUILD_CHECKS "off" CACHE STRING "Compile-time diagnostics: off | warn | strict")
+set_property(CACHE FESOM_BUILD_CHECKS PROPERTY STRINGS off warn strict)
+
+set(FESOM_BUILD_CHECK_FLAGS "")
+set(FESOM_ALLOW_ARG_MISMATCH ON)
+if(NOT FESOM_BUILD_CHECKS STREQUAL "off")
+   if(NOT FESOM_BUILD_CHECKS MATCHES "^(warn|strict)$")
+      message(FATAL_ERROR "FESOM_BUILD_CHECKS must be one of: off, warn, strict (got '${FESOM_BUILD_CHECKS}')")
+   endif()
+   if(FESOM_BUILD_CHECKS STREQUAL "strict")
+      set(FESOM_ALLOW_ARG_MISMATCH OFF)
+   endif()
+
+   if(CMAKE_Fortran_COMPILER_ID STREQUAL GNU)
+      set(FESOM_BUILD_CHECK_FLAGS -Wall -Wextra -Wno-unused-dummy-argument -Wno-compare-reals)
+   elseif(CMAKE_Fortran_COMPILER_ID STREQUAL Intel OR CMAKE_Fortran_COMPILER_ID STREQUAL IntelLLVM)
+      set(FESOM_BUILD_CHECK_FLAGS -warn all,noexternals)
+   else()
+      message(WARNING "FESOM_BUILD_CHECKS=${FESOM_BUILD_CHECKS}: no flag mapping for compiler ${CMAKE_Fortran_COMPILER_ID}.")
+   endif()
+   message(STATUS "FESOM_BUILD_CHECKS=${FESOM_BUILD_CHECKS} (allow argument mismatch: ${FESOM_ALLOW_ARG_MISMATCH})")
+endif()
+
+# Runtime diagnostics for development builds. Appended after the production flags,
+# so they win on -O and -finit-*; must be set here to reach mesh_part too.
+set(FESOM_RUNTIME_CHECKS "off" CACHE STRING "Runtime diagnostics for development builds: off | checks | paranoid")
+set_property(CACHE FESOM_RUNTIME_CHECKS PROPERTY STRINGS off checks paranoid)
+
+set(FESOM_RUNTIME_CHECK_FLAGS "")
+if(NOT FESOM_RUNTIME_CHECKS STREQUAL "off")
+   if(NOT FESOM_RUNTIME_CHECKS MATCHES "^(checks|paranoid)$")
+      message(FATAL_ERROR "FESOM_RUNTIME_CHECKS must be one of: off, checks, paranoid (got '${FESOM_RUNTIME_CHECKS}')")
+   endif()
+
+   if(CMAKE_Fortran_COMPILER_ID STREQUAL GNU)
+      if(FESOM_RUNTIME_CHECKS STREQUAL "paranoid")
+         set(FESOM_RUNTIME_CHECK_FLAGS -fcheck=all -fbacktrace
+                                       -ffpe-trap=invalid,zero,overflow
+                                       -finit-real=snan -finit-integer=-9999)
+      else()
+         set(FESOM_RUNTIME_CHECK_FLAGS -fcheck=bounds -fbacktrace)
+      endif()
+   elseif(CMAKE_Fortran_COMPILER_ID STREQUAL Intel OR CMAKE_Fortran_COMPILER_ID STREQUAL IntelLLVM)
+      if(FESOM_RUNTIME_CHECKS STREQUAL "paranoid")
+         set(FESOM_RUNTIME_CHECK_FLAGS -check all -traceback -fpe0 -init=snan,arrays)
+      else()
+         set(FESOM_RUNTIME_CHECK_FLAGS -check bounds -traceback)
+      endif()
+   else()
+      message(WARNING "FESOM_RUNTIME_CHECKS=${FESOM_RUNTIME_CHECKS}: no flag mapping for compiler ${CMAKE_Fortran_COMPILER_ID}; building without runtime checks.")
+   endif()
+
+   if(FESOM_RUNTIME_CHECK_FLAGS)
+      string(REPLACE ";" " " _fesom_checks_pretty "${FESOM_RUNTIME_CHECK_FLAGS}")
+      message(STATUS "FESOM_RUNTIME_CHECKS=${FESOM_RUNTIME_CHECKS} -> ${_fesom_checks_pretty}")
+   endif()
+endif()
+
 #add_subdirectory(oasis3-mct/lib/psmile)
 add_subdirectory(src)
 

--- a/mesh_part/CMakeLists.txt
+++ b/mesh_part/CMakeLists.txt
@@ -111,11 +111,13 @@ elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
     target_compile_options(${PROJECT_NAME} PRIVATE 
         -fdefault-real-8 -ffree-line-length-none
     )
-    if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+    if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10 AND FESOM_ALLOW_ARG_MISMATCH)
         target_compile_options(${PROJECT_NAME} PRIVATE -fallow-argument-mismatch)
     endif()
 endif()
 target_link_libraries(${PROJECT_NAME} PUBLIC ${PROJECT_NAME}_C MPI::MPI_Fortran)
+target_compile_options(${PROJECT_NAME} PRIVATE ${FESOM_RUNTIME_CHECK_FLAGS} ${FESOM_BUILD_CHECK_FLAGS})
+
 set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE Fortran)
 
 # Install the executable

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -460,7 +460,7 @@ elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL  GNU )
    else()
       target_compile_options(${PROJECT_NAME} PRIVATE -O3 -ffloat-store -finit-local-zero  -finline-functions -fimplicit-none  ${_FESOM_GNU_RKIND} -ffree-line-length-none -cpp)
    endif()
-   if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+   if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" AND FESOM_ALLOW_ARG_MISMATCH)
       if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
          target_compile_options(${PROJECT_NAME} PRIVATE -fallow-argument-mismatch) # gfortran v10 is strict about erroneous API calls: "Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)"
       else()
@@ -565,6 +565,8 @@ elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL NVHPC )
    endif()
 endif()
 
+target_compile_options(${PROJECT_NAME} PRIVATE ${FESOM_RUNTIME_CHECK_FLAGS} ${FESOM_BUILD_CHECK_FLAGS})
+
 target_include_directories(${PROJECT_NAME} PRIVATE ${NETCDF_Fortran_INCLUDE_DIRECTORIES} ${OASIS_Fortran_INCLUDE_DIRECTORIES})
 target_include_directories(${PROJECT_NAME} PRIVATE ${MCT_Fortran_INCLUDE_DIRECTORIES} ${MPEU_Fortran_INCLUDE_DIRECTORIES})
 target_include_directories(${PROJECT_NAME} PRIVATE ${SCRIP_Fortran_INCLUDE_DIRECTORIES})
@@ -601,11 +603,13 @@ endif()
    
 # fesom.x executable
 add_executable(${PROJECT_NAME}.x ${src_home}/fesom_main.F90)
+target_compile_options(${PROJECT_NAME}.x PRIVATE ${FESOM_RUNTIME_CHECK_FLAGS} ${FESOM_BUILD_CHECK_FLAGS})
 target_link_libraries(${PROJECT_NAME}.x PUBLIC ${PROJECT_NAME})
 
 # fesom_meshdiag executable (optional)
 if(BUILD_MESHDIAG)
     add_executable(fesom_meshdiag ${src_home}/fesom_meshdiag.F90)
+    target_compile_options(fesom_meshdiag PRIVATE ${FESOM_RUNTIME_CHECK_FLAGS} ${FESOM_BUILD_CHECK_FLAGS})
     target_link_libraries(fesom_meshdiag PUBLIC ${PROJECT_NAME})
     target_link_libraries(fesom_meshdiag PRIVATE MPI::MPI_Fortran)
     


### PR DESCRIPTION
Adds two opt-in diagnostic levels for development builds. Both default to `off`,
and with both off the compile flags are byte-identical to before — verified by
diffing the generated flag lines.

```
FESOM_RUNTIME_CHECKS = off | checks | paranoid     # what a run does
    checks    -fcheck=bounds -fbacktrace           # ~3% overhead at -O3
    paranoid  + -fcheck=all, FP traps, -finit-real=snan -finit-integer=-9999

FESOM_BUILD_CHECKS   = off | warn | strict         # whether the build succeeds
    warn      -Wall -Wextra
    strict    also stops adding -fallow-argument-mismatch, so gfortran >=10
              reports the mismatches as errors
```

Two options rather than one, because they act on different things: asking for
runtime diagnostics should not be able to break your build.

### Intended use

1. **Local checks during development** — run the normal CTest suite against a
   checked build.
2. **A path to removing the bad flags from production.** `-finit-local-zero` and
   `-fallow-argument-mismatch` are in the production flags today and each hides a
   class of bug: the first makes uninitialised reads return `0.0` and therefore
   undetectable by construction, the second downgrades real interface errors.
   These levels let us find and fix what they hide, and drop them once the code
   is clean.
3. **Eventually CI**, so new contributions cannot introduce these silently.
   Production CI builds and runs will not catch them.

Not proposed as a CI gate yet — it is a target to work toward, not a switch to
flip. Running the local suite with `FESOM_RUNTIME_CHECKS=checks` currently fails
3 of 9 tests on pre-existing issues (a CVMix KPP shape mismatch and a
`myList_elem2D` rank remapping in the partitioner), and `FESOM_BUILD_CHECKS=strict`
does not build. Those are the debts to pay off first.

### Notes

Defined at top level rather than in `src/`: `mesh_part` is a separate CMake
project and would not otherwise see the flags — and the partitioner is where the
rank-remapping violation shows up. Applied to all four Fortran targets.

Flags are appended to each target's existing options so they win on `-O` and
`-finit-*`. Passing them via `CMAKE_Fortran_FLAGS` does not work: that variable is
prepended, so an `-O0` given that way is silently overridden by the `-O2`/`-O3`
the targets set themselves.

Default build and full local suite unchanged: 9/9.
