### PR TITLE
Fix ghost records in mean output when the time step changes (#123)

### DIFF
--- a/cmake/FesomTesting.cmake
+++ b/cmake/FesomTesting.cmake
@@ -505,6 +505,103 @@ function(add_fesom_test_with_options TEST_NAME MESH_NAME STEP_PER_DAY RUN_LENGTH
     message(STATUS "Added FESOM test: ${TEST_NAME} with mesh: ${MESH_NAME}, cavity: ${USE_CAVITY}")
 endfunction()
 
+# Regression test for github issue #123 (ghost records on time-step change):
+# run one day with step_per_day=96, then rewrite fesom.clock and re-run the SAME
+# day with step_per_day=144 without deleting the results. Records are stamped
+# with the exact averaging-period end, so the second run must land on the same
+# timestamp and overwrite the record: exactly 1 record afterwards. Code that
+# stamps period_end - dt appends a second, shifted record instead (the ghost),
+# which shows up here as "current mean I/O counter = 2".
+function(add_fesom_output_restamp_test TEST_NAME)
+    set(options "")
+    set(oneValueArgs NP TIMEOUT)
+    set(multiValueArgs "")
+    cmake_parse_arguments(FESOM_TEST "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    if(NOT DEFINED FESOM_TEST_NP)
+        set(FESOM_TEST_NP 2)
+    endif()
+    if(NOT DEFINED FESOM_TEST_TIMEOUT)
+        set(FESOM_TEST_TIMEOUT 300)
+    endif()
+
+    set(TEST_RUN_DIR "${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME}")
+    set(TEST_DATA_DIR "${CMAKE_SOURCE_DIR}/tests/data")
+    set(RESULT_DIR "${TEST_RUN_DIR}/results")
+
+    generate_fesom_clock("${RESULT_DIR}")
+    configure_fesom_namelists("${TEST_RUN_DIR}" "${TEST_DATA_DIR}" "${RESULT_DIR}")
+
+    set(TEST_SCRIPT "${TEST_RUN_DIR}/run_test.cmake")
+    file(GENERATE OUTPUT ${TEST_SCRIPT} CONTENT "
+        file(MAKE_DIRECTORY \"${TEST_RUN_DIR}\")
+        file(MAKE_DIRECTORY \"${RESULT_DIR}\")
+
+        # see add_fesom_test_with_options for why these are safe unconditionally
+        set(ENV{OMPI_ALLOW_RUN_AS_ROOT} \"1\")
+        set(ENV{OMPI_ALLOW_RUN_AS_ROOT_CONFIRM} \"1\")
+        set(ENV{OMPI_MCA_rmaps_base_oversubscribe} \"1\")
+        set(ENV{PRTE_MCA_rmaps_default_mapping_policy} \":oversubscribe\")
+
+        # start from a clean slate: the point of the test is the SECOND run below
+        file(REMOVE_RECURSE \"${RESULT_DIR}\")
+        file(MAKE_DIRECTORY \"${RESULT_DIR}\")
+        file(WRITE \"${RESULT_DIR}/fesom.clock\" \"0 1 1948\\n0 1 1948\\n\")
+
+        # run A: one day at step_per_day=96 (dt=900s), as configured
+        execute_process(
+            COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${FESOM_TEST_NP} ${CMAKE_BINARY_DIR}/bin/fesom.x
+            WORKING_DIRECTORY \"${TEST_RUN_DIR}\"
+            RESULT_VARIABLE run_a_result
+            OUTPUT_VARIABLE run_a_output
+            ERROR_VARIABLE run_a_error
+            TIMEOUT ${FESOM_TEST_TIMEOUT}
+        )
+        file(WRITE \"${TEST_RUN_DIR}/test_output_run_a.log\" \"\${run_a_output}\")
+        file(WRITE \"${TEST_RUN_DIR}/test_error_run_a.log\" \"\${run_a_error}\")
+        if(NOT run_a_result EQUAL 0 OR NOT run_a_output MATCHES \"fesom should stop with exit status = 0\")
+            message(FATAL_ERROR \"Test ${TEST_NAME} FAILED: first run did not finish cleanly (exit \${run_a_result})\")
+        endif()
+
+        # re-run the SAME day with a different time step, keeping the output file
+        file(WRITE \"${RESULT_DIR}/fesom.clock\" \"0 1 1948\\n0 1 1948\\n\")
+        file(READ \"${TEST_RUN_DIR}/namelist.config\" _nml)
+        string(REGEX REPLACE \"([^A-Za-z0-9_])step_per_day[ \\t]*=[ \\t]*[0-9]+\" \"\\\\1step_per_day=144\" _nml \"\${_nml}\")
+        file(WRITE \"${TEST_RUN_DIR}/namelist.config\" \"\${_nml}\")
+
+        execute_process(
+            COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${FESOM_TEST_NP} ${CMAKE_BINARY_DIR}/bin/fesom.x
+            WORKING_DIRECTORY \"${TEST_RUN_DIR}\"
+            RESULT_VARIABLE run_b_result
+            OUTPUT_VARIABLE run_b_output
+            ERROR_VARIABLE run_b_error
+            TIMEOUT ${FESOM_TEST_TIMEOUT}
+        )
+        file(WRITE \"${TEST_RUN_DIR}/test_output.log\" \"\${run_b_output}\")
+        file(WRITE \"${TEST_RUN_DIR}/test_error.log\" \"\${run_b_error}\")
+        if(NOT run_b_result EQUAL 0 OR NOT run_b_output MATCHES \"fesom should stop with exit status = 0\")
+            message(FATAL_ERROR \"Test ${TEST_NAME} FAILED: second run did not finish cleanly (exit \${run_b_result})\")
+        endif()
+
+        # the second run must OVERWRITE the record from the first run, not append
+        # a ghost. The I/O layer prints the record position it decided on.
+        if(NOT run_b_output MATCHES \"sst: current mean I/O counter =[ \\t]*1[^0-9]\")
+            message(FATAL_ERROR \"Test ${TEST_NAME} FAILED: re-running a period with a different time step did not overwrite the existing record (ghost record, github issue #123). See ${TEST_RUN_DIR}/test_output.log\")
+        endif()
+        message(STATUS \"Test ${TEST_NAME} PASSED: record was overwritten in place on time-step change\")
+    ")
+
+    add_test(
+        NAME ${TEST_NAME}
+        COMMAND ${CMAKE_COMMAND} -P ${TEST_SCRIPT}
+    )
+    set_tests_properties(${TEST_NAME} PROPERTIES
+        TIMEOUT ${FESOM_TEST_TIMEOUT}
+        WORKING_DIRECTORY ${TEST_RUN_DIR}
+        PROCESSORS ${FESOM_TEST_NP}
+    )
+    message(STATUS "Added FESOM test: ${TEST_NAME} (output re-stamp regression, issue #123)")
+endfunction()
+
 # Function to find and validate MPI for testing
 function(setup_mpi_testing)
     find_package(MPI REQUIRED)

--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -2865,7 +2865,11 @@ subroutine output(istep, ice, dynamics, tracers, partit, mesh)
     logical       :: trigger_flush
 #endif
 
-ctime=timeold+(dayold-1.)*86400
+! stamp records with the exact end of the averaging period (events fire when
+! timenew==86400., see gen_events.F90); timeold would shift the stamp by -dt,
+! producing duplicate "ghost" records when a run is repeated with a different
+! time step (github issue #123)
+ctime=timenew+(daynew-1.)*86400
     
     !___________________________________________________________________________
     if (lfirst) then
@@ -3000,7 +3004,7 @@ ctime=timeold+(dayold-1.)*86400
                 do k=entry%rec_count, 1, -1
                     !PS if (partit%flag_debug)  print *, achar(27)//'[33m'//' -I/O-> call assert_nf B'//achar(27)//'[0m'//',  k=',k, ', rootpart=', entry%root_rank
                     ! determine rtime from exiting file
-                    call assert_nf( nf90_get_var(entry%ncid, entry%tID, rtime), __LINE__)
+                    call assert_nf( nf90_get_var(entry%ncid, entry%tID, rtime, start=(/k/)), __LINE__)
                     if (ctime > rtime) then
                         entry%rec_count=k+1
                         exit ! a proper rec_count detected, exit the loop

--- a/src/io_netcdf_file_module.F90
+++ b/src/io_netcdf_file_module.F90
@@ -183,7 +183,10 @@ contains
     deallocate(this%gatts)
     call move_alloc(tmparr, this%gatts)
     
-    this%gatts( size(this%gatts) )%it = att_type_text(name=att_name, text=att_text)
+    ! sourced allocation instead of intrinsic polymorphic assignment: same
+    ! semantics (the element is freshly unallocated), matches add_var_att_text,
+    ! and avoids a gfortran 16.2 ICE on the assignment form
+    allocate( this%gatts( size(this%gatts) )%it, source=att_type_text(name=att_name, text=att_text) )
   end subroutine add_global_att_text
 
 
@@ -199,7 +202,8 @@ contains
     deallocate(this%gatts)
     call move_alloc(tmparr, this%gatts)
     
-    this%gatts( size(this%gatts) )%it = att_type_int(name=att_name, val=att_val)
+    ! see comment in add_global_att_text
+    allocate( this%gatts( size(this%gatts) )%it, source=att_type_int(name=att_name, val=att_val) )
   end subroutine add_global_att_int
 
 

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -47,6 +47,12 @@ if(ENABLE_MPI_TESTS AND NOT FESOM_COUPLED AND NOT OIFS_COUPLED AND NOT USE_YAC)
         TIMEOUT ${TEST_TIMEOUT}
     )
     
+    # Regression test for ghost output records on time-step change (issue #123)
+    add_fesom_output_restamp_test(integration_pi_output_restamp
+        NP 2
+        TIMEOUT ${TEST_TIMEOUT}
+    )
+
     # Additional MPI test configurations can be added here
     # For example, testing different domain decompositions
 elseif(NOT ENABLE_MPI_TESTS)


### PR DESCRIPTION
Fixes #123.

## The problem

Mean-output records were stamped with `timeold`, i.e. one time step *before* the period boundary the output events fire on (`gen_events.F90` triggers on `timenew == 86400.`). A monthly record therefore carried the stamp `end_of_month - dt`. Re-running a period with a different time step produced a new, slightly shifted stamp, and since the restart scan only overwrites records with stamps >= the current time, the old record survived as a duplicate "ghost" — exactly the behaviour reported in #123.

## The fix

1. **`io_meandata.F90`**: stamp records with `timenew`/`daynew` — the exact averaging-period end, independent of `dt`. Re-running a period now lands on the identical timestamp and overwrites the record in place.
2. **`io_meandata.F90`**: the restart scan that positions `rec_count` in an existing file called `nf90_get_var` without `start=(/k/)`, so every iteration read the *first* record's time instead of record `k`'s. In practice the scan could only ever append. Fixed.
3. **`io_netcdf_file_module.F90`**: unrelated one-liner — gfortran 16.2 ICEs (all optimization levels) on the intrinsic polymorphic assignment in `add_global_att_*`; switched to sourced allocation, which is the same semantics and the pattern the file already uses in `add_var_att_*`. Needed to build on current Homebrew gcc at all.

## Regression test

`integration_pi_output_restamp` (pi mesh, 2 ranks): runs one day at `step_per_day=96`, then rewrites `fesom.clock` and re-runs the same day at `step_per_day=144` without deleting the results, asserting the record is overwritten rather than appended.

Verified locally (macOS, gfortran 16.2 + OpenMPI 5):

| build | after run A (dt=900s) | after re-running same day (dt=600s) |
|---|---|---|
| current main | `time = 85500` | `time = 85500, 85800` — ghost record |
| this branch | `time = 86400` | `time = 86400` — overwritten in place |

The test **fails on current main** and passes with the fix. `integration_pi_mpi2` also passes on this branch.

## Notes for reviewers

- Output timestamps change: a daily record is now stamped `86400` (period end, i.e. midnight of the next day in CF terms) instead of `86400 - dt`. Downstream analysis that special-cased the `-dt` offset will see the shift; that is the point of the fix, but worth flagging before 2.7.
- Files written by *previous* code versions keep their old shifted stamps, so extending such a file across a time-step change can still leave one ghost the first time. Files written by this version are stable.
- The `entry%currentDate/currentTime` stream metadata (MULTIO) still uses `timeold`; left untouched deliberately to keep this PR minimal.
