### PR TITLE
CF interval-aware output time axis: time_bounds, midpoint stamps, honest accumulation intervals

### DIFF
--- a/cmake/FesomTesting.cmake
+++ b/cmake/FesomTesting.cmake
@@ -628,6 +628,103 @@ function(add_fesom_test_with_options TEST_NAME MESH_NAME STEP_PER_DAY RUN_LENGTH
     message(STATUS "Added FESOM test: ${TEST_NAME} with mesh: ${MESH_NAME}, cavity: ${USE_CAVITY}")
 endfunction()
 
+# Regression test for ghost records on time-step change:
+# run one day with step_per_day=96, then rewrite fesom.clock and re-run the SAME
+# day with step_per_day=144 without deleting the results. Records are stamped
+# with the exact averaging-period end, so the second run must land on the same
+# timestamp and overwrite the record: exactly 1 record afterwards. Code that
+# stamps period_end - dt appends a second, shifted record instead (the ghost),
+# which shows up here as "current mean I/O counter = 2".
+function(add_fesom_output_restamp_test TEST_NAME)
+    set(options "")
+    set(oneValueArgs NP TIMEOUT)
+    set(multiValueArgs "")
+    cmake_parse_arguments(FESOM_TEST "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    if(NOT DEFINED FESOM_TEST_NP)
+        set(FESOM_TEST_NP 2)
+    endif()
+    if(NOT DEFINED FESOM_TEST_TIMEOUT)
+        set(FESOM_TEST_TIMEOUT 300)
+    endif()
+
+    set(TEST_RUN_DIR "${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME}")
+    set(TEST_DATA_DIR "${CMAKE_SOURCE_DIR}/tests/data")
+    set(RESULT_DIR "${TEST_RUN_DIR}/results")
+
+    generate_fesom_clock("${RESULT_DIR}")
+    configure_fesom_namelists("${TEST_RUN_DIR}" "${TEST_DATA_DIR}" "${RESULT_DIR}")
+
+    set(TEST_SCRIPT "${TEST_RUN_DIR}/run_test.cmake")
+    file(GENERATE OUTPUT ${TEST_SCRIPT} CONTENT "
+        file(MAKE_DIRECTORY \"${TEST_RUN_DIR}\")
+        file(MAKE_DIRECTORY \"${RESULT_DIR}\")
+
+        # see add_fesom_test_with_options for why these are safe unconditionally
+        set(ENV{OMPI_ALLOW_RUN_AS_ROOT} \"1\")
+        set(ENV{OMPI_ALLOW_RUN_AS_ROOT_CONFIRM} \"1\")
+        set(ENV{OMPI_MCA_rmaps_base_oversubscribe} \"1\")
+        set(ENV{PRTE_MCA_rmaps_default_mapping_policy} \":oversubscribe\")
+
+        # start from a clean slate: the point of the test is the SECOND run below
+        file(REMOVE_RECURSE \"${RESULT_DIR}\")
+        file(MAKE_DIRECTORY \"${RESULT_DIR}\")
+        file(WRITE \"${RESULT_DIR}/fesom.clock\" \"0 1 1948\\n0 1 1948\\n\")
+
+        # run A: one day at step_per_day=96 (dt=900s), as configured
+        execute_process(
+            COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${FESOM_TEST_NP} ${CMAKE_BINARY_DIR}/bin/fesom.x
+            WORKING_DIRECTORY \"${TEST_RUN_DIR}\"
+            RESULT_VARIABLE run_a_result
+            OUTPUT_VARIABLE run_a_output
+            ERROR_VARIABLE run_a_error
+            TIMEOUT ${FESOM_TEST_TIMEOUT}
+        )
+        file(WRITE \"${TEST_RUN_DIR}/test_output_run_a.log\" \"\${run_a_output}\")
+        file(WRITE \"${TEST_RUN_DIR}/test_error_run_a.log\" \"\${run_a_error}\")
+        if(NOT run_a_result EQUAL 0 OR NOT run_a_output MATCHES \"fesom should stop with exit status = 0\")
+            message(FATAL_ERROR \"Test ${TEST_NAME} FAILED: first run did not finish cleanly (exit \${run_a_result})\")
+        endif()
+
+        # re-run the SAME day with a different time step, keeping the output file
+        file(WRITE \"${RESULT_DIR}/fesom.clock\" \"0 1 1948\\n0 1 1948\\n\")
+        file(READ \"${TEST_RUN_DIR}/namelist.config\" _nml)
+        string(REGEX REPLACE \"([^A-Za-z0-9_])step_per_day[ \\t]*=[ \\t]*[0-9]+\" \"\\\\1step_per_day=144\" _nml \"\${_nml}\")
+        file(WRITE \"${TEST_RUN_DIR}/namelist.config\" \"\${_nml}\")
+
+        execute_process(
+            COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${FESOM_TEST_NP} ${CMAKE_BINARY_DIR}/bin/fesom.x
+            WORKING_DIRECTORY \"${TEST_RUN_DIR}\"
+            RESULT_VARIABLE run_b_result
+            OUTPUT_VARIABLE run_b_output
+            ERROR_VARIABLE run_b_error
+            TIMEOUT ${FESOM_TEST_TIMEOUT}
+        )
+        file(WRITE \"${TEST_RUN_DIR}/test_output.log\" \"\${run_b_output}\")
+        file(WRITE \"${TEST_RUN_DIR}/test_error.log\" \"\${run_b_error}\")
+        if(NOT run_b_result EQUAL 0 OR NOT run_b_output MATCHES \"fesom should stop with exit status = 0\")
+            message(FATAL_ERROR \"Test ${TEST_NAME} FAILED: second run did not finish cleanly (exit \${run_b_result})\")
+        endif()
+
+        # the second run must OVERWRITE the record from the first run, not append
+        # a ghost. The I/O layer prints the record position it decided on.
+        if(NOT run_b_output MATCHES \"sst: current mean I/O counter =[ \\t]*1[^0-9]\")
+            message(FATAL_ERROR \"Test ${TEST_NAME} FAILED: re-running a period with a different time step did not overwrite the existing record (ghost record). See ${TEST_RUN_DIR}/test_output.log\")
+        endif()
+        message(STATUS \"Test ${TEST_NAME} PASSED: record was overwritten in place on time-step change\")
+    ")
+
+    add_test(
+        NAME ${TEST_NAME}
+        COMMAND ${CMAKE_COMMAND} -P ${TEST_SCRIPT}
+    )
+    set_tests_properties(${TEST_NAME} PROPERTIES
+        TIMEOUT ${FESOM_TEST_TIMEOUT}
+        WORKING_DIRECTORY ${TEST_RUN_DIR}
+        PROCESSORS ${FESOM_TEST_NP}
+    )
+    message(STATUS "Added FESOM test: ${TEST_NAME} (output re-stamp regression)")
+endfunction()
+
 # Function to find and validate MPI for testing
 function(setup_mpi_testing)
     find_package(MPI REQUIRED)

--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -97,6 +97,16 @@ module io_MEANDATA
     integer :: currentDate,  currentTime
     integer :: previousDate, previousTime
     integer :: startDate, startTime
+    ! CF interval tracking: model time at which the current
+    ! accumulation interval started, in seconds since the start of year
+    ! t_accum_year. Set at stream creation and after every write, so bounds
+    ! reflect what was actually averaged (partial intervals after cold starts
+    ! and restarts included).
+    real(kind=WP) :: t_accum_start = 0._WP
+    integer       :: t_accum_year  = -1
+    real(kind=WP) :: tbnds_copy(2) = 0._WP ! interval of the record being written
+    integer       :: tbndsID = -1
+    logical       :: has_bounds = .true.   ! .false. when appending to a pre-time_bounds file
   contains
     final destructor
   end type Meandata
@@ -172,6 +182,11 @@ module io_MEANDATA
     integer                                    :: varid, timeid, timedimid
     integer                                    :: rec_count = 0
     character(500)                             :: filename = ""  ! current output file path
+    ! CF interval tracking, same semantics as in type Meandata
+    real(kind=WP)                              :: t_accum_start = 0._WP
+    integer                                    :: t_accum_year  = -1
+    integer                                    :: tbndsid = -1
+    logical                                    :: has_bounds = .true.
   end type Meandata0D
 
   type(Meandata0D), save, target :: io_stream0D(50)
@@ -2647,6 +2662,29 @@ end function
 !
 !
 !_______________________________________________________________________________
+!_______________________________________________________________________________
+! Interval start of an output entry, in seconds since the start of the CURRENT
+! year (g_clock yearnew). An interval that started in the previous year (the
+! normal case for the first record of a new yearly file: the previous write was
+! at the old year's end) comes out as 0; a cold start late in the old year
+! yields a negative offset, still consistent with this year's time units.
+function accum_start_this_year(t_accum_start, t_accum_year) result(t_start)
+  use g_clock
+  implicit none
+  real(kind=WP), intent(in) :: t_accum_start
+  integer,       intent(in) :: t_accum_year
+  real(kind=WP)             :: t_start
+  integer                   :: y, flag
+  t_start = t_accum_start
+  if (t_accum_year < 0) return
+  do y = t_accum_year, yearnew-1
+     call check_fleapyr(y, flag)
+     t_start = t_start - real(365+flag, WP)*86400._WP
+  end do
+end function accum_start_this_year
+!
+!
+!_______________________________________________________________________________
 subroutine create_new_file(entry, ice, dynamics, partit, mesh)
     use g_clock
     use mod_mesh
@@ -2669,6 +2707,7 @@ subroutine create_new_file(entry, ice, dynamics, partit, mesh)
     type(Meandata), intent(inout) :: entry
     character(len=*), parameter :: global_attributes_prefix = "FESOM_"
     integer :: nlev_chunk
+    integer :: bnds_dimid
 #if defined(__icepack)
     integer, allocatable :: ncat_arr(:)
     integer              :: ii
@@ -2755,6 +2794,18 @@ subroutine create_new_file(entry, ice, dynamics, partit, mesh)
     call assert_nf( nf90_put_att(entry%ncid, entry%tID, 'units', trim(att_text)), __LINE__)
     call assert_nf( nf90_put_att(entry%ncid, entry%tID, 'axis', 'T'), __LINE__)
     call assert_nf( nf90_put_att(entry%ncid, entry%tID, 'stored_direction', 'increasing'), __LINE__)
+    ! CF interval metadata; names and layout match what XIOS
+    ! writes so downstream tooling sees one convention across backends
+    if (include_fleapyear) then
+        call assert_nf( nf90_put_att(entry%ncid, entry%tID, 'calendar', 'standard'), __LINE__)
+    else
+        call assert_nf( nf90_put_att(entry%ncid, entry%tID, 'calendar', '365_day'), __LINE__)
+    end if
+    write(att_text, '(I4.4,a)') yearold, '-01-01 00:00:00'
+    call assert_nf( nf90_put_att(entry%ncid, entry%tID, 'time_origin', trim(att_text)), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, entry%tID, 'bounds', 'time_bounds'), __LINE__)
+    call assert_nf( nf90_def_dim(entry%ncid, 'axis_nbounds', 2, bnds_dimid), __LINE__)
+    call assert_nf( nf90_def_var(entry%ncid, 'time_bounds', nf90_double, (/bnds_dimid, entry%recID/), entry%tbndsID), __LINE__)
 
     call assert_nf( nf90_def_var(entry%ncid, trim(entry%name), entry%data_strategy%netcdf_type(), (/entry%dimid(entry%ndim:1:-1), entry%recID/), entry%varID), __LINE__)
 
@@ -2801,6 +2852,7 @@ subroutine create_new_file(entry, ice, dynamics, partit, mesh)
     call assert_nf( nf90_put_att(entry%ncid, entry%varID, 'units', entry%units), __LINE__)
     call assert_nf( nf90_put_att(entry%ncid, entry%varID, 'location', entry%defined_on), __LINE__)
     call assert_nf( nf90_put_att(entry%ncid, entry%varID, 'mesh', entry%mesh), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, entry%varID, 'cell_methods', 'time: mean'), __LINE__)
 
     ! Add _FillValue attribute for missing/invalid data (CF-compliant)
     if (entry%accuracy == i_real8) then
@@ -2887,6 +2939,16 @@ subroutine assoc_ids(entry)
     call assert_nf( nf90_inquire_dimension(entry%ncid, entry%recID, len=entry%rec_count), __LINE__)
     !___Associate the time and iteration variables______________________________
     call assert_nf( nf90_inq_varid(entry%ncid, 'time', entry%tID), __LINE__)
+    !___Associate the interval bounds; a file written by older FESOM versions has
+    ! none. Such a legacy file keeps getting bounds-less records appended (one
+    ! write path for everybody); only new files carry time_bounds.
+    if (nf90_inq_varid(entry%ncid, 'time_bounds', entry%tbndsID) == nf90_noerr) then
+        entry%has_bounds = .true.
+    else
+        entry%has_bounds = .false.
+        entry%tbndsID = -1
+        write(*,*) 'I/O '//trim(entry%name)//' WARNING: appending to a pre-time_bounds file; new records get the new time stamps but no time_bounds'
+    end if
     !___Associate physical variables____________________________________________
     call assert_nf( nf90_inq_varid(entry%ncid, entry%name, entry%varID), __LINE__)
 
@@ -3092,6 +3154,9 @@ subroutine write_mean(entry, entry_index)
         if (.not. parallel_write .or. out_is_lead_writer()) &
             write(*,*) 'writing mean record for ', trim(entry%name), '; rec. count = ', entry%rec_count
         call assert_nf( nf90_put_var(entry%ncid, entry%Tid, entry%ctime_copy, start = (/entry%rec_count/) ), __LINE__)
+        if (entry%has_bounds) then
+            call assert_nf( nf90_put_var(entry%ncid, entry%tbndsID, entry%tbnds_copy, start=(/1, entry%rec_count/), count=(/2, 1/) ), __LINE__)
+        end if
     end if
   
     !_______writing 2D and 3D fields____________________________________________
@@ -3303,12 +3368,18 @@ subroutine output(istep, ice, dynamics, tracers, partit, mesh)
     type(t_ice)   , intent(inout), target :: ice
     character(:), allocatable             :: filepath
     real(real64)                          :: rtime !timestamp of the record
+    real(kind=WP)                         :: t_start !start of this entry's accumulation interval, seconds since start of current year
 #if defined(__MULTIO)
     logical       :: output_done
     logical       :: trigger_flush
 #endif
 
-ctime=timeold+(dayold-1.)*86400
+! End of the current step, i.e. the end of the accumulation interval when an
+! output event fires (events fire on timenew==86400., see gen_events.F90).
+! The record's time stamp is the interval MIDPOINT and the interval itself
+! goes to time_bounds; both are independent of the time step, so re-running
+! a period cannot produce shifted duplicate records.
+ctime=timenew+(daynew-1.)*86400
     
     !___________________________________________________________________________
     if (lfirst) then
@@ -3395,6 +3466,9 @@ ctime=timeold+(dayold-1.)*86400
         !_______________________________________________________________________
         ! if its time for output --> do_output==.true.
         if (do_output) then
+            ! start of this entry's accumulation interval, in this year's time
+            ! units; must be taken BEFORE the tracker is reset further down
+            t_start = accum_start_this_year(entry%t_accum_start, entry%t_accum_year)
             if (vec_autorotate) call io_r2g(n, partit, mesh) ! automatically detect if a vector field and rotate if makes sense!
 #if !defined(__MULTIO)
             if(entry%thread_running) call entry%thread%join()
@@ -3447,13 +3521,17 @@ ctime=timeold+(dayold-1.)*86400
                 end if ! --> if(filepath /= trim(entry%filename)) then
 
                 !_______________________________________________________________
-                ! if the time rtime at the rec_count is larger than ctime we
-                ! look for the closest record with the timestamp less than ctime
+                ! position rec_count in the (possibly pre-existing) file:
+                ! overwrite every record whose stamp lies AFTER the start of the
+                ! current accumulation interval. Any stamping convention places
+                ! a record's stamp inside (or at the end of) its own interval,
+                ! so this rule also dedups correctly against files written by
+                ! older code with time-step-dependent stamps.
                 do k=entry%rec_count, 1, -1
                     !PS if (partit%flag_debug)  print *, achar(27)//'[33m'//' -I/O-> call assert_nf B'//achar(27)//'[0m'//',  k=',k, ', rootpart=', entry%root_rank
                     ! determine rtime from exiting file
                     call assert_nf( nf90_get_var(entry%ncid, entry%tID, rtime, start=(/k/)), __LINE__)
-                    if (ctime > rtime) then
+                    if (rtime <= t_start) then
                         entry%rec_count=k+1
                         exit ! a proper rec_count detected, exit the loop
                     end if
@@ -3546,7 +3624,12 @@ ctime=timeold+(dayold-1.)*86400
             !___________________________________________________________________
             entry%lastcounter=entry%addcounter
             entry%addcounter   = 0  ! clean_meanarrays
-            entry%ctime_copy = ctime
+            ! stamp = interval midpoint, interval itself goes to time_bounds;
+            ! then start the next accumulation interval at the current time
+            entry%ctime_copy = 0.5_WP*(t_start + ctime)
+            entry%tbnds_copy = (/t_start, ctime/)
+            entry%t_accum_start = ctime
+            entry%t_accum_year  = yearnew
 
 #if defined(__MULTIO)
 !            if (n==1) then
@@ -3597,11 +3680,12 @@ subroutine output_0D_streams(istep, partit)
     integer, intent(in) :: istep
     type(t_partit), intent(inout) :: partit
 
-    integer :: n, ierr
+    integer :: n, ierr, k
     logical :: do_output
     type(Meandata0D), pointer :: entry0D
     character(500) :: filepath
     real(real64) :: mean_value, rtime
+    real(kind=WP) :: t_start !start of this entry's accumulation interval, seconds since start of current year
 
     ! When XIOS is the I/O driver, the 0D scalar fields are written via
     ! xios_send_field calls (see gen_modules_cmor_diag.F90's compute_cmor_diag)
@@ -3629,6 +3713,8 @@ subroutine output_0D_streams(istep, partit)
         endif
         
         if (do_output) then
+            ! start of this entry's accumulation interval (before the tracker reset below)
+            t_start = accum_start_this_year(entry0D%t_accum_start, entry0D%t_accum_year)
             ! Compute mean value
             if (entry0D%addcounter > 0) then
                 mean_value = entry0D%local_value / real(entry0D%addcounter, real64)
@@ -3667,21 +3753,39 @@ subroutine output_0D_streams(istep, partit)
                         call assert_nf(nf90_inq_varid(entry0D%ncid, 'time', entry0D%timeid), __LINE__)
                         call assert_nf(nf90_inq_varid(entry0D%ncid, trim(entry0D%name), entry0D%varid), __LINE__)
                         call assert_nf(nf90_inquire_dimension(entry0D%ncid, entry0D%timedimid, len=entry0D%rec_count), __LINE__)
+                        ! legacy file without time_bounds: keep appending bounds-less records
+                        if (nf90_inq_varid(entry0D%ncid, 'time_bounds', entry0D%tbndsid) == nf90_noerr) then
+                            entry0D%has_bounds = .true.
+                        else
+                            entry0D%has_bounds = .false.
+                            entry0D%tbndsid = -1
+                        endif
                     endif
                 endif
-                
-                ! Write data
-                entry0D%rec_count = entry0D%rec_count + 1
-                rtime = ctime
-                
+
+                ! Write data: position rec_count with the same rule as the
+                ! 2D/3D streams (overwrite records after the interval start),
+                ! stamp with the interval midpoint, store the interval itself
+                do k=entry0D%rec_count, 1, -1
+                    call assert_nf(nf90_get_var(entry0D%ncid, entry0D%timeid, rtime, start=(/k/)), __LINE__)
+                    if (rtime <= t_start) exit
+                end do
+                entry0D%rec_count = k + 1
+                rtime = 0.5_WP*(t_start + ctime)
+
                 call assert_nf(nf90_put_var(entry0D%ncid, entry0D%timeid, rtime, start=(/entry0D%rec_count/)), __LINE__)
+                if (entry0D%has_bounds) then
+                    call assert_nf(nf90_put_var(entry0D%ncid, entry0D%tbndsid, (/t_start, ctime/), start=(/1, entry0D%rec_count/), count=(/2, 1/)), __LINE__)
+                endif
                 call assert_nf(nf90_put_var(entry0D%ncid, entry0D%varid, mean_value, start=(/entry0D%rec_count/)), __LINE__)
                 call assert_nf(nf90_sync(entry0D%ncid), __LINE__)
             endif
-            
-            ! Reset accumulator
+
+            ! Reset accumulator and start the next accumulation interval
             entry0D%local_value = 0._real64
             entry0D%addcounter = 0
+            entry0D%t_accum_start = ctime
+            entry0D%t_accum_year  = yearnew
         endif
     end do
     
@@ -3692,24 +3796,33 @@ end subroutine output_0D_streams
 ! Create a new NetCDF file for 0D (scalar) output
 subroutine create_0D_file(entry0D, filepath)
     use g_clock
+    use g_config
     implicit none
     type(Meandata0D), intent(inout) :: entry0D
     character(len=*), intent(in) :: filepath
     
-    integer :: ierr
+    integer :: ierr, bnds_dimid
     character(100) :: time_units
-    
+
     ! Create file
     call assert_nf(nf90_create(trim(filepath), IOR(NF90_CLOBBER, NF90_NETCDF4), entry0D%ncid), __LINE__)
-    
+
     ! Define time dimension (unlimited)
     call assert_nf(nf90_def_dim(entry0D%ncid, 'time', NF90_UNLIMITED, entry0D%timedimid), __LINE__)
-    
+
     ! Define time variable
     call assert_nf(nf90_def_var(entry0D%ncid, 'time', NF90_DOUBLE, (/entry0D%timedimid/), entry0D%timeid), __LINE__)
     write(time_units, '(a,i4.4,a,i2.2,a,i2.2,a)') 'seconds since ', yearnew, '-01-01 00:00:00'
     call assert_nf(nf90_put_att(entry0D%ncid, entry0D%timeid, 'units', trim(time_units)), __LINE__)
-    call assert_nf(nf90_put_att(entry0D%ncid, entry0D%timeid, 'calendar', 'standard'), __LINE__)
+    if (include_fleapyear) then
+        call assert_nf(nf90_put_att(entry0D%ncid, entry0D%timeid, 'calendar', 'standard'), __LINE__)
+    else
+        call assert_nf(nf90_put_att(entry0D%ncid, entry0D%timeid, 'calendar', '365_day'), __LINE__)
+    endif
+    call assert_nf(nf90_put_att(entry0D%ncid, entry0D%timeid, 'bounds', 'time_bounds'), __LINE__)
+    call assert_nf(nf90_def_dim(entry0D%ncid, 'axis_nbounds', 2, bnds_dimid), __LINE__)
+    call assert_nf(nf90_def_var(entry0D%ncid, 'time_bounds', NF90_DOUBLE, (/bnds_dimid, entry0D%timedimid/), entry0D%tbndsid), __LINE__)
+    entry0D%has_bounds = .true.
     
     ! Define data variable
     if (entry0D%accuracy == i_real8) then
@@ -3724,6 +3837,7 @@ subroutine create_0D_file(entry0D, filepath)
     if (len_trim(entry0D%long_description) > 0) then
         call assert_nf(nf90_put_att(entry0D%ncid, entry0D%varid, 'long_name', trim(entry0D%long_description)), __LINE__)
     endif
+    call assert_nf(nf90_put_att(entry0D%ncid, entry0D%varid, 'cell_methods', 'time: mean'), __LINE__)
     
     ! End define mode
     call assert_nf(nf90_enddef(entry0D%ncid), __LINE__)
@@ -3911,6 +4025,11 @@ subroutine def_stream3D(glsize, lcsize, name, description, units, data, freq, fr
     entry%currentTime=INT(INT(timeold / 3600) * 10000 + (INT(timeold / 60) - INT(timeold / 3600) * 60) * 100 + (timeold-INT(timeold / 60) * 60))
     entry%startDate=entry%currentDate
     entry%startTime=entry%currentTime
+    ! accumulation starts now: at the beginning of the step this stream is
+    ! created on (streams are created on the first output() call, i.e. before
+    ! the first sample of step 1 is folded in)
+    entry%t_accum_start = timeold + (dayold-1.)*86400._WP
+    entry%t_accum_year  = yearold
     !___________________________________________________________________________
     ! fill up 3d meandata streaming object
     ! 3d specific
@@ -3988,6 +4107,11 @@ subroutine def_stream2D(glsize, lcsize, name, description, units, data, freq, fr
     entry%currentTime=INT(INT(timeold / 3600) * 10000 + (INT(timeold / 60) - INT(timeold / 3600) * 60) * 100 + (timeold-INT(timeold / 60) * 60))
     entry%startDate=entry%currentDate
     entry%startTime=entry%currentTime
+    ! accumulation starts now: at the beginning of the step this stream is
+    ! created on (streams are created on the first output() call, i.e. before
+    ! the first sample of step 1 is folded in)
+    entry%t_accum_start = timeold + (dayold-1.)*86400._WP
+    entry%t_accum_year  = yearold
     !___________________________________________________________________________
     ! fill up 3d meandata streaming object
     ! 2d specific
@@ -4013,6 +4137,7 @@ end subroutine
 subroutine def_stream0D(name, description, units, data, freq, freq_unit, accuracy, partit, long_description)
   USE MOD_PARTIT
   USE MOD_PARSUP
+  use g_clock
   implicit none
   character(len=*),      intent(in)    :: name, description, units
   real(kind=WP), target, intent(in)    :: data
@@ -4059,6 +4184,9 @@ subroutine def_stream0D(name, description, units, data, freq, freq_unit, accurac
     entry%is_in_use = .true.
     entry%ncid = -1
     entry%rec_count = 0
+    ! accumulation starts at the beginning of the step this stream is created on
+    entry%t_accum_start = timeold + (dayold-1.)*86400._WP
+    entry%t_accum_year  = yearold
     
     if (present(long_description)) then
         entry%long_description = long_description

--- a/src/io_netcdf_file_module.F90
+++ b/src/io_netcdf_file_module.F90
@@ -185,7 +185,10 @@ contains
     deallocate(this%gatts)
     call move_alloc(tmparr, this%gatts)
     
-    this%gatts( size(this%gatts) )%it = att_type_text(name=att_name, text=att_text)
+    ! sourced allocation instead of intrinsic polymorphic assignment: same
+    ! semantics (the element is freshly unallocated), matches add_var_att_text,
+    ! and avoids a gfortran 16.2 ICE on the assignment form
+    allocate( this%gatts( size(this%gatts) )%it, source=att_type_text(name=att_name, text=att_text) )
   end subroutine add_global_att_text
 
 
@@ -201,7 +204,8 @@ contains
     deallocate(this%gatts)
     call move_alloc(tmparr, this%gatts)
     
-    this%gatts( size(this%gatts) )%it = att_type_int(name=att_name, val=att_val)
+    ! see comment in add_global_att_text
+    allocate( this%gatts( size(this%gatts) )%it, source=att_type_int(name=att_name, val=att_val) )
   end subroutine add_global_att_int
 
 

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -122,6 +122,12 @@ if(ENABLE_MPI_TESTS AND NOT FESOM_COUPLED AND NOT OIFS_COUPLED AND NOT USE_YAC)
     # (see add_fesom_test_with_options in cmake/FesomTesting.cmake). Run the suite in an
     # SP build dir to get SP coverage of everything, including the CVMix schemes.
 
+    # Regression test for ghost output records on time-step change
+    add_fesom_output_restamp_test(integration_pi_output_restamp
+        NP 2
+        TIMEOUT ${TEST_TIMEOUT}
+    )
+
     # Additional MPI test configurations can be added here
     # For example, testing different domain decompositions
 elseif(NOT ENABLE_MPI_TESTS)


### PR DESCRIPTION
Implements the design agreed in #1034. Fixes #123 (and the mechanism behind #431); supersedes the discussion outcome of #763.

## What changes

Mean-output records now say what interval they describe, instead of encoding it implicitly in a time-step-dependent stamp:

```
double time(time) ;
    time:bounds = "time_bounds" ;
    time:calendar = "standard" / "365_day" ;   (from include_fleapyear)
    time:time_origin = "1948-01-01 00:00:00" ;
double time_bounds(time, axis_nbounds) ;       // [interval_start, interval_end]
sst:cell_methods = "time: mean" ;
```

The `time` value is the interval **midpoint**. Names and layout are exactly what XIOS already writes in coupled AWI-CM3 runs, so downstream tooling sees one convention across backends.

### How it works

1. **Tracked accumulation intervals.** Every stream records when its accumulation started (at stream creation and after each write). Bounds are `[t_accum_start, t_now]`: what was actually averaged. A cold start on Jan 15 produces a January record with bounds `[Jan 15, Feb 1]` instead of silently pretending to be a full-month mean. XIOS writes nominal bounds regardless, so this is one point where the native backend is now more precise.
2. **Convention-independent overwrite rule.** When appending to an existing file, the record scan overwrites every record whose stamp lies after the start of the current interval (previously: a stamp-value comparison, which is what let ghost records survive a time-step change). Any stamping convention places a record's stamp inside its own interval, so this dedups correctly even against files written by older FESOM versions with `end - dt` stamps.
3. **Legacy files stay bounds-less.** Appending to a file without `time_bounds` warns once and appends new-style stamps without bounds: one write path for everybody, no retrofitted guesses. Since files are yearly, everyone migrates naturally at the next year boundary. (Rare case by agreement in #1034; normally output is not continued across model versions.)
4. The 0D scalar streams get the identical treatment.

## What this means for downstream tooling

This is the output-convention change discussed at length in #763 and #1034:

- A daily mean is stamped `43200` (noon) instead of `86400 - dt`; a January monthly mean sits mid-January instead of `Jan-31 23:5x`. Tools that group by calendar period classify records correctly by construction. Tools that special-cased the old `-dt` offset need updating.
- Anything already consuming XIOS-written FESOM output needs no changes at all. 

## Verification (pi mesh, 2 ranks; macOS gfortran 16.2 / OpenMPI 5)

| scenario | result |
|---|---|
| `integration_pi_mpi2` | passes |
| daily record | `time = 43200`, `time_bounds = [0, 86400]` |
| re-run same day, dt 900 s to 600 s (the #123 ghost case) | one record, overwritten in place |
| 2-day run, warm-restart re-run of day 2 (the #431 case) | record 2 overwritten; bounds `[0,86400], [86400,172800]` |
| append to hand-built legacy file (stamp `85500`, no bounds) | old record kept, new record appended without bounds, warning printed, no crash |
| year rollover Dec 31 1948 to Jan 1 1949 | 1948 file: `[31449600, 31536000]`; 1949 file: `[0, 86400]`, the interval start correctly re-based into the new yearly file's units |
| same ghost case on an `ASYNCHRONOUS_IO_THREADS=ON` build | identical result; the bounds travel through the same snapshot mechanism as ctime_copy |
| `integration_pi_output_restamp` (regression test, added here) | passes; fails on `main` |

## Backend coverage

- Serial gather path and asynchronous I/O threads: tested above.
- Parallel writer (`parallel_write=.true.`): wired in by construction. The `time_bounds` definition sits in the common `create_new_file` path, the bounds write sits inside the same collective guard as the time write (every writer issues it), and the record scan already runs on the whole writer set since the parallel-writer work in #969. Not runtime-verifiable on my laptop: `nf90_create_par` needs netCDF built against parallel HDF5, and the Homebrew build is serial-only (unmodified `main` aborts identically there). One pi run with `parallel_write=.true.` on albedo would close this gap.
- XIOS is untouched; it already writes this convention itself.
- MULTIO is untouched. The design's `previousDate/currentTime` unification needs a `__MULTIO` build to verify, which I cannot do locally; those fields still carry the old `timeold`-based values. Flagged as a follow-up for whoever runs MULTIO.

## Caveats

- Rebased on current `main`, which already contains the record-scan index fix (#1035).
- Includes a gfortran >= 16 workaround in `io_netcdf_file_module.F90` (sourced allocation instead of an intrinsic polymorphic assignment that ICEs at every optimization level). Same semantics, same idiom the file already uses in `add_var_att_*`; needed to build on current Homebrew gcc at all. Can be split out if preferred.
- **0D streams are compile-tested only**: nothing on `main` registers one (`def_stream0D` callers live on RECOM/CMOR branches), so that path had no runtime exercise here.
- Restart/blowup files are untouched (out of scope per #1034).
