### PR TITLE
mpi: add MPI_WP_FULL and use it for the WP_full reductions

### DIFF
--- a/src/MOD_PARTIT.F90
+++ b/src/MOD_PARTIT.F90
@@ -17,6 +17,16 @@ integer, parameter   :: MPI_WP = MPI_REAL             ! single precision
 #else
 integer, parameter   :: MPI_WP = MPI_DOUBLE_PRECISION ! double precision (default)
 #endif
+! MPI datatype matching WP_full (see o_PARAM), which is real64 regardless of WP.
+! Pick the constant that matches how the buffer is DECLARED, for any MPI operation --
+! reduce, bcast, gather, scatter, send/recv alike:
+!   real(kind=WP)      -> MPI_WP
+!   real(kind=WP_full) -> MPI_WP_FULL
+! Buffers declared real(real64) independently of WP (the typed gather_*/scatter_*
+! routines with real4/int2 siblings) keep MPI_DOUBLE_PRECISION -- they do not track
+! WP_full. Mixing these up is invisible in a double-precision build, where
+! WP_full == WP, and corrupts memory in a single-precision one.
+integer, parameter   :: MPI_WP_FULL = MPI_DOUBLE_PRECISION
 integer, parameter   :: MAX_LAENDERECK=16
 integer, parameter   :: MAX_NEIGHBOR_PARTITIONS=32
 

--- a/src/cpl_driver.F90
+++ b/src/cpl_driver.F90
@@ -605,27 +605,27 @@ include "associate_mesh_ass.h"
     if (mype .eq. 0) then 
       print *, 'FESOM before 1st GatherV', displs_from_all_pes(npes), counts_from_all_pes(npes), number_of_all_points
     endif
-    CALL MPI_GATHERV(my_x_coords, my_number_of_points, MPI_DOUBLE_PRECISION, all_x_coords,  &
-                    counts_from_all_pes, displs_from_all_pes, MPI_DOUBLE_PRECISION, localroot, MPI_COMM_FESOM, ierror)
+    CALL MPI_GATHERV(my_x_coords, my_number_of_points, MPI_WP, all_x_coords,  &
+                    counts_from_all_pes, displs_from_all_pes, MPI_WP, localroot, MPI_COMM_FESOM, ierror)
 
     if (mype .eq. 0) then 
       print *, 'FESOM before 2nd GatherV'
     endif
-    CALL MPI_GATHERV(my_y_coords, my_number_of_points, MPI_DOUBLE_PRECISION, all_y_coords,  &
-                    counts_from_all_pes, displs_from_all_pes, MPI_DOUBLE_PRECISION, localroot, MPI_COMM_FESOM, ierror)
+    CALL MPI_GATHERV(my_y_coords, my_number_of_points, MPI_WP, all_y_coords,  &
+                    counts_from_all_pes, displs_from_all_pes, MPI_WP, localroot, MPI_COMM_FESOM, ierror)
 
     if (mype .eq. 0) then 
       print *, 'FESOM before 3rd GatherV'
     endif
-    CALL MPI_GATHERV(area(1,:), my_number_of_points, MPI_DOUBLE_PRECISION, all_area,  &
-                    counts_from_all_pes, displs_from_all_pes, MPI_DOUBLE_PRECISION, localroot, MPI_COMM_FESOM, ierror)
+    CALL MPI_GATHERV(area(1,:), my_number_of_points, MPI_WP, all_area,  &
+                    counts_from_all_pes, displs_from_all_pes, MPI_WP, localroot, MPI_COMM_FESOM, ierror)
 
     if (compute_oasis_corners) then
       do j = 1, 25
-        CALL MPI_GATHERV(my_x_corners(:,j), myDim_nod2D, MPI_DOUBLE_PRECISION, all_x_corners(:,:,j),  &
-                      counts_from_all_pes, displs_from_all_pes, MPI_DOUBLE_PRECISION, localroot, MPI_COMM_FESOM, ierror)
-        CALL MPI_GATHERV(my_y_corners(:,j), myDim_nod2D, MPI_DOUBLE_PRECISION, all_y_corners(:,:,j),  &
-                      counts_from_all_pes, displs_from_all_pes, MPI_DOUBLE_PRECISION, localroot, MPI_COMM_FESOM, ierror)
+        CALL MPI_GATHERV(my_x_corners(:,j), myDim_nod2D, MPI_WP, all_x_corners(:,:,j),  &
+                      counts_from_all_pes, displs_from_all_pes, MPI_WP, localroot, MPI_COMM_FESOM, ierror)
+        CALL MPI_GATHERV(my_y_corners(:,j), myDim_nod2D, MPI_WP, all_y_corners(:,:,j),  &
+                      counts_from_all_pes, displs_from_all_pes, MPI_WP, localroot, MPI_COMM_FESOM, ierror)
       end do
     endif
 
@@ -986,7 +986,7 @@ include "associate_mesh_ass.h"
       end if
 
       if(num_fesom_groups > 1) then
-          call MPI_Bcast(data_array, partit%myDim_nod2d, MPI_DOUBLE_PRECISION, 0, partit%MPI_COMM_FESOM_SAME_RANK_IN_GROUPS, partit%MPIerr)
+          call MPI_Bcast(data_array, partit%myDim_nod2d, MPI_WP, 0, partit%MPI_COMM_FESOM_SAME_RANK_IN_GROUPS, partit%MPIerr)
       end if
 #endif
 

--- a/src/gen_forcing_couple.F90
+++ b/src/gen_forcing_couple.F90
@@ -1020,13 +1020,13 @@ SUBROUTINE integrate_2D(flux_global, flux_local, eff_vol, field2d, mask, partit,
   flux_local(1)=sum(lump2d_north*field2d(1:myDim_nod2D)*mask(1:myDim_nod2D))
   flux_local(2)=sum(lump2d_south*field2d(1:myDim_nod2D)*mask(1:myDim_nod2D))
   call MPI_AllREDUCE(flux_local, flux_global, 2, &
-  		     MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_FESOM, MPIerr)
+  		     MPI_WP, MPI_SUM, MPI_COMM_FESOM, MPIerr)
 		     
 		     
   eff_vol_local(1)=sum(lump2d_north*mask(1:myDim_nod2D))
   eff_vol_local(2)=sum(lump2d_south*mask(1:myDim_nod2D))
   call MPI_AllREDUCE(eff_vol_local, eff_vol,  2, & 
-  		     MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_FESOM, MPIerr)
+  		     MPI_WP, MPI_SUM, MPI_COMM_FESOM, MPIerr)
 		     
 END SUBROUTINE integrate_2D
 !
@@ -1107,22 +1107,22 @@ SUBROUTINE net_rec_from_atm(action, partit)
 #else
      if (my_global_rank==target_root) then
 #endif
-        CALL MPI_IRecv(atm_net_fluxes_north(1), nrecv, MPI_DOUBLE_PRECISION, source_root, 111, MPI_COMM_WORLD, request(1), partit%MPIerr)
-        CALL MPI_IRecv(atm_net_fluxes_south(1), nrecv, MPI_DOUBLE_PRECISION, source_root, 112, MPI_COMM_WORLD, request(2), partit%MPIerr)
+        CALL MPI_IRecv(atm_net_fluxes_north(1), nrecv, MPI_WP, source_root, 111, MPI_COMM_WORLD, request(1), partit%MPIerr)
+        CALL MPI_IRecv(atm_net_fluxes_south(1), nrecv, MPI_WP, source_root, 112, MPI_COMM_WORLD, request(2), partit%MPIerr)
         CALL MPI_Waitall(2, request, status, partit%MPIerr)
      end if
 
 #if defined(__recom) && defined(__usetp)
         if(num_fesom_groups > 1) then
-           call MPI_Bcast(atm_net_fluxes_north(1), nrecv, MPI_DOUBLE_PRECISION, 0, partit%MPI_COMM_FESOM_SAME_RANK_IN_GROUPS, partit%MPIerr)
-           call MPI_Bcast(atm_net_fluxes_south(1), nrecv, MPI_DOUBLE_PRECISION, 0, partit%MPI_COMM_FESOM_SAME_RANK_IN_GROUPS, partit%MPIerr)
+           call MPI_Bcast(atm_net_fluxes_north(1), nrecv, MPI_WP, 0, partit%MPI_COMM_FESOM_SAME_RANK_IN_GROUPS, partit%MPIerr)
+           call MPI_Bcast(atm_net_fluxes_south(1), nrecv, MPI_WP, 0, partit%MPI_COMM_FESOM_SAME_RANK_IN_GROUPS, partit%MPIerr)
         end if
      end if ! (my_global_rank_test==target_root) then
 #endif
   call MPI_Barrier(partit%MPI_COMM_FESOM, partit%MPIerr)     
-  call MPI_AllREDUCE(atm_net_fluxes_north(1), aux, nrecv, MPI_DOUBLE_PRECISION, MPI_SUM, partit%MPI_COMM_FESOM, partit%MPIerr)
+  call MPI_AllREDUCE(atm_net_fluxes_north(1), aux, nrecv, MPI_WP, MPI_SUM, partit%MPI_COMM_FESOM, partit%MPIerr)
   atm_net_fluxes_north=aux
-  call MPI_AllREDUCE(atm_net_fluxes_south(1), aux, nrecv, MPI_DOUBLE_PRECISION, MPI_SUM, partit%MPI_COMM_FESOM, partit%MPIerr)
+  call MPI_AllREDUCE(atm_net_fluxes_south(1), aux, nrecv, MPI_WP, MPI_SUM, partit%MPI_COMM_FESOM, partit%MPIerr)
   atm_net_fluxes_south=aux
   end if
 END SUBROUTINE net_rec_from_atm

--- a/src/gen_modules_cmor_diag.F90
+++ b/src/gen_modules_cmor_diag.F90
@@ -102,7 +102,7 @@ contains
           volo_local = volo_local + areasvol(k, n2) * hnode(k, n2)
        end do
     end do
-    call MPI_AllREDUCE(volo_local, volo, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_FESOM, ierr)
+    call MPI_AllREDUCE(volo_local, volo, 1, MPI_WP, MPI_SUM, MPI_COMM_FESOM, ierr)
   
     ! Allocate 2D arrays (indexed by nod2D)
     allocate(opottemptend(myDim_nod2D))
@@ -295,8 +295,8 @@ contains
             thetaoga = thetaoga + temp(k, n2) * areasvol(k, n2) * hnode(k, n2)
         end do
     end do
-    call MPI_AllREDUCE(MPI_IN_PLACE, soga, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_FESOM, ierr)
-    call MPI_AllREDUCE(MPI_IN_PLACE, thetaoga, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_FESOM, ierr)
+    call MPI_AllREDUCE(MPI_IN_PLACE, soga, 1, MPI_WP, MPI_SUM, MPI_COMM_FESOM, ierr)
+    call MPI_AllREDUCE(MPI_IN_PLACE, thetaoga, 1, MPI_WP, MPI_SUM, MPI_COMM_FESOM, ierr)
     soga = soga / volo
     thetaoga = thetaoga / volo
   
@@ -338,12 +338,12 @@ contains
         end if
     end do
     
-    call MPI_AllREDUCE(MPI_IN_PLACE, siarean, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_FESOM, ierr)
-    call MPI_AllREDUCE(MPI_IN_PLACE, siareas, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_FESOM, ierr)
-    call MPI_AllREDUCE(MPI_IN_PLACE, siextentn, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_FESOM, ierr)
-    call MPI_AllREDUCE(MPI_IN_PLACE, siextents, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_FESOM, ierr)
-    call MPI_AllREDUCE(MPI_IN_PLACE, sivoln, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_FESOM, ierr)
-    call MPI_AllREDUCE(MPI_IN_PLACE, sivols, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_FESOM, ierr)
+    call MPI_AllREDUCE(MPI_IN_PLACE, siarean, 1, MPI_WP, MPI_SUM, MPI_COMM_FESOM, ierr)
+    call MPI_AllREDUCE(MPI_IN_PLACE, siareas, 1, MPI_WP, MPI_SUM, MPI_COMM_FESOM, ierr)
+    call MPI_AllREDUCE(MPI_IN_PLACE, siextentn, 1, MPI_WP, MPI_SUM, MPI_COMM_FESOM, ierr)
+    call MPI_AllREDUCE(MPI_IN_PLACE, siextents, 1, MPI_WP, MPI_SUM, MPI_COMM_FESOM, ierr)
+    call MPI_AllREDUCE(MPI_IN_PLACE, sivoln, 1, MPI_WP, MPI_SUM, MPI_COMM_FESOM, ierr)
+    call MPI_AllREDUCE(MPI_IN_PLACE, sivols, 1, MPI_WP, MPI_SUM, MPI_COMM_FESOM, ierr)
     
     ! Convert to proper units
     siarean = siarean / 1.0e12_WP      ! to 10^12 m^2

--- a/src/gen_support.F90
+++ b/src/gen_support.F90
@@ -353,7 +353,7 @@ lval=0.0_WP_full
   gval=0.0_WP_full
   ! reduce into a WP_full buffer and round once: MPI must not write a real64
   ! into the caller's real(WP) argument when WP is single precision.
-  call MPI_AllREDUCE(lval, gval, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+  call MPI_AllREDUCE(lval, gval, 1, MPI_WP_FULL, MPI_SUM, &
        MPI_COMM_FESOM, MPIerr)
   int2D=real(gval, WP)
 end subroutine integrate_nod_2D
@@ -404,7 +404,7 @@ subroutine integrate_nod_3D(data, int3D, partit, mesh)
   gval=0.0_WP_full
   ! reduce into a WP_full buffer and round once: MPI must not write a real64
   ! into the caller's real(WP) argument when WP is single precision.
-  call MPI_AllREDUCE(lval, gval, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+  call MPI_AllREDUCE(lval, gval, 1, MPI_WP_FULL, MPI_SUM, &
        MPI_COMM_FESOM, MPIerr)
   int3D=real(gval, WP)
 end subroutine integrate_nod_3D
@@ -700,7 +700,7 @@ subroutine integrate_elem_3D(data, int3D, partit, mesh)
   gval=0.0_WP_full
   ! reduce into a WP_full buffer and round once: MPI must not write a real64
   ! into the caller's real(WP) argument when WP is single precision.
-  call MPI_AllREDUCE(lval, gval, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+  call MPI_AllREDUCE(lval, gval, 1, MPI_WP_FULL, MPI_SUM, &
        MPI_COMM_FESOM, MPIerr)
   int3D=real(gval, WP)
 end subroutine integrate_elem_3D
@@ -746,7 +746,7 @@ subroutine integrate_elem_2D(data, int2D, partit, mesh)
   gval=0.0_WP_full
   ! reduce into a WP_full buffer and round once: MPI must not write a real64
   ! into the caller's real(WP) argument when WP is single precision.
-  call MPI_AllREDUCE(lval, gval, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+  call MPI_AllREDUCE(lval, gval, 1, MPI_WP_FULL, MPI_SUM, &
        MPI_COMM_FESOM, MPIerr)
   int2D=real(gval, WP)
 end subroutine integrate_elem_2D

--- a/src/icb_coupling.F90
+++ b/src/icb_coupling.F90
@@ -345,7 +345,7 @@ subroutine cap_ibhf_n(tracers, mesh, partit)
     end do
 !$OMP END PARALLEL DO
 
-    call MPI_AllReduce(heat_disc_loc,    heat_disc_glob,    1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_FESOM, ierr_mpi)
+    call MPI_AllReduce(heat_disc_loc,    heat_disc_glob,    1, MPI_WP, MPI_SUM, MPI_COMM_FESOM, ierr_mpi)
     call MPI_AllReduce(cells_capped_loc, cells_capped_glob, 1, MPI_INTEGER,          MPI_SUM, MPI_COMM_FESOM, ierr_mpi)
 
     if (mype == 0 .and. cells_capped_glob > 0) then

--- a/src/io_restart.F90
+++ b/src/io_restart.F90
@@ -611,7 +611,7 @@ subroutine write_initial_conditions(istep, nstart, ntotal, which_readr, ice, dyn
             do tr_num = tr_num_start, tr_num_end
 
 ! kh 09.01.26 also handle additional dimension of valuesold for AB_order
-                call MPI_Bcast(tracers%data(tr_num)%valuesold(:,:,:), tr_arr_slice_count_fix_1 * (tracers%data(tr_num)%AB_order - 1), MPI_DOUBLE_PRECISION, group_i, partit%MPI_COMM_FESOM_SAME_RANK_IN_GROUPS, partit%mpierr)
+                call MPI_Bcast(tracers%data(tr_num)%valuesold(:,:,:), tr_arr_slice_count_fix_1 * (tracers%data(tr_num)%AB_order - 1), MPI_WP, group_i, partit%MPI_COMM_FESOM_SAME_RANK_IN_GROUPS, partit%mpierr)
             end do
         end do
     end if

--- a/src/io_tracks.F90
+++ b/src/io_tracks.F90
@@ -701,9 +701,9 @@ contains
     end do
 
     allocate(sampled(nz_track, t%M), wsum_tot(nz_track, t%M))
-    call MPI_Allreduce(contrib, sampled,  nz_track*t%M, MPI_DOUBLE_PRECISION, &
+    call MPI_Allreduce(contrib, sampled,  nz_track*t%M, MPI_WP, &
                        MPI_SUM, partit%MPI_COMM_FESOM, ierr)
-    call MPI_Allreduce(wsum,    wsum_tot, nz_track*t%M, MPI_DOUBLE_PRECISION, &
+    call MPI_Allreduce(wsum,    wsum_tot, nz_track*t%M, MPI_WP, &
                        MPI_SUM, partit%MPI_COMM_FESOM, ierr)
     deallocate(contrib, wsum)
 
@@ -822,7 +822,7 @@ contains
     end do
 
     allocate(sampled(nz_track, t%P), nhit_tot(nz_track, t%P))
-    call MPI_Allreduce(contrib, sampled,  nz_track*t%P, MPI_DOUBLE_PRECISION, &
+    call MPI_Allreduce(contrib, sampled,  nz_track*t%P, MPI_WP, &
                        MPI_SUM, partit%MPI_COMM_FESOM, ierr)
     call MPI_Allreduce(nhit,    nhit_tot, nz_track*t%P, MPI_INTEGER,          &
                        MPI_SUM, partit%MPI_COMM_FESOM, ierr)

--- a/src/io_tracks.F90
+++ b/src/io_tracks.F90
@@ -38,7 +38,7 @@ module io_tracks_module
   use ixml_tree,           only: xios_add_axistogrid, xios_add_domaintogrid
   use mpi
   use mod_mesh,            only: t_mesh
-  use mod_partit,          only: t_partit
+  use mod_partit,          only: t_partit, MPI_WP, MPI_WP_FULL
   use mod_tracer,          only: t_tracer
   use mod_dyn,             only: t_dyn
   use o_param,             only: WP, rad
@@ -495,9 +495,9 @@ contains
        geom%M = M_b
     end if
     call mpi_bcast(geom%edge_cut_ni,   2*M_b, MPI_INTEGER,          0, partit%MPI_COMM_FESOM, ierr)
-    call mpi_bcast(geom%edge_cut_lint, M_b,   MPI_DOUBLE_PRECISION, 0, partit%MPI_COMM_FESOM, ierr)
-    call mpi_bcast(geom%edge_cut_midP, 2*M_b, MPI_DOUBLE_PRECISION, 0, partit%MPI_COMM_FESOM, ierr)
-    call mpi_bcast(geom%edge_cut_dist, M_b,   MPI_DOUBLE_PRECISION, 0, partit%MPI_COMM_FESOM, ierr)
+    call mpi_bcast(geom%edge_cut_lint, M_b,   MPI_WP_FULL, 0, partit%MPI_COMM_FESOM, ierr)
+    call mpi_bcast(geom%edge_cut_midP, 2*M_b, MPI_WP_FULL, 0, partit%MPI_COMM_FESOM, ierr)
+    call mpi_bcast(geom%edge_cut_dist, M_b,   MPI_WP_FULL, 0, partit%MPI_COMM_FESOM, ierr)
 
     if (var_kind /= 2) return
 
@@ -521,10 +521,10 @@ contains
        geom%P = P_b
     end if
     call mpi_bcast(geom%path_ei,          P_b,   MPI_INTEGER,          0, partit%MPI_COMM_FESOM, ierr)
-    call mpi_bcast(geom%path_dx,          P_b,   MPI_DOUBLE_PRECISION, 0, partit%MPI_COMM_FESOM, ierr)
-    call mpi_bcast(geom%path_dy,          P_b,   MPI_DOUBLE_PRECISION, 0, partit%MPI_COMM_FESOM, ierr)
-    call mpi_bcast(geom%path_centroid_xy, 2*P_b, MPI_DOUBLE_PRECISION, 0, partit%MPI_COMM_FESOM, ierr)
-    call mpi_bcast(geom%path_nvec_cs,     2*P_b, MPI_DOUBLE_PRECISION, 0, partit%MPI_COMM_FESOM, ierr)
+    call mpi_bcast(geom%path_dx,          P_b,   MPI_WP_FULL, 0, partit%MPI_COMM_FESOM, ierr)
+    call mpi_bcast(geom%path_dy,          P_b,   MPI_WP_FULL, 0, partit%MPI_COMM_FESOM, ierr)
+    call mpi_bcast(geom%path_centroid_xy, 2*P_b, MPI_WP_FULL, 0, partit%MPI_COMM_FESOM, ierr)
+    call mpi_bcast(geom%path_nvec_cs,     2*P_b, MPI_WP_FULL, 0, partit%MPI_COMM_FESOM, ierr)
   end subroutine broadcast_transect
 
 

--- a/src/mod_tracks_geometry.F90
+++ b/src/mod_tracks_geometry.F90
@@ -9,13 +9,11 @@ module mod_tracks_geometry
   !
   ! All inputs are GLOBAL mesh arrays — caller must gather/broadcast them.
   use, intrinsic :: ieee_arithmetic, only: ieee_value, ieee_quiet_nan
-  use o_param, only: pi, rad, r_earth
+  use o_param, only: pi, rad, r_earth, WP_full
   implicit none
   private
 
-  integer, parameter, public :: TG_WP = selected_real_kind(13)
-
-  real(TG_WP), parameter :: R_EARTH_KM = real(r_earth, TG_WP)/1000.0_TG_WP
+  real(WP_full), parameter :: R_EARTH_KM = real(r_earth, WP_full)/1000.0_WP_full
 
   type, public :: transect_t
     character(len=64)         :: name = ''
@@ -25,22 +23,22 @@ module mod_tracks_geometry
 
     integer,     allocatable  :: edge_cut_i   (:)        ! (M) global edge id (-1 = inserted land slot)
     integer,     allocatable  :: edge_cut_ni  (:, :)     ! (2, M) global node ids
-    real(TG_WP), allocatable  :: edge_cut_lint(:)        ! (M)
-    real(TG_WP), allocatable  :: edge_cut_P   (:, :)     ! (2, M) lon, lat (degrees)
-    real(TG_WP), allocatable  :: edge_cut_midP(:, :)     ! (2, M) lon, lat (degrees)
-    real(TG_WP), allocatable  :: edge_cut_evec(:, :)     ! (2, M) edge along-vector (degrees)
-    real(TG_WP), allocatable  :: edge_cut_dist(:)        ! (M) km from start
+    real(WP_full), allocatable  :: edge_cut_lint(:)        ! (M)
+    real(WP_full), allocatable  :: edge_cut_P   (:, :)     ! (2, M) lon, lat (degrees)
+    real(WP_full), allocatable  :: edge_cut_midP(:, :)     ! (2, M) lon, lat (degrees)
+    real(WP_full), allocatable  :: edge_cut_evec(:, :)     ! (2, M) edge along-vector (degrees)
+    real(WP_full), allocatable  :: edge_cut_dist(:)        ! (M) km from start
 
     integer,     allocatable  :: path_ei         (:)     ! (P) global elem id, -1 = land slot
     integer,     allocatable  :: path_ni         (:, :)  ! (3, P) global node ids
     integer,     allocatable  :: path_cut_ni     (:, :)  ! (2, P) global node ids of entering edge
-    real(TG_WP), allocatable  :: path_dx         (:)     ! (P) midpoint→centroid x (metres)
-    real(TG_WP), allocatable  :: path_dy         (:)     ! (P) midpoint→centroid y (metres)
-    real(TG_WP), allocatable  :: path_nvec_cs    (:, :)  ! (2, P) section-normal direction
-    real(TG_WP), allocatable  :: path_centroid_xy(:, :)  ! (2, P) lon, lat of path centroid
+    real(WP_full), allocatable  :: path_dx         (:)     ! (P) midpoint→centroid x (metres)
+    real(WP_full), allocatable  :: path_dy         (:)     ! (P) midpoint→centroid y (metres)
+    real(WP_full), allocatable  :: path_nvec_cs    (:, :)  ! (2, P) section-normal direction
+    real(WP_full), allocatable  :: path_centroid_xy(:, :)  ! (2, P) lon, lat of path centroid
 
-    real(TG_WP), allocatable  :: path_xy   (:, :)        ! (2, Pxy) alternating midP/centroid
-    real(TG_WP), allocatable  :: path_dist (:)           ! (Pxy) km from start
+    real(WP_full), allocatable  :: path_xy   (:, :)        ! (2, Pxy) alternating midP/centroid
+    real(WP_full), allocatable  :: path_dist (:)           ! (Pxy) km from start
   end type transect_t
 
   public :: analyse_transect
@@ -51,24 +49,24 @@ module mod_tracks_geometry
     integer                   :: ncut = 0
     integer,     allocatable  :: edge_cut_i   (:)
     integer,     allocatable  :: edge_cut_ni  (:, :)
-    real(TG_WP), allocatable  :: edge_cut_lint(:)
-    real(TG_WP), allocatable  :: edge_cut_P   (:, :)
-    real(TG_WP), allocatable  :: edge_cut_midP(:, :)
-    real(TG_WP), allocatable  :: edge_cut_evec(:, :)
-    real(TG_WP)               :: e_vec(2)   = 0.0_TG_WP
-    real(TG_WP)               :: n_vec(2)   = 0.0_TG_WP
-    real(TG_WP)               :: alpha      = 0.0_TG_WP
+    real(WP_full), allocatable  :: edge_cut_lint(:)
+    real(WP_full), allocatable  :: edge_cut_P   (:, :)
+    real(WP_full), allocatable  :: edge_cut_midP(:, :)
+    real(WP_full), allocatable  :: edge_cut_evec(:, :)
+    real(WP_full)               :: e_vec(2)   = 0.0_WP_full
+    real(WP_full)               :: n_vec(2)   = 0.0_WP_full
+    real(WP_full)               :: alpha      = 0.0_WP_full
 
     integer                   :: P    = 0
     integer                   :: Pxy  = 0
     integer,     allocatable  :: path_ei         (:)
     integer,     allocatable  :: path_ni         (:, :)
     integer,     allocatable  :: path_cut_ni     (:, :)
-    real(TG_WP), allocatable  :: path_dx         (:)
-    real(TG_WP), allocatable  :: path_dy         (:)
-    real(TG_WP), allocatable  :: path_nvec_cs    (:, :)   ! (2, P) per-sub-segment n_vec
-    real(TG_WP), allocatable  :: path_centroid_xy(:, :)
-    real(TG_WP), allocatable  :: path_xy         (:, :)
+    real(WP_full), allocatable  :: path_dx         (:)
+    real(WP_full), allocatable  :: path_dy         (:)
+    real(WP_full), allocatable  :: path_nvec_cs    (:, :)   ! (2, P) per-sub-segment n_vec
+    real(WP_full), allocatable  :: path_centroid_xy(:, :)
+    real(WP_full), allocatable  :: path_xy         (:, :)
   end type subseg_t
 
 contains
@@ -96,22 +94,22 @@ contains
                               n_csi, csi_lon, csi_lat, name, &
                               transect)
     integer,          intent(in)    :: n_nod, n_edge, n_elem, n_csi
-    real(TG_WP),      intent(in)    :: lon_nod(n_nod), lat_nod(n_nod)        ! degrees, geographic
+    real(WP_full),      intent(in)    :: lon_nod(n_nod), lat_nod(n_nod)        ! degrees, geographic
     integer,          intent(in)    :: edge(2, n_edge)                       ! global node ids (1-based)
     integer,          intent(in)    :: edge_tri(2, n_edge)                   ! global elem ids (1-based, -1 = boundary)
-    real(TG_WP),      intent(in)    :: edge_cross_dxdy(4, n_edge)            ! 1:2 LEFT, 3:4 RIGHT (metres)
+    real(WP_full),      intent(in)    :: edge_cross_dxdy(4, n_edge)            ! 1:2 LEFT, 3:4 RIGHT (metres)
     integer,          intent(in)    :: elem_nodes(3, n_elem)                 ! global node ids (1-based)
-    real(TG_WP),      intent(in)    :: csi_lon(n_csi), csi_lat(n_csi)        ! degrees
+    real(WP_full),      intent(in)    :: csi_lon(n_csi), csi_lat(n_csi)        ! degrees
     character(len=*), intent(in)    :: name
     type(transect_t), intent(out)   :: transect
 
     type(subseg_t), allocatable :: segs(:)
-    real(TG_WP)                 :: poly_lon(n_csi), poly_lat(n_csi)
-    real(TG_WP)                 :: auxx, auxy, auxn, alpha_tot
-    real(TG_WP)                 :: n_vec_tot(2)
+    real(WP_full)                 :: poly_lon(n_csi), poly_lat(n_csi)
+    real(WP_full)                 :: auxx, auxy, auxn, alpha_tot
+    real(WP_full)                 :: n_vec_tot(2)
     integer                     :: ii, n_segs
     logical                     :: crosses_dl
-    real(TG_WP)                 :: px0, px1
+    real(WP_full)                 :: px0, px1
 
     transect%name = name
 
@@ -120,17 +118,17 @@ contains
     poly_lat = csi_lat
     auxx = poly_lon(n_csi) - poly_lon(1)
     auxy = poly_lat(n_csi) - poly_lat(1)
-    if (auxx >  180.0_TG_WP) auxx = auxx - 360.0_TG_WP
-    if (auxx < -180.0_TG_WP) auxx = auxx + 360.0_TG_WP
+    if (auxx >  180.0_WP_full) auxx = auxx - 360.0_WP_full
+    if (auxx < -180.0_WP_full) auxx = auxx + 360.0_WP_full
     auxn = sqrt(auxx*auxx + auxy*auxy)
-    if (auxn > 0.0_TG_WP) then
+    if (auxn > 0.0_WP_full) then
       auxx = auxx / auxn
       auxy = auxy / auxn
     end if
-    alpha_tot = atan2(auxy, auxx) * 180.0_TG_WP / real(pi, TG_WP)
+    alpha_tot = atan2(auxy, auxx) * 180.0_WP_full / real(pi, WP_full)
 
     ! tripyview flips the polyline if total bearing falls in [-180, -90]
-    if (alpha_tot >= -180.0_TG_WP .and. alpha_tot <= -90.0_TG_WP) then
+    if (alpha_tot >= -180.0_WP_full .and. alpha_tot <= -90.0_WP_full) then
       poly_lon = poly_lon(n_csi:1:-1)
       poly_lat = poly_lat(n_csi:1:-1)
       auxx = -auxx
@@ -144,10 +142,10 @@ contains
     do ii = 1, n_csi - 1
       px0 = poly_lon(ii)
       px1 = poly_lon(ii + 1)
-      crosses_dl = abs(px1 - px0) > 180.0_TG_WP
+      crosses_dl = abs(px1 - px0) > 180.0_WP_full
       if (crosses_dl) then
-        if (px0 < 0.0_TG_WP) px0 = px0 + 360.0_TG_WP
-        if (px1 < 0.0_TG_WP) px1 = px1 + 360.0_TG_WP
+        if (px0 < 0.0_WP_full) px0 = px0 + 360.0_WP_full
+        if (px1 < 0.0_WP_full) px1 = px1 + 360.0_WP_full
       end if
 
       call calc_csect_vec(px0, px1, poly_lat(ii), poly_lat(ii + 1), segs(ii))
@@ -158,10 +156,10 @@ contains
 
       ! shift edge_cut_P back to [-180,180] for downstream concat/plotting
       if (crosses_dl .and. segs(ii)%ncut > 0) then
-        where (segs(ii)%edge_cut_P   (1, :) > 180.0_TG_WP) &
-          segs(ii)%edge_cut_P   (1, :) = segs(ii)%edge_cut_P   (1, :) - 360.0_TG_WP
-        where (segs(ii)%edge_cut_midP(1, :) > 180.0_TG_WP) &
-          segs(ii)%edge_cut_midP(1, :) = segs(ii)%edge_cut_midP(1, :) - 360.0_TG_WP
+        where (segs(ii)%edge_cut_P   (1, :) > 180.0_WP_full) &
+          segs(ii)%edge_cut_P   (1, :) = segs(ii)%edge_cut_P   (1, :) - 360.0_WP_full
+        where (segs(ii)%edge_cut_midP(1, :) > 180.0_WP_full) &
+          segs(ii)%edge_cut_midP(1, :) = segs(ii)%edge_cut_midP(1, :) - 360.0_WP_full
       end if
 
       if (segs(ii)%ncut == 0) cycle    ! no crossings — skip this sub-segment
@@ -182,7 +180,7 @@ contains
     ! path_nvec_cs is left as-is from concat_subtransects: each path step
     ! carries its sub-segment's own n_vec (tripyview's _do_build_path:855).
     if (transect%P > 0) then
-      if (n_vec_tot(1) < 0.0_TG_WP .or. n_vec_tot(2) < 0.0_TG_WP) then
+      if (n_vec_tot(1) < 0.0_WP_full .or. n_vec_tot(2) < 0.0_WP_full) then
         transect%path_dx = -transect%path_dx
         transect%path_dy = -transect%path_dy
       end if
@@ -227,26 +225,26 @@ contains
 !> tripyview's _do_calc_csect_vec.
 ! -----------------------------------------------------------------------------
   subroutine calc_csect_vec(x0, x1, y0, y1, seg)
-    real(TG_WP),     intent(in)    :: x0, x1, y0, y1
+    real(WP_full),     intent(in)    :: x0, x1, y0, y1
     type(subseg_t),  intent(inout) :: seg
-    real(TG_WP) :: dx, dy, dn
+    real(WP_full) :: dx, dy, dn
 
     dx = x1 - x0
     dy = y1 - y0
     dn = sqrt(dx*dx + dy*dy)
-    if (dn > 0.0_TG_WP) then
+    if (dn > 0.0_WP_full) then
       seg%e_vec = (/  dx/dn,  dy/dn /)
       ! Per-sub-segment normal with tripyview's conditional flip:
       ! going N (dy > 0) or W (dx < 0) -> clockwise rotation;
       ! otherwise counter-clockwise. Matches sub_transect.py:437-440.
-      if (dy > 0.0_TG_WP .or. dx < 0.0_TG_WP) then
+      if (dy > 0.0_WP_full .or. dx < 0.0_WP_full) then
         seg%n_vec = (/  dy/dn, -dx/dn /)
       else
         seg%n_vec = (/ -dy/dn,  dx/dn /)
       end if
     else
-      seg%e_vec = 0.0_TG_WP
-      seg%n_vec = 0.0_TG_WP
+      seg%e_vec = 0.0_WP_full
+      seg%n_vec = 0.0_WP_full
     end if
     seg%alpha = atan2(seg%e_vec(2), seg%e_vec(1))   ! radians
   end subroutine calc_csect_vec
@@ -266,32 +264,32 @@ contains
   subroutine find_intersected_edges(n_nod, lon_nod, lat_nod, n_edge, edge, &
                                     x0, x1, y0, y1, crosses_dl, seg)
     integer,         intent(in)    :: n_nod, n_edge
-    real(TG_WP),     intent(in)    :: lon_nod(n_nod), lat_nod(n_nod)
+    real(WP_full),     intent(in)    :: lon_nod(n_nod), lat_nod(n_nod)
     integer,         intent(in)    :: edge(2, n_edge)
-    real(TG_WP),     intent(in)    :: x0, x1, y0, y1
+    real(WP_full),     intent(in)    :: x0, x1, y0, y1
     logical,         intent(in)    :: crosses_dl
     type(subseg_t),  intent(inout) :: seg
 
     ! Bounding box (with polar widening)
-    real(TG_WP) :: Pxmin, Pxmax, Pymin, Pymax, Pdx, Pdy
-    real(TG_WP) :: a, b, c, dx10, dy10, dd10
+    real(WP_full) :: Pxmin, Pxmax, Pymin, Pymax, Pdx, Pdy
+    real(WP_full) :: a, b, c, dx10, dy10, dd10
     integer     :: n_cand, n_hit
     integer,     allocatable :: cand_idx(:), hit_idx(:), srt(:)
-    real(TG_WP), allocatable :: x0e(:), y0e(:), x1e(:), y1e(:), dxe(:), dye(:)
-    real(TG_WP), allocatable :: s0(:), s1(:), tparam(:), xi(:), yi(:), fac(:)
-    real(TG_WP), allocatable :: emin_lon(:), emax_lon(:), emin_lat(:), emax_lat(:)
-    real(TG_WP), allocatable :: fac_hit(:)
+    real(WP_full), allocatable :: x0e(:), y0e(:), x1e(:), y1e(:), dxe(:), dye(:)
+    real(WP_full), allocatable :: s0(:), s1(:), tparam(:), xi(:), yi(:), fac(:)
+    real(WP_full), allocatable :: emin_lon(:), emax_lon(:), emin_lat(:), emax_lat(:)
+    real(WP_full), allocatable :: fac_hit(:)
     integer     :: e, j, k
-    real(TG_WP) :: lon_a, lon_b
+    real(WP_full) :: lon_a, lon_b
 
-    Pdx = 10.0_TG_WP   ! tripyview default
-    Pdy = 10.0_TG_WP
+    Pdx = 10.0_WP_full   ! tripyview default
+    Pdy = 10.0_WP_full
     Pxmin = min(x0, x1)
     Pxmax = max(x0, x1)
     Pymin = min(y0, y1)
     Pymax = max(y0, y1)
     ! polar latitude widening (tripyview: Pymin<-70 or Pymax>80 -> Pdx=180)
-    if (Pymin < -70.0_TG_WP .or. Pymax > 80.0_TG_WP) Pdx = 180.0_TG_WP
+    if (Pymin < -70.0_WP_full .or. Pymax > 80.0_WP_full) Pdx = 180.0_WP_full
     Pxmin = Pxmin - Pdx;  Pxmax = Pxmax + Pdx
     Pymin = Pymin - Pdy;  Pymax = Pymax + Pdy
 
@@ -302,8 +300,8 @@ contains
       lon_a = lon_nod(edge(1, e))
       lon_b = lon_nod(edge(2, e))
       if (crosses_dl) then
-        if (lon_a < 0.0_TG_WP) lon_a = lon_a + 360.0_TG_WP
-        if (lon_b < 0.0_TG_WP) lon_b = lon_b + 360.0_TG_WP
+        if (lon_a < 0.0_WP_full) lon_a = lon_a + 360.0_WP_full
+        if (lon_b < 0.0_WP_full) lon_b = lon_b + 360.0_WP_full
       end if
       emin_lon(e) = min(lon_a, lon_b)
       emax_lon(e) = max(lon_a, lon_b)
@@ -350,8 +348,8 @@ contains
       x1e(j) = lon_nod(edge(2, e))
       y1e(j) = lat_nod(edge(2, e))
       if (crosses_dl) then
-        if (x0e(j) < 0.0_TG_WP) x0e(j) = x0e(j) + 360.0_TG_WP
-        if (x1e(j) < 0.0_TG_WP) x1e(j) = x1e(j) + 360.0_TG_WP
+        if (x0e(j) < 0.0_WP_full) x0e(j) = x0e(j) + 360.0_WP_full
+        if (x1e(j) < 0.0_WP_full) x1e(j) = x1e(j) + 360.0_WP_full
       end if
       dxe(j) = x1e(j) - x0e(j)
       dye(j) = y1e(j) - y0e(j)
@@ -362,12 +360,12 @@ contains
     n_hit = 0
     allocate(hit_idx(n_cand), fac_hit(n_cand))
     do j = 1, n_cand
-      if ((s1(j) - s0(j)) == 0.0_TG_WP) cycle    ! parallel — no isolated crossing
+      if ((s1(j) - s0(j)) == 0.0_WP_full) cycle    ! parallel — no isolated crossing
       tparam(j) = s0(j) / (s0(j) - s1(j))
       xi(j) = x0e(j) + tparam(j) * dxe(j)
       yi(j) = y0e(j) + tparam(j) * dye(j)
       fac(j) = ( (xi(j) - x0)*dx10 + (yi(j) - y0)*dy10 ) / dd10
-      if (s0(j)*s1(j) < 0.0_TG_WP .and. fac(j) >= 0.0_TG_WP .and. fac(j) <= 1.0_TG_WP) then
+      if (s0(j)*s1(j) < 0.0_WP_full .and. fac(j) >= 0.0_WP_full .and. fac(j) <= 1.0_WP_full) then
         n_hit = n_hit + 1
         hit_idx(n_hit) = j
         fac_hit(n_hit) = fac(j)
@@ -402,8 +400,8 @@ contains
       seg%edge_cut_lint(k)    = tparam(j)
       seg%edge_cut_P   (1, k) = xi(j)
       seg%edge_cut_P   (2, k) = yi(j)
-      seg%edge_cut_midP(1, k) = x0e(j) + 0.5_TG_WP * dxe(j)
-      seg%edge_cut_midP(2, k) = y0e(j) + 0.5_TG_WP * dye(j)
+      seg%edge_cut_midP(1, k) = x0e(j) + 0.5_WP_full * dxe(j)
+      seg%edge_cut_midP(2, k) = y0e(j) + 0.5_WP_full * dye(j)
       seg%edge_cut_evec(1, k) = dxe(j)
       seg%edge_cut_evec(2, k) = dye(j)
     end do
@@ -430,18 +428,18 @@ contains
   subroutine build_path(n_nod, lon_nod, lat_nod, n_elem, elem_nodes, &
                         edge_tri, edge_cross_dxdy, ncsi, ncs, seg)
     integer,        intent(in)    :: n_nod, n_elem
-    real(TG_WP),    intent(in)    :: lon_nod(n_nod), lat_nod(n_nod)
+    real(WP_full),    intent(in)    :: lon_nod(n_nod), lat_nod(n_nod)
     integer,        intent(in)    :: elem_nodes(3, n_elem)
     integer,        intent(in)    :: edge_tri(2, *)
-    real(TG_WP),    intent(in)    :: edge_cross_dxdy(4, *)
+    real(WP_full),    intent(in)    :: edge_cross_dxdy(4, *)
     integer,        intent(in)    :: ncsi, ncs              ! 1-based sub-seg id, # sub-segs
     type(subseg_t), intent(inout) :: seg
 
     integer  :: edi, nced, eg, el(2)
-    real(TG_WP) :: alpha, ca, sa, theta, auxx, auxy
+    real(WP_full) :: alpha, ca, sa, theta, auxx, auxy
 
     integer,     allocatable :: bei(:), bni(:, :), bcni(:, :)
-    real(TG_WP), allocatable :: bdx(:), bdy(:), bcen(:, :), bxy(:, :)
+    real(WP_full), allocatable :: bdx(:), bdy(:), bcen(:, :), bxy(:, :)
     integer :: pcap, pxycap, pp, pxy_p
 
     nced = seg%ncut
@@ -533,19 +531,19 @@ contains
                            pp, pxy_p, pcap, pxycap, &
                            bei, bni, bcni, bdx, bdy, bcen, bxy)
     integer,        intent(in)    :: edi, nced, ncsi, ncs
-    real(TG_WP),    intent(in)    :: theta
+    real(WP_full),    intent(in)    :: theta
     integer,        intent(in)    :: el(2), eg
     integer,        intent(in)    :: n_nod, n_elem
-    real(TG_WP),    intent(in)    :: lon_nod(n_nod), lat_nod(n_nod)
+    real(WP_full),    intent(in)    :: lon_nod(n_nod), lat_nod(n_nod)
     integer,        intent(in)    :: elem_nodes(3, n_elem)
-    real(TG_WP),    intent(in)    :: edge_cross_dxdy(4, *)
+    real(WP_full),    intent(in)    :: edge_cross_dxdy(4, *)
     type(subseg_t), intent(in)    :: seg
     integer,        intent(inout) :: pp, pxy_p, pcap, pxycap
     integer,        allocatable, intent(inout) :: bei(:), bni(:, :), bcni(:, :)
-    real(TG_WP),    allocatable, intent(inout) :: bdx(:), bdy(:), bcen(:, :), bxy(:, :)
-    real(TG_WP) :: cx, cy
+    real(WP_full),    allocatable, intent(inout) :: bdx(:), bdy(:), bcen(:, :), bxy(:, :)
+    real(WP_full) :: cx, cy
 
-    if (theta >= 0.0_TG_WP) then
+    if (theta >= 0.0_WP_full) then
       ! upsection = LEFT triangle (el(1)), always interior because el(1) > 0
       if (edi == 1) then
         call elem_centroid(el(1), n_nod, lon_nod, lat_nod, n_elem, elem_nodes, cx, cy)
@@ -618,19 +616,19 @@ contains
                              pp, pxy_p, pcap, pxycap, &
                              bei, bni, bcni, bdx, bdy, bcen, bxy)
     integer,        intent(in)    :: edi, nced
-    real(TG_WP),    intent(in)    :: theta
+    real(WP_full),    intent(in)    :: theta
     integer,        intent(in)    :: el(2), eg
     integer,        intent(in)    :: n_nod, n_elem
-    real(TG_WP),    intent(in)    :: lon_nod(n_nod), lat_nod(n_nod)
+    real(WP_full),    intent(in)    :: lon_nod(n_nod), lat_nod(n_nod)
     integer,        intent(in)    :: elem_nodes(3, n_elem)
-    real(TG_WP),    intent(in)    :: edge_cross_dxdy(4, *)
+    real(WP_full),    intent(in)    :: edge_cross_dxdy(4, *)
     type(subseg_t), intent(in)    :: seg
     integer,        intent(inout) :: pp, pxy_p, pcap, pxycap
     integer,        allocatable, intent(inout) :: bei(:), bni(:, :), bcni(:, :)
-    real(TG_WP),    allocatable, intent(inout) :: bdx(:), bdy(:), bcen(:, :), bxy(:, :)
-    real(TG_WP) :: cx, cy
+    real(WP_full),    allocatable, intent(inout) :: bdx(:), bdy(:), bcen(:, :), bxy(:, :)
+    real(WP_full) :: cx, cy
 
-    if (theta >= 0.0_TG_WP) then
+    if (theta >= 0.0_WP_full) then
       ! downsection = RIGHT triangle (el(2)); may be -1 for boundary
       if (el(2) > 0) then
         call elem_centroid(el(2), n_nod, lon_nod, lat_nod, n_elem, elem_nodes, cx, cy)
@@ -676,10 +674,10 @@ contains
   !> boundary edge has no far-side triangle.
   subroutine push_ghost(bei, bni, bcni, bdx, bdy, bcen, pcap, pp)
     integer,     allocatable, intent(inout) :: bei(:), bni(:, :), bcni(:, :)
-    real(TG_WP), allocatable, intent(inout) :: bdx(:), bdy(:), bcen(:, :)
+    real(WP_full), allocatable, intent(inout) :: bdx(:), bdy(:), bcen(:, :)
     integer,                  intent(inout) :: pcap, pp
-    real(TG_WP) :: nan
-    nan = ieee_value(0.0_TG_WP, ieee_quiet_nan)
+    real(WP_full) :: nan
+    nan = ieee_value(0.0_WP_full, ieee_quiet_nan)
     call grow_p(bei, bni, bcni, bdx, bdy, bcen, pcap, pp + 1)
     pp = pp + 1
     bei(pp)     = -1
@@ -765,8 +763,8 @@ contains
 ! -----------------------------------------------------------------------------
   subroutine compute_distance_from_startpoint(t)
     type(transect_t), intent(inout) :: t
-    real(TG_WP), allocatable :: xx(:), yy(:), zz(:), seg(:)
-    real(TG_WP) :: dot, cum
+    real(WP_full), allocatable :: xx(:), yy(:), zz(:), seg(:)
+    real(WP_full) :: dot, cum
     integer :: i
 
     if (t%Pxy > 0) then
@@ -778,12 +776,12 @@ contains
       allocate(seg(t%Pxy - 1))
       do i = 1, t%Pxy - 1
         dot = xx(i)*xx(i+1) + yy(i)*yy(i+1) + zz(i)*zz(i+1)
-        if (dot > 1.0_TG_WP) dot = 1.0_TG_WP
-        if (dot < -1.0_TG_WP) dot = -1.0_TG_WP
+        if (dot > 1.0_WP_full) dot = 1.0_WP_full
+        if (dot < -1.0_WP_full) dot = -1.0_WP_full
         seg(i) = acos(dot) * R_EARTH_KM
       end do
-      cum = 0.0_TG_WP
-      t%path_dist(1) = 0.0_TG_WP
+      cum = 0.0_WP_full
+      t%path_dist(1) = 0.0_WP_full
       do i = 1, t%Pxy - 1
         cum = cum + seg(i)
         t%path_dist(i + 1) = cum
@@ -798,12 +796,12 @@ contains
         call lonlat_to_cart3d(t%edge_cut_midP(1, i), t%edge_cut_midP(2, i), &
                               xx(i), yy(i), zz(i))
       end do
-      t%edge_cut_dist(1) = 0.0_TG_WP
-      cum = 0.0_TG_WP
+      t%edge_cut_dist(1) = 0.0_WP_full
+      cum = 0.0_WP_full
       do i = 1, t%M - 1
         dot = xx(i)*xx(i+1) + yy(i)*yy(i+1) + zz(i)*zz(i+1)
-        if (dot > 1.0_TG_WP) dot = 1.0_TG_WP
-        if (dot < -1.0_TG_WP) dot = -1.0_TG_WP
+        if (dot > 1.0_WP_full) dot = 1.0_WP_full
+        if (dot < -1.0_WP_full) dot = -1.0_WP_full
         cum = cum + acos(dot) * R_EARTH_KM
         t%edge_cut_dist(i + 1) = cum
       end do
@@ -817,11 +815,11 @@ contains
 
   !> Project (lon, lat) in degrees onto the unit sphere.
   subroutine lonlat_to_cart3d(lon_deg, lat_deg, x, y, z)
-    real(TG_WP), intent(in)  :: lon_deg, lat_deg
-    real(TG_WP), intent(out) :: x, y, z
-    real(TG_WP) :: lon, lat, clat
-    lon = lon_deg * real(rad, TG_WP)
-    lat = lat_deg * real(rad, TG_WP)
+    real(WP_full), intent(in)  :: lon_deg, lat_deg
+    real(WP_full), intent(out) :: x, y, z
+    real(WP_full) :: lon, lat, clat
+    lon = lon_deg * real(rad, WP_full)
+    lat = lat_deg * real(rad, WP_full)
     clat = cos(lat)
     x = clat * cos(lon)
     y = clat * sin(lon)
@@ -832,31 +830,31 @@ contains
   !> with a [-180, 180] wrap when the element straddles the dateline.
   subroutine elem_centroid(eid, n_nod, lon_nod, lat_nod, n_elem, elem_nodes, cx, cy)
     integer,     intent(in)  :: eid, n_nod, n_elem
-    real(TG_WP), intent(in)  :: lon_nod(n_nod), lat_nod(n_nod)
+    real(WP_full), intent(in)  :: lon_nod(n_nod), lat_nod(n_nod)
     integer,     intent(in)  :: elem_nodes(3, n_elem)
-    real(TG_WP), intent(out) :: cx, cy
-    real(TG_WP) :: xv(3), yv(3)
+    real(WP_full), intent(out) :: cx, cy
+    real(WP_full) :: xv(3), yv(3)
     integer :: i
     do i = 1, 3
       xv(i) = lon_nod(elem_nodes(i, eid))
       yv(i) = lat_nod(elem_nodes(i, eid))
     end do
     ! periodic boundary shift if the triangle straddles the dateline
-    if (maxval(xv) - minval(xv) > 180.0_TG_WP) then
-      if (count(xv > 0.0_TG_WP) > count(xv < 0.0_TG_WP)) then
-        where (xv < 0.0_TG_WP) xv = xv + 360.0_TG_WP
+    if (maxval(xv) - minval(xv) > 180.0_WP_full) then
+      if (count(xv > 0.0_WP_full) > count(xv < 0.0_WP_full)) then
+        where (xv < 0.0_WP_full) xv = xv + 360.0_WP_full
       else
-        where (xv > 0.0_TG_WP) xv = xv - 360.0_TG_WP
+        where (xv > 0.0_WP_full) xv = xv - 360.0_WP_full
       end if
     end if
-    cx = sum(xv) / 3.0_TG_WP
-    cy = sum(yv) / 3.0_TG_WP
+    cx = sum(xv) / 3.0_WP_full
+    cy = sum(yv) / 3.0_WP_full
   end subroutine elem_centroid
 
   !> Insertion-sort permutation: idx is filled such that arr(idx(i))
   !> is non-decreasing. O(n^2); fine for the few-hundred-crossings size.
   subroutine argsort_real(arr, idx)
-    real(TG_WP), intent(in)  :: arr(:)
+    real(WP_full), intent(in)  :: arr(:)
     integer,     intent(out) :: idx(size(arr))
     integer :: i, j, tmp
     do i = 1, size(arr)
@@ -877,10 +875,10 @@ contains
   !> Geometric-growth resize of a 2 x cap buffer so it can hold at least
   !> `want` entries along its second axis. No-op when cap is large enough.
   subroutine grow_xy(buf, cap, want)
-    real(TG_WP), allocatable, intent(inout) :: buf(:, :)
+    real(WP_full), allocatable, intent(inout) :: buf(:, :)
     integer,                  intent(inout) :: cap
     integer,                  intent(in)    :: want
-    real(TG_WP), allocatable :: tmp(:, :)
+    real(WP_full), allocatable :: tmp(:, :)
     integer :: ncap
     if (want <= cap) return
     ncap = max(want, 2*cap)
@@ -895,11 +893,11 @@ contains
   !> large enough.
   subroutine grow_p(bei, bni, bcni, bdx, bdy, bcen, cap, want)
     integer,     allocatable, intent(inout) :: bei(:), bni(:, :), bcni(:, :)
-    real(TG_WP), allocatable, intent(inout) :: bdx(:), bdy(:), bcen(:, :)
+    real(WP_full), allocatable, intent(inout) :: bdx(:), bdy(:), bcen(:, :)
     integer,                  intent(inout) :: cap
     integer,                  intent(in)    :: want
     integer,     allocatable :: tei(:), tni(:, :), tcni(:, :)
-    real(TG_WP), allocatable :: tdx(:), tdy(:), tcen(:, :)
+    real(WP_full), allocatable :: tdx(:), tdy(:), tcen(:, :)
     integer :: ncap
     if (want <= cap) return
     ncap = max(want, 2*cap)

--- a/src/oce_ale_tracer.F90
+++ b/src/oce_ale_tracer.F90
@@ -401,14 +401,14 @@ subroutine solve_tracers_ale(ice, dynamics, tracers, partit, mesh)
                     request_count = request_count + 1
 
 ! non-blocking communication overlapped with computation in loop
-                    call MPI_IBcast(tracers%data(tr_num_to_send)%values(:, :), tr_arr_slice_count_fix_1, MPI_DOUBLE_PRECISION, &
+                    call MPI_IBcast(tracers%data(tr_num_to_send)%values(:, :), tr_arr_slice_count_fix_1, MPI_WP, &
                                                 group_i, MPI_COMM_FESOM_SAME_RANK_IN_GROUPS, tr_arr_requests(request_count),     MPIerr)
 
                     if(use_MEDUSA) then
-                        call MPI_IBcast(Sinkflx_tr (:, :, tr_num_to_send), Sinkflx_tr_slice_count_fix_1, MPI_DOUBLE_PRECISION, &
+                        call MPI_IBcast(Sinkflx_tr (:, :, tr_num_to_send), Sinkflx_tr_slice_count_fix_1, MPI_WP, &
                                                     group_i, MPI_COMM_FESOM_SAME_RANK_IN_GROUPS, SinkFlx_tr_requests(request_count), MPIerr)
                     endif
-                        call MPI_IBcast(Benthos_tr (:, :, tr_num_to_send), Benthos_tr_slice_count_fix_1, MPI_DOUBLE_PRECISION, &
+                        call MPI_IBcast(Benthos_tr (:, :, tr_num_to_send), Benthos_tr_slice_count_fix_1, MPI_WP, &
                                                     group_i, MPI_COMM_FESOM_SAME_RANK_IN_GROUPS, Benthos_tr_requests(request_count), MPIerr)
                 end if
             end do
@@ -426,13 +426,13 @@ subroutine solve_tracers_ale(ice, dynamics, tracers, partit, mesh)
 
                 request_count = request_count + 1
 
-                call MPI_IBcast(tracers%data(tr_num_end)%values(:, :), tr_arr_slice_count_fix_1, MPI_DOUBLE_PRECISION, &
+                call MPI_IBcast(tracers%data(tr_num_end)%values(:, :), tr_arr_slice_count_fix_1, MPI_WP, &
                                 group_i, MPI_COMM_FESOM_SAME_RANK_IN_GROUPS, tr_arr_requests(request_count),     MPIerr)
                 if(use_MEDUSA) then
-                    call MPI_IBcast(Sinkflx_tr (:, :, tr_num_end), Sinkflx_tr_slice_count_fix_1, MPI_DOUBLE_PRECISION, &
+                    call MPI_IBcast(Sinkflx_tr (:, :, tr_num_end), Sinkflx_tr_slice_count_fix_1, MPI_WP, &
                                     group_i, MPI_COMM_FESOM_SAME_RANK_IN_GROUPS, SinkFlx_tr_requests(request_count), MPIerr)
                 endif
-                    call MPI_IBcast(Benthos_tr (:, :, tr_num_end), Benthos_tr_slice_count_fix_1, MPI_DOUBLE_PRECISION, &
+                    call MPI_IBcast(Benthos_tr (:, :, tr_num_end), Benthos_tr_slice_count_fix_1, MPI_WP, &
                                     group_i, MPI_COMM_FESOM_SAME_RANK_IN_GROUPS, Benthos_tr_requests(request_count), MPIerr)
             end if
         end do

--- a/src/oce_mesh.F90
+++ b/src/oce_mesh.F90
@@ -2429,9 +2429,9 @@ type(t_partit), intent(inout), target :: partit
     end do
     area_glob  = 0.0_WP_full
     area_glob2 = 0.0_WP_full
-    call MPI_AllREDUCE(area_acc,  area_glob,  1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+    call MPI_AllREDUCE(area_acc,  area_glob,  1, MPI_WP_FULL, MPI_SUM, &
         MPI_COMM_FESOM, MPIerr)
-    call MPI_AllREDUCE(area_acc2, area_glob2, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+    call MPI_AllREDUCE(area_acc2, area_glob2, 1, MPI_WP_FULL, MPI_SUM, &
         MPI_COMM_FESOM, MPIerr)
     mesh%ocean_area        = real(area_glob,  WP)
     mesh%ocean_areawithcav = real(area_glob2, WP)

--- a/src/solver.F90
+++ b/src/solver.F90
@@ -144,7 +144,7 @@ subroutine ssh_solve_cg(x, rhs, solverinfo, partit, mesh)
   ! the stopping test -- so rounding here steers the iteration itself rather than
   ! just reporting on it. The vectors (rr/zz/pp/App) and the matrix stay WP: the
   ! bandwidth is theirs, the accuracy is these.
-  ! The MPI_Allreduce calls below already pass MPI_DOUBLE; declaring these
+  ! The MPI_Allreduce calls below pass MPI_WP_FULL to match; declaring these
   ! WP_full makes the buffer type and the declared type agree by construction
   ! rather than by WP happening to be real64.
   real(kind=WP_full)           :: sprod(2), s_old, s_aux, al, be, rtol
@@ -184,7 +184,7 @@ subroutine ssh_solve_cg(x, rhs, solverinfo, partit, mesh)
  s_old = sum(real(rhs(1:myDim_nod2D), WP_full) * real(rhs(1:myDim_nod2D), WP_full))
 #endif
 
-  call MPI_Allreduce(MPI_IN_PLACE, s_old, 1, MPI_DOUBLE, MPI_SUM, partit%MPI_COMM_FESOM, MPIerr)
+  call MPI_Allreduce(MPI_IN_PLACE, s_old, 1, MPI_WP_FULL, MPI_SUM, partit%MPI_COMM_FESOM, MPIerr)
   rtol=solverinfo%soltol*sqrt(s_old/real(nod2D,WP_full))
   ! ==============
   ! Compute r0
@@ -224,7 +224,7 @@ subroutine ssh_solve_cg(x, rhs, solverinfo, partit, mesh)
   s_old = sum(real(rr(1:myDim_nod2D), WP_full) * real(zz(1:myDim_nod2D), WP_full))
 #endif
 
-  call MPI_Allreduce(MPI_IN_PLACE, s_old, 1, MPI_DOUBLE, MPI_SUM, partit%MPI_COMM_FESOM, MPIerr)
+  call MPI_Allreduce(MPI_IN_PLACE, s_old, 1, MPI_WP_FULL, MPI_SUM, partit%MPI_COMM_FESOM, MPIerr)
   
   ! ===============
   ! Iterations
@@ -256,7 +256,7 @@ subroutine ssh_solve_cg(x, rhs, solverinfo, partit, mesh)
  s_aux = sum(real(pp(1:myDim_nod2D), WP_full) * real(App(1:myDim_nod2D), WP_full))
 #endif
 
-  call MPI_Allreduce(MPI_IN_PLACE, s_aux, 1, MPI_DOUBLE, MPI_SUM, partit%MPI_COMM_FESOM, MPIerr)
+  call MPI_Allreduce(MPI_IN_PLACE, s_aux, 1, MPI_WP_FULL, MPI_SUM, partit%MPI_COMM_FESOM, MPIerr)
 
      ! ===========
      ! Breakdown guard. An equivalent check existed until 4eb2f21d ("Removed
@@ -313,7 +313,7 @@ sprod(1:2)=0.0_WP_full
     sprod(2) = sum(real(rr(1:myDim_nod2D), WP_full) * real(rr(1:myDim_nod2D), WP_full))
 #endif
   
-  call MPI_Allreduce(MPI_IN_PLACE, sprod, 2, MPI_DOUBLE, MPI_SUM, partit%MPI_COMM_FESOM, MPIerr)
+  call MPI_Allreduce(MPI_IN_PLACE, sprod, 2, MPI_WP_FULL, MPI_SUM, partit%MPI_COMM_FESOM, MPIerr)
 
 !$OMP BARRIER
      ! ===========

--- a/src/toy_channel_neverworld2.F90
+++ b/src/toy_channel_neverworld2.F90
@@ -248,7 +248,7 @@ MODULE Toy_Neverworld2
         !___________________________________________________________________________
         ! determine latitudinal domain size from mesh
         loc_Ly=omp_min_max_sum1(geo_coord_nod2D(2,:), 1, myDim_nod2D, 'max', partit)
-        call MPI_AllREDUCE(loc_Ly, Ly, 1, MPI_DOUBLE_PRECISION, MPI_MAX, MPI_COMM_FESOM, MPIerr)
+        call MPI_AllREDUCE(loc_Ly, Ly, 1, MPI_WP, MPI_MAX, MPI_COMM_FESOM, MPIerr)
         
         !___________________________________________________________________________
         ! Do windprofile input (momentum flux):


### PR DESCRIPTION
`WP_full` (`o_PARAM`) is real64 regardless of `WP`, but there was no MPI constant to match it.
The ten call sites reducing `WP_full` buffers therefore spelled the datatype raw —
`MPI_DOUBLE_PRECISION` in `gen_support`/`oce_mesh`, `MPI_DOUBLE` (the **C** handle) in `solver`.
Two spellings for one concept, and nothing tying either to the buffer.

That is what keeps breaking. Merging `main` into the SP branch produced this bug **three times in
a single merge**: an auto-merge paired a `WP_full` buffer with `MPI_WP`, or a `WP` buffer with an
8-byte datatype. Both are invisible in a double-precision build, where `WP_full == WP`, and
corrupt memory in a single-precision one — `MPI_WP` is `MPI_REAL` under `USE_SINGLE_PRECISION`,
so it reads four bytes of an eight-byte value, while the reverse writes eight bytes into a
four-byte variable. The observable symptom was `p.Ap=NaN` on the first SSH CG iteration.

### What this adds

`MPI_WP_FULL` beside the existing `MPI_WP` in `MOD_PARTIT.F90`. **Not a new type** — a named
integer constant holding the same handle those sites already passed:

```fortran
real(kind=WP)      -> MPI_WP
real(kind=WP_full) -> MPI_WP_FULL
```

The rule is stated by how the buffer is **declared**, for *any* MPI operation — reduce, bcast,
gather, scatter, send/recv — not by whether the call is a reduction. Today every `WP_full` buffer
happens to sit in a reduction; naming it by kind is what makes the rule hold for code not yet
written.

Converted: `gen_support.F90` (4), `oce_mesh.F90` (2), `solver.F90` (4).

### Deliberately not converted

Buffers declared `real(real64)` *independently* of `WP_full` — `gen_halo_exchange`'s
`gather_nod2D/nod3D/elem2D/elem3D`, `io_scatter`, `io_gather`. Those are double-precision APIs by
design, each with `real4` and `int2` sibling routines chosen by the caller's kind, and they keep
`MPI_DOUBLE_PRECISION`. Claiming they track `WP_full` would be wrong. Verified untouched: 12
`MPI_DOUBLE_PRECISION` uses remain across those three files, and only 4 files change here.

Likewise untouched because they are already correct: `loc_max`/`glob_max` in `gen_support` and
`aux`/`vol_n`/`vol_e` in `oce_mesh` use `MPI_WP` on `WP` buffers.

### Verification

- DP suite **9/9**, SP suite **9/9** (`-E '^(remote_|ecbundle_)'`)
- DP output **bitwise identical to `main`** — `tests/perf/nc_diff.py` against a freshly built
  pristine-main baseline: `WORST_REL=0.000e+00 NAN=0` on `integration_pi_mpi2` and
  `integration_pi_cavity_mpi2`

The bitwise gate is the meaningful one: `MPI_WP_FULL` is the same handle, so any difference would
mean a wrong site was converted.

### Follow-up

This is the naming half. A separate PR will fix the sites where the datatype is genuinely wrong —
`MPI_DOUBLE_PRECISION` on `real(kind=WP)` buffers — which is the correctness half.
