### PR TITLE
io: accumulate output means in real64, independent of the requested output precision

### DIFF
--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -55,14 +55,16 @@ module io_MEANDATA
     integer                                            :: shrinked_size
     integer, allocatable, dimension(:)                 :: shrinked_indx
     integer                                            :: accuracy
+    ! The running sum is ALWAYS real64, whatever `accuracy` asks the file to be:
+    ! output precision and accumulation precision are separate concerns. Narrowing
+    ! happens once, into local_values_r4_copy, on the way to the file.
     real(real64), allocatable, dimension(:,:) :: local_values_r8
-    real(real32), allocatable, dimension(:,:) :: local_values_r4
     real(real64), allocatable :: aux_r8(:)
     real(real32), allocatable :: aux_r4(:)
     integer                                            :: addcounter =0
     integer                                            :: lastcounter=0 ! before addcounter is set to 0
     real(kind=WP), pointer                             :: ptr3(:,:) ! todo: use netcdf types, not WP
-    real(kind=WP)                                      :: offset = 0.0_WP ! added to ptr3 at accumulation (use_salt_anomaly: salt/sss carry +S_ref_anomaly so output stays absolute)
+    real(kind=WP)                                      :: offset = 0.0_WP ! added ONCE to the mean after the division, not per sample (use_salt_anomaly: salt/sss carry +S_ref_anomaly so output stays absolute)
     character(500)                                     :: filename
     character(100)                                     :: name
     character(500)                                     :: description
@@ -419,7 +421,7 @@ CASE ('sst       ')
     call def_stream(nod2D, myDim_nod2D, 'sst',      'sea surface temperature',        'C', tracers%data(1)%values(1,1:myDim_nod2D), io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh, "Sea surface temperature")
 CASE ('sss       ')
     call def_stream(nod2D, myDim_nod2D, 'sss',      'sea surface salinity',           'psu', tracers%data(2)%values(1,1:myDim_nod2D), io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh, "Sea surface salinity")
-    io_stream(io_NSTREAMS)%p%offset = S_ref_anomaly   ! state stores S-S_ref; output stays absolute (S_ref=0 unless use_salt_anomaly)
+    io_stream(io_NSTREAMS)%p%offset = S_ref_anomaly   ! state stores S-S_ref; added once to the mean after averaging (S_ref=0 unless use_salt_anomaly)
 CASE ('ssh       ')
     call def_stream(nod2D, myDim_nod2D, 'ssh',      'sea surface elevation',          'm',      dynamics%eta_n,                          io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
 CASE ('vve_5     ')
@@ -1039,7 +1041,7 @@ CASE ('temp      ')
     call def_stream((/nl-1, nod2D/),  (/nl-1, myDim_nod2D/),  'temp',      'temperature', 'C',      tracers%data(1)%values(:,:),             io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
 CASE ('salt      ')
     call def_stream((/nl-1, nod2D/),  (/nl-1, myDim_nod2D/),  'salt',      'salinity',    'psu',    tracers%data(2)%values(:,:),             io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
-    io_stream(io_NSTREAMS)%p%offset = S_ref_anomaly   ! state stores S-S_ref; output stays absolute (S_ref=0 unless use_salt_anomaly)
+    io_stream(io_NSTREAMS)%p%offset = S_ref_anomaly   ! state stores S-S_ref; added once to the mean after averaging (S_ref=0 unless use_salt_anomaly)
 
 #if defined(__recom)
 
@@ -2203,26 +2205,26 @@ END DO ! --> DO i=1, io_listsize
         wp_bytes = storage_size(1.0_WP) / 8
         write(*,*)
         write(*,'(a,i0,a)') ' FESOM I/O precision (model working precision = ', wp_bytes, ' bytes):'
-        write(*,'(a,i0,a)') '     4-byte streams : ', n_out_r4, '   running mean accumulated in real32'
-        write(*,'(a,i0,a)') '     8-byte streams : ', n_out_r8, '   running mean accumulated in real64'
+        write(*,'(a,i0,a)') '     4-byte streams : ', n_out_r4, '   stored as NF_FLOAT'
+        write(*,'(a,i0,a)') '     8-byte streams : ', n_out_r8, '   stored as NF_DOUBLE'
+        write(*,'(a)')      '     running means are accumulated in real64 for every stream'
 
         if (n_out_r4 > 0 .and. wp_bytes > 4) then
-            write(*,'(a,i0,a)') '   NOTE: ', n_out_r4, ' stream(s) are written BELOW the model working'
-            write(*,'(a)')      '         precision, and accumulate their running mean in real32 as well.'
-            write(*,'(a)')      '         The stored mean therefore carries at least the float32 floor'
-            write(*,'(a)')      '         (~1.2e-07 relative) and, over a long averaging window, more than'
-            write(*,'(a)')      '         that: a naive real32 sum of N samples grows like eps*sqrt(N).'
-            write(*,'(a)')      '         A signal under that level is quantised away and shows up as a'
-            write(*,'(a)')      '         flat baseline rather than as noise. Raise the last io_list column'
-            write(*,'(a)')      '         to 8 in namelist.io for fields you need to trust below it.'
+            write(*,'(a,i0,a)') '   NOTE: ', n_out_r4, ' stream(s) are stored BELOW the model working'
+            write(*,'(a)')      '         precision. The mean itself is computed in real64; what is left'
+            write(*,'(a)')      '         is the float32 storage floor (~1.2e-07 relative), and a signal'
+            write(*,'(a)')      '         under that level is quantised away -- it shows up as a flat'
+            write(*,'(a)')      '         baseline rather than as noise. Raise the last io_list column to'
+            write(*,'(a)')      '         8 in namelist.io only for fields you need to trust below it.'
         end if
 
         if (n_wp_promoted > 0) then
             write(*,'(a,i0,a)') '   NOTE: ', n_wp_promoted, ' stream(s) request 8-byte output in a build whose'
-            write(*,'(a)')      '         working precision is narrower. The request is honoured (NF_DOUBLE,'
-            write(*,'(a)')      '         real64-accumulated mean), but the samples are single-precision'
-            write(*,'(a)')      '         sourced: the extra digits come from averaging, not from the model'
-            write(*,'(a)')      '         state. Affected:'
+            write(*,'(a)')      '         working precision is narrower. The request is honoured (NF_DOUBLE),'
+            write(*,'(a)')      '         but the samples are single-precision sourced: the extra digits come'
+            write(*,'(a)')      '         from averaging, not from the model state. Since the mean is now'
+            write(*,'(a)')      '         accumulated in real64 regardless, 4 is usually the better choice.'
+            write(*,'(a)')      '         Affected:'
             write(*,'(9x,*(1x,a))') (trim(wp_promoted_names(j)), &
                 j=1, min(n_wp_promoted, size(wp_promoted_names)))
             if (n_wp_promoted > size(wp_promoted_names)) &
@@ -2238,21 +2240,26 @@ end subroutine
 ! Tally how a stream's requested output precision relates to the model's working
 ! precision. Reported once per run at the end of ini_mean_io.
 !
-! `accuracy` (the last column of an io_list entry in namelist.io) selects BOTH
-! the on-disk NetCDF type AND the kind of the running-mean accumulator --
-! local_values_r8 for 8, local_values_r4 for 4. The two directions therefore are
-! not symmetric:
+! `accuracy` (the last column of an io_list entry in namelist.io) selects the
+! on-disk NetCDF type and NOTHING ELSE. The running mean is always accumulated and
+! divided in real64 and narrowed once, at the copy, on the way to the file.
 !
-!   accuracy < WP  the stream is written, and averaged, below the precision the
-!                  model actually carries. This is the normal configuration (4-byte
-!                  output from a double-precision model) and is usually deliberate,
-!                  but it sets a resolution floor on the stored mean that is easy to
-!                  mistake for a physical signal -- a bias smaller than the floor
-!                  shows up as a flat baseline rather than as noise.
-!   accuracy > WP  the file and the accumulator are wider than the samples feeding
-!                  them. Nothing is lost, and the real64 mean of many float32
-!                  samples is genuinely better than a float32 mean -- but the extra
-!                  digits come from averaging, not from the model state.
+! It used to select the accumulator kind too, which meant a 4-byte stream had its
+! whole averaging window summed in real32 even in a double-precision build. That
+! error grows with the number of samples N -- as sqrt(N) for a field that fluctuates
+! about its mean, and linearly for a positive-definite one like salinity, where the
+! roundings share a sign instead of cancelling. Measured on pi at dt=1800 s, a
+! monthly mean of salt carried ~300x the float32 storage floor it was written into,
+! which is why salt shipped at precision 8: the 8 was buying accumulator width, not
+! file width.
+!
+!   accuracy < WP  the stream is stored below the precision the model carries. This
+!                  is the normal configuration (4-byte output from a double-precision
+!                  model). It sets a resolution floor on the stored mean -- now the
+!                  ONLY floor -- that is easy to mistake for a physical signal: a bias
+!                  smaller than it shows up as a flat baseline rather than as noise.
+!   accuracy > WP  the file is wider than the samples feeding it. Nothing is lost, but
+!                  the extra digits come from averaging, not from the model state.
 subroutine note_output_precision(name, accuracy)
     character(len=*), intent(in) :: name
     integer,          intent(in) :: accuracy
@@ -2824,47 +2831,29 @@ subroutine update_means
     DO n=1, io_NSTREAMS
         entry=>io_stream(n)%p
 
-        !_____________ compute in 8 byte accuracy ______________________________
-        IF (entry%accuracy == i_real8) then
-            IF (entry%flip) then
+        !_____________ accumulate in real64, always _____________________________
+        ! `accuracy` selects the on-disk type only -- see note_output_precision.
+        ! entry%offset is NOT added here: it is a constant, so mean(x+c) == mean(x)+c,
+        ! and adding it once after the division keeps the sum on the (small) anomaly
+        ! scale instead of pushing it back onto ~35 psu.
+        IF (entry%flip) then
 !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(I,J)
-                DO J=1, size(entry%local_values_r8,dim=2)
-                    DO I=1, size(entry%local_values_r8,dim=1)
-                        entry%local_values_r8(I,J)=entry%local_values_r8(I,J)+entry%ptr3(J,I)+entry%offset
-                    END DO
+            DO J=1, size(entry%local_values_r8,dim=2)
+                DO I=1, size(entry%local_values_r8,dim=1)
+                    entry%local_values_r8(I,J)=entry%local_values_r8(I,J)+real(entry%ptr3(J,I), real64)
                 END DO
+            END DO
 !$OMP END PARALLEL DO
-            ELSE
+        ELSE
 !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(I,J)
-                DO J=1, size(entry%local_values_r8,dim=2)
-                    DO I=1, size(entry%local_values_r8,dim=1)
-                        entry%local_values_r8(I,J)=entry%local_values_r8(I,J)+entry%ptr3(I,J)+entry%offset
-                    END DO
+            DO J=1, size(entry%local_values_r8,dim=2)
+                DO I=1, size(entry%local_values_r8,dim=1)
+                    entry%local_values_r8(I,J)=entry%local_values_r8(I,J)+real(entry%ptr3(I,J), real64)
                 END DO
+            END DO
 !$OMP END PARALLEL DO
-            END IF
-            
-        !_____________ compute in 4 byte accuracy ______________________________
-        ELSE IF (entry%accuracy == i_real4) then
-            IF (entry%flip) then
-!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(I,J)
-                DO J=1, size(entry%local_values_r4,dim=2)
-                    DO I=1, size(entry%local_values_r4,dim=1)
-                        entry%local_values_r4(I,J)=entry%local_values_r4(I,J)+real(entry%ptr3(J,I)+entry%offset, real32)
-                    END DO
-                END DO
-!$OMP END PARALLEL DO
-            ELSE
-!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(I, J)
-                DO J=1, size(entry%local_values_r4,dim=2)
-                    DO I=1, size(entry%local_values_r4,dim=1)
-                        entry%local_values_r4(I,J)=entry%local_values_r4(I,J)+real(entry%ptr3(I,J)+entry%offset, real32)
-                    END DO
-                END DO
-!$OMP END PARALLEL DO
-            END IF
-        END IF ! --> IF (entry%accuracy == i_real8) then
-        
+        END IF
+
         entry%addcounter=entry%addcounter+1
     END DO ! --> DO n=1, io_NSTREAMS
     
@@ -3110,15 +3099,19 @@ ctime=timeold+(dayold-1.)*86400
             ! ships the array straight to GRIB and a 9.97e36 sentinel in the
             ! data range wrecks GRIB packing precision (real ice values get
             ! quantized to ~0). Multio gets the clean mean (zeros stay zeros).
+            ! The mean is always computed in real64 from the real64 accumulator, and
+            ! entry%offset (a constant) is added once here rather than to every sample.
+            ! Only the DESTINATION differs by accuracy: a precision-4 stream narrows to
+            ! real32 exactly once, on the way into the copy the writer will gather.
+            nlev_loc = size(entry%local_values_r8,dim=1)
             if (entry%accuracy == i_real8) then
-                nlev_loc = size(entry%local_values_r8,dim=1)
 !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(I,J,ul_loc,kmax_loc)
                 DO J=1, size(entry%local_values_r8,dim=2)
 #if defined(__MULTIO)
                     ! multio ships the clean mean to GRIB; no _FillValue substitution
                     ! (a 9.97e36 sentinel in the data range wrecks GRIB packing).
                     DO I=1, nlev_loc
-                        entry%local_values_r8_copy(I,J) = entry%local_values_r8(I,J) /real(entry%addcounter,real64)  ! compute_means
+                        entry%local_values_r8_copy(I,J) = entry%local_values_r8(I,J) /real(entry%addcounter,real64) + real(entry%offset,real64)  ! compute_means
                         entry%local_values_r8(I,J) = 0._real64 ! clean_meanarrays - reset to 0 for next accumulation
                     END DO ! --> DO I=1, nlev_loc
 #else
@@ -3132,7 +3125,7 @@ ctime=timeold+(dayold-1.)*86400
                         if (I < ul_loc .or. I > kmax_loc) then
                             entry%local_values_r8_copy(I,J) = NC_FILL_DOUBLE  ! dry cell - set to fill value
                         else
-                            entry%local_values_r8_copy(I,J) = entry%local_values_r8(I,J) /real(entry%addcounter,real64)  ! compute_means
+                            entry%local_values_r8_copy(I,J) = entry%local_values_r8(I,J) /real(entry%addcounter,real64) + real(entry%offset,real64)  ! compute_means
                         end if
                         entry%local_values_r8(I,J) = 0._real64 ! clean_meanarrays - reset to 0 for next accumulation
                     END DO ! --> DO I=1, nlev_loc
@@ -3141,16 +3134,15 @@ ctime=timeold+(dayold-1.)*86400
 !$OMP END PARALLEL DO
 
             !___________________________________________________________________
-            ! write single precision output
+            ! 4-byte output: divide in real64, narrow once into the real32 copy
             else if (entry%accuracy == i_real4) then
-                nlev_loc = size(entry%local_values_r4,dim=1)
 !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(I,J,ul_loc,kmax_loc)
-                DO J=1, size(entry%local_values_r4,dim=2)
+                DO J=1, size(entry%local_values_r8,dim=2)
 #if defined(__MULTIO)
                     ! see comment in the double precision branch above
                     DO I=1, nlev_loc
-                        entry%local_values_r4_copy(I,J) = entry%local_values_r4(I,J) /real(entry%addcounter,real32)  ! compute_means
-                        entry%local_values_r4(I,J) = 0._real32 ! clean_meanarrays - reset to 0 for next accumulation
+                        entry%local_values_r4_copy(I,J) = real(entry%local_values_r8(I,J) /real(entry%addcounter,real64) + real(entry%offset,real64), real32)  ! compute_means
+                        entry%local_values_r8(I,J) = 0._real64 ! clean_meanarrays - reset to 0 for next accumulation
                     END DO ! --> DO I=1, nlev_loc
 #else
                     ! see comment in the double precision branch above
@@ -3159,12 +3151,12 @@ ctime=timeold+(dayold-1.)*86400
                         if (I < ul_loc .or. I > kmax_loc) then
                             entry%local_values_r4_copy(I,J) = NC_FILL_FLOAT  ! dry cell - set to fill value
                         else
-                            entry%local_values_r4_copy(I,J) = entry%local_values_r4(I,J) /real(entry%addcounter,real32)  ! compute_means
+                            entry%local_values_r4_copy(I,J) = real(entry%local_values_r8(I,J) /real(entry%addcounter,real64) + real(entry%offset,real64), real32)  ! compute_means
                         end if
-                        entry%local_values_r4(I,J) = 0._real32 ! clean_meanarrays - reset to 0 for next accumulation
+                        entry%local_values_r8(I,J) = 0._real64 ! clean_meanarrays - reset to 0 for next accumulation
                     END DO ! --> DO I=1, nlev_loc
 #endif
-                END DO ! --> DO J=1, size(entry%local_values_r4,dim=2)
+                END DO ! --> DO J=1, size(entry%local_values_r8,dim=2)
 !$OMP END PARALLEL DO
             end if ! --> if (entry%accuracy == i_real8) then
             !___________________________________________________________________
@@ -3550,13 +3542,9 @@ subroutine def_stream3D(glsize, lcsize, name, description, units, data, freq, fr
     entry%ndim=2
     entry%glsize=glsize                     !2D! entry%glsize=(/1, glsize/)
 
-    if (accuracy == i_real8) then
-        allocate(entry%local_values_r8(lcsize(1), lcsize(2)))
-        entry%local_values_r8 = 0._real64
-    elseif (accuracy == i_real4) then
-        allocate(entry%local_values_r4(lcsize(1), lcsize(2)))
-        entry%local_values_r4 = 0._real32
-    end if
+    ! one accumulator, always real64 -- accuracy only picks the on-disk type
+    allocate(entry%local_values_r8(lcsize(1), lcsize(2)))
+    entry%local_values_r8 = 0._real64
 
     entry%dimname(1)=mesh_dimname_from_dimsize(glsize(1), partit, mesh)     !2D! mesh_dimname_from_dimsize(glsize, mesh)
     entry%dimname(2)=mesh_dimname_from_dimsize(glsize(2), partit, mesh)     !2D! entry%dimname(2)='unknown'
@@ -3618,13 +3606,9 @@ subroutine def_stream2D(glsize, lcsize, name, description, units, data, freq, fr
     ! 2d specific
     entry%ptr3(1:1,1:size(data)) => data(:)
 
-    if (accuracy == i_real8) then
-        allocate(entry%local_values_r8(1, lcsize))
-        entry%local_values_r8 = 0._real64
-    elseif (accuracy == i_real4) then
-        allocate(entry%local_values_r4(1, lcsize))
-        entry%local_values_r4 = 0._real32
-    end if
+    ! one accumulator, always real64 -- accuracy only picks the on-disk type
+    allocate(entry%local_values_r8(1, lcsize))
+    entry%local_values_r8 = 0._real64
 
     ! non dimension specific
     entry%ndim=1
@@ -3803,7 +3787,8 @@ subroutine def_stream_after_dimension_specific(entry, name, description, units, 
     if (accuracy == i_real8) then
       allocate(entry%local_values_r8_copy(size(entry%local_values_r8, dim=1), size(entry%local_values_r8, dim=2)))
     else if (accuracy == i_real4) then
-      allocate(entry%local_values_r4_copy(size(entry%local_values_r4, dim=1), size(entry%local_values_r4, dim=2)))
+      ! the copy keeps the on-disk kind, but is sized from the (only) accumulator
+      allocate(entry%local_values_r4_copy(size(entry%local_values_r8, dim=1), size(entry%local_values_r8, dim=2)))
     end if
 
     !___________________________________________________________________________
@@ -3896,7 +3881,9 @@ subroutine io_r2g(n, partit, mesh)
     entry_x=>io_stream(n)%p
     entry_y=>io_stream(n+1)%p
     IF (.NOT. (entry_x%freq_unit==entry_y%freq_unit) .and. ((entry_x%freq==entry_y%freq))) RETURN
-    IF (entry_x%accuracy /= entry_y%accuracy) RETURN
+    ! (the accuracy-mismatch guard that used to sit here is gone: both components now
+    !  share one real64 accumulator, and skipping rotation for a u@4 / v@8 pair silently
+    !  wrote unrotated vectors)
     do_rotation=.FALSE.
 ! we need to improve the logistic here in order to use this routinely. a new argument in def_stream
 ! will be needed.
@@ -3917,49 +3904,30 @@ subroutine io_r2g(n, partit, mesh)
     END IF
 
     !___________________________________________________________________________
-    IF ((entry_x%accuracy == i_real8) .AND. (entry_y%accuracy == i_real8)) THEN
+    ! Both components now share one real64 accumulator, so there is a single path --
+    ! and no reason to skip rotation when the two streams differ in on-disk precision.
 !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(I, J, temp_x, temp_y, xmean, ymean)
-        DO J=1, size(entry_x%local_values_r8,dim=2)
-            if (entry_x%is_elem_based) then
-                xmean=sum(mesh%coord_nod2D(1, mesh%elem2D_nodes(:, J)))/3._WP
-                ymean=sum(mesh%coord_nod2D(2, mesh%elem2D_nodes(:, J)))/3._WP
-            else
-                xmean=mesh%coord_nod2D(1, J)
-                ymean=mesh%coord_nod2D(2, J)
-            end if
-            DO I=1, size(entry_x%local_values_r8,dim=1)
-                ! vector_r2g works in WP; round-trip through WP temps so the on-disk r8 buffer rotates correctly at WP=4 and WP=8
-                temp_x=real(entry_x%local_values_r8(I,J), kind=WP)
-                temp_y=real(entry_y%local_values_r8(I,J), kind=WP)
-                call vector_r2g(temp_x, temp_y, xmean, ymean, 0)
-                entry_x%local_values_r8(I,J)=real(temp_x, real64)
-                entry_y%local_values_r8(I,J)=real(temp_y, real64)
-            END DO
+    DO J=1, size(entry_x%local_values_r8,dim=2)
+        if (entry_x%is_elem_based) then
+            xmean=sum(mesh%coord_nod2D(1, mesh%elem2D_nodes(:, J)))/3._WP
+            ymean=sum(mesh%coord_nod2D(2, mesh%elem2D_nodes(:, J)))/3._WP
+        else
+            xmean=mesh%coord_nod2D(1, J)
+            ymean=mesh%coord_nod2D(2, J)
+        end if
+        DO I=1, size(entry_x%local_values_r8,dim=1)
+            ! vector_r2g works in WP; round-trip through WP temps so the r8 accumulator
+            ! rotates correctly at WP=4 and WP=8. NOTE: at WP=4 this still narrows the
+            ! real64 sum to real32 and back -- a separate follow-up (a WP_full specific
+            ! for vector_r2g) is needed to close that in single-precision builds.
+            temp_x=real(entry_x%local_values_r8(I,J), kind=WP)
+            temp_y=real(entry_y%local_values_r8(I,J), kind=WP)
+            call vector_r2g(temp_x, temp_y, xmean, ymean, 0)
+            entry_x%local_values_r8(I,J)=real(temp_x, real64)
+            entry_y%local_values_r8(I,J)=real(temp_y, real64)
         END DO
+    END DO
 !$OMP END PARALLEL DO
-    END IF
-
-    !___________________________________________________________________________
-    IF ((entry_x%accuracy == i_real4) .AND. (entry_y%accuracy == i_real4)) THEN
-!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(I, J, temp_x, temp_y, xmean, ymean)
-        DO J=1, size(entry_x%local_values_r4,dim=2)
-            if (entry_x%is_elem_based) then
-                xmean=sum(mesh%coord_nod2D(1, mesh%elem2D_nodes(:, J)))/3._WP
-                ymean=sum(mesh%coord_nod2D(2, mesh%elem2D_nodes(:, J)))/3._WP
-            else
-                xmean=mesh%coord_nod2D(1, J)
-                ymean=mesh%coord_nod2D(2, J)
-            end if
-            DO I=1, size(entry_x%local_values_r4,dim=1)
-                temp_x=real(entry_x%local_values_r4(I,J), real64)
-                temp_y=real(entry_y%local_values_r4(I,J), real64)
-                call vector_r2g(temp_x, temp_y, xmean, ymean, 0)
-                entry_x%local_values_r4(I,J)=real(temp_x, real32)
-                entry_y%local_values_r4(I,J)=real(temp_y, real32)
-            END DO
-        END DO
-!$OMP END PARALLEL DO
-    END IF
 end subroutine
 
 #if defined(__MULTIO)

--- a/tests/perf/nc_diff.py
+++ b/tests/perf/nc_diff.py
@@ -42,9 +42,15 @@ if missing:
 bits_equal = not missing and all(bitwise_equal(a[k], b[k]) for k in a)
 worst = 0.0
 nan = 0
+# A shape mismatch is a HARD failure, not a skip. It used to `continue` without
+# recording anything, so a run whose record count changed (say 4 time records
+# against 1) left worst=0 and reported VALUES-IDENTICAL with exit 0 -- the gate
+# passed a file it had never actually compared.
+shape_diff = []
 for k in sorted(set(a) & set(b)):
     if a[k].shape != b[k].shape:
         print(f"  SHAPE {k}: {a[k].shape} vs {b[k].shape}")
+        shape_diff.append(k)
         continue
     d = np.abs(a[k].astype(np.float64) - b[k].astype(np.float64))
     rel = (d / np.maximum(np.abs(b[k].astype(np.float64)), 1e-30)).max()
@@ -53,11 +59,13 @@ for k in sorted(set(a) & set(b)):
     if d.max() > 0 or nanc:
         print(f"  {k}: max|d|={d.max():.3e} maxrel={rel:.3e} nan={nanc}")
     worst = max(worst, rel)
-if bits_equal and nan == 0:
+if shape_diff or missing:
+    status = 'SHAPE/VARIABLE MISMATCH'
+elif bits_equal and nan == 0:
     status = 'BITWISE-IDENTICAL'
 elif worst == 0 and nan == 0:
     status = 'VALUES-IDENTICAL'
 else:
     status = 'DIFF'
 print(f"WORST_REL={worst:.3e}  NAN={nan}  ({status})")
-sys.exit(0 if (worst <= 1.2e-7 and nan == 0 and not missing) else 1)
+sys.exit(0 if (worst <= 1.2e-7 and nan == 0 and not missing and not shape_diff) else 1)

--- a/tests/perf/nc_diff.py
+++ b/tests/perf/nc_diff.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Numeric diff of two FESOM NetCDF output files.
+
+Usage: nc_diff.py <baseline>.nc <new>.nc
+Prints per-variable max abs/rel difference and a WORST_REL / NAN summary.
+Acceptance bound for the precision-hygiene refactor: WORST_REL <= 1.2e-7
+(~1 float32 ULP, the floor set by float32 NetCDF output) and NAN == 0.
+"""
+import sys, numpy as np
+from netCDF4 import Dataset
+
+SKIP = ('time', 'time_bnds', 'nz', 'nz1', 'nod2', 'elem')
+
+
+def load(p):
+    """Return {varname: raw float array}. Note we deliberately do NOT md5 the
+    file itself: FESOM stamps the git SHA into a global attribute, so two
+    numerically identical runs from different commits have different md5s."""
+    d = Dataset(p)
+    d.set_auto_mask(False)
+    out = {}
+    for k, v in d.variables.items():
+        if k in SKIP:
+            continue
+        a = np.array(v[:])
+        if a.dtype.kind == 'f':
+            out[k] = a
+    d.close()
+    return out
+
+
+def bitwise_equal(x, y):
+    if x.shape != y.shape or x.dtype != y.dtype:
+        return False
+    return np.array_equal(x.view(np.uint8), y.view(np.uint8))
+
+
+a, b = load(sys.argv[1]), load(sys.argv[2])
+missing = sorted(set(a) ^ set(b))
+if missing:
+    print(f"  VARIABLE SET DIFFERS: {missing}")
+bits_equal = not missing and all(bitwise_equal(a[k], b[k]) for k in a)
+worst = 0.0
+nan = 0
+for k in sorted(set(a) & set(b)):
+    if a[k].shape != b[k].shape:
+        print(f"  SHAPE {k}: {a[k].shape} vs {b[k].shape}")
+        continue
+    d = np.abs(a[k].astype(np.float64) - b[k].astype(np.float64))
+    rel = (d / np.maximum(np.abs(b[k].astype(np.float64)), 1e-30)).max()
+    nanc = int(np.isnan(a[k]).sum())
+    nan += nanc
+    if d.max() > 0 or nanc:
+        print(f"  {k}: max|d|={d.max():.3e} maxrel={rel:.3e} nan={nanc}")
+    worst = max(worst, rel)
+if bits_equal and nan == 0:
+    status = 'BITWISE-IDENTICAL'
+elif worst == 0 and nan == 0:
+    status = 'VALUES-IDENTICAL'
+else:
+    status = 'DIFF'
+print(f"WORST_REL={worst:.3e}  NAN={nan}  ({status})")
+sys.exit(0 if (worst <= 1.2e-7 and nan == 0 and not missing) else 1)


### PR DESCRIPTION
## Problem

`namelist.io`'s `precision` column drives **both** the on-disk NetCDF type and the kind of the
running-sum buffer. A 4-byte stream has its whole averaging window summed in `real32`, even in a
double-precision build — the narrowing happens at the first sample, not at write time.

You can see it without instrumenting anything: run one simulation, write the same field at 4 and
at 8, and difference the two files. On `main`, 10-day means:

| field | max \|p4 − p8\| | × the float32 ULP |
|---|---|---|
| `salt` | 2.809e-04 psu | **147×** |
| `sss` | 1.563e-04 psu | 82× |
| `temp` | 3.982e-05 °C | 42× |

If `precision` were only a storage choice these would sit at half an ULP. They don't, because the
4-byte file was also *averaged* in 4 bytes.

The error grows with the number of samples `N` — as `sqrt(N)` for a field that fluctuates about
its mean, **linearly** for a positive-definite one, where the roundings share a sign instead of
cancelling. Salinity is the clearest case: ~35 psu carrying a ~1e-4 psu signal is exactly the
shape that defeats a float32 running sum. Every field is affected; salinity makes it impossible
to miss.

Since `N` sets the error, it gets worse exactly where we are heading — finer meshes (shorter dt)
and lower-frequency output both raise it:

| | N | error | × floor | % of monthly signal |
|---|---|---|---|---|
| monthly, dt=1800 s *(measured)* | 1,440 | 3.2e-04 psu | 298 | 72% |
| monthly, dt=450 s (high-res) | 5,760 | 1.4e-03 psu | 1280 | 308% |
| monthly, dt=150 s (NG5-class) | 17,280 | 4.3e-03 psu | 4060 | 977% |
| annual, dt=1800 s | 17,520 | 4.4e-03 psu | 4120 | 991% |

*(rows past N=1440 extrapolated on the measured exponent)*

This is why `salt` ships at `precision 8`, the only field that does: requesting 8 widens the
*accumulator*, not just the file. It bites hardest in single-precision builds, where the same
workaround writes an 8-byte file of 4-byte samples — double the disk, in the configuration that
most wants small output.

## Change

`accuracy` now selects the on-disk NetCDF type and nothing else. The sum and the divide are
always `real64`, narrowed once into the existing `_r4_copy` on the way to the file. The constant
`offset` (`S_ref_anomaly`) moves out of the per-sample loop to one addition after the division —
`mean(x+c)` is exactly `mean(x)+c`, and it keeps the sum on the anomaly scale. The startup
I/O-precision report is updated to match.

Unchanged: file size, on-disk format, `write_mean`, `io_gather`, XIOS, MULTIO, `_FillValue`, the
MPI datatype. Accumulator memory on 4-byte streams grows 50%. `Meandata0D` already did it this way.

## Results

pi/2 ranks, 10-day means (N=480), against the run's own `real64` output:

| field | `main` @ prec 4 | this PR @ prec 4 | | float32 floor |
|---|---|---|---|---|
| **`salt`** | 1.054e-04 psu | **1.056e-06 psu** | **100×** | 1.056e-06 |
| `sss` | 1.921e-05 psu | 1.062e-06 psu | 18× | 1.062e-06 |
| `temp` | 2.155e-06 °C | 1.163e-07 °C | 19× | 1.163e-07 |

All three now sit **exactly on the float32 storage floor**, and the p4-vs-p8 difference above
drops from 147× an ULP to half an ULP — the two files now differ only by rounding, which is what
`precision` was always supposed to mean.

- `precision 8` output is **bitwise identical** (`tests/perf/nc_diff.py`, `WORST_REL=0`).
- `precision 4` output changes, toward the exact mean. Not bit-identical, by design.
- CTest DP gating set passes (6/6).

## Why it matters beyond the fix

Storage precision is no longer hostage to accumulation precision, so choosing an on-disk type
becomes a question about the *signal* alone. That makes 4-byte `salt` defensible for the first
time (~230× margin on the measured signal, ~3.3× smaller after deflate) and opens up formats
below 4 bytes — CF `add_offset` packing, netCDF-4 quantisation — which could not even be
evaluated before.

## Follow-ups

- `setups/test_core2/setup.yml` is the only `fcheck:` target at `prec: 4`; regenerate with
  `setups/update_truth_values.sh`.
- XIOS registers ~221 streams at `precision 4`; if it averages every step this buys nothing
  there — worth measuring.
- In an SP build `io_r2g` still round-trips the mean accumulator through `WP` for rotated
  vectors, undoing this change for `u`/`v` and friends. `vec_autorotate` is off by default, so
  no shipped config is affected. A tested patch and the open question are written up separately.
