### PR TITLE
Restart: one instant per file, named after its date

### DIFF
--- a/config/namelist.config
+++ b/config/namelist.config
@@ -49,6 +49,8 @@ yearnew = 1958                 ! initial year
 MeshPath         = '/pool/data/AWICM/FESOM2/MESHES_FESOM2.1/core2/'   ! path to mesh files (nod2d.out, elem2d.out, etc.)
 ClimateDataPath  = '/pool/data/AWICM/FESOM2/INITIAL/phc3.0/'          ! path to initial conditions (temperature, salinity)
 ResultPath       = '/work/ab0246/$USER/runtime/fesom2/'               ! path for output files and fesom.clock file
+RestartInPath    = ''                                                 ! where restarts are read from; empty means ResultPath
+RestartOutPath   = ''                                                 ! where restarts are written to; empty means ResultPath
 /
 
 ! ============================================================================

--- a/docs/getting_started/getting_started.rst
+++ b/docs/getting_started/getting_started.rst
@@ -264,17 +264,36 @@ Let's assume that we run the model with a timestep of 30 minutes (= 1800 seconds
     84600.0 365 1958
     0.0     1   1959
 
-where the first row is the second of the day of the last time step of the model, and the second row gives the time when the simulation is to be continued. The first row indicates that the model ran for 365 days (in 1958) and 84600 seconds, which is ``1 day - 1`` FESOM timestep in seconds. In the next run, FESOM2 will look for restart files for the year 1958 and continue the simulation at the 1st of January in 1959.
+where the first row is the second of the day of the last time step of the model, and the second row gives the time when the simulation is to be continued. The first row indicates that the model ran for 365 days (in 1958) and 84600 seconds, which is ``1 day - 1`` FESOM timestep in seconds. In the next run, FESOM2 will look for the restart written at the 1st of January 1959 and continue the simulation from there.
+
+Restart file naming
+-------------------
+Each restart holds a single model state, named after the date of that state:
+
+::
+
+    fesom.1959-01-01.oce.restart/
+    fesom.1959-01-01.ice.restart/
+
+Each of those is a directory holding one netCDF file per restart variable.
+
+The date is the instant the model state belongs to, which is why a run finishing at the end of 1958 leaves a restart called ``1959-01-01``: that is the moment the next run continues from, and the same moment the second row of the clock file names. To restart from an earlier point, set the clock file to that date and FESOM2 reads the restart carrying it.
+
+.. note::
+   Restarts written by FESOM2 before 2.8 are named after the year (``fesom.1958.oce.restart``) and hold every restart record of that year in one file per variable. Those are still read: if no date-stamped restart is found for the requested instant, FESOM2 falls back to the yearly file and picks the record matching the clock. Nothing writes that layout any more.
+
+.. attention::
+   The raw restart (``fesom_raw_restart``) is a core dump of the last write and is preferred over the netCDF restart whenever it is present. Setting the clock back to an earlier date therefore has no effect while a raw restart is lying around. Delete the ``fesom_raw_restart`` directory to make FESOM2 use the netCDF restart the clock asks for.
 
 
 Tricking FESOM2 into accepting existing restart files
 -----------------------------------------------------
-The simple time management of FESOM2 allows to easily trick FESOM2 to accept existing restart files. Let's assume that you have performed a full ``JRA55`` cycle until the year 2019 and you want to perform a second cycle, restarting from the last year of the first cycle. This can be done by (copying and) renaming the last year into:
+The simple time management of FESOM2 allows to easily trick FESOM2 to accept existing restart files. Let's assume that you have performed a full ``JRA55`` cycle until the year 2019 and you want to perform a second cycle, restarting from the last year of the first cycle. This can be done by (copying and) renaming the restart of the last year into:
 
 ::
 
-    mv fesom.2019.ice.nc fesom.1957.ice.nc
-    mv fesom.2019.oce.nc fesom.1957.oce.nc
+    mv fesom.2020-01-01.ice.restart fesom.1958-01-01.ice.restart
+    mv fesom.2020-01-01.oce.restart fesom.1958-01-01.oce.restart
 
 by changing the clock file into:
 

--- a/src/fortran_utils.F90
+++ b/src/fortran_utils.F90
@@ -66,4 +66,66 @@ contains
     endif
   end subroutine mkdir
 
+
+  !> Calendar stamp of a model instant: YYYY-MM-DD.
+  !>
+  !> The instant is normalised first, because FESOM's clock represents midnight
+  !> two ways and both have to produce one name. The end of day d
+  !> (sec_of_day == 86400) is the start of day d+1, and the end of the last day
+  !> of a year is 1 January of the next. That is the same normalisation
+  !> clock_finish applies before writing fesom.clock and clock_init applies
+  !> after reading it back, which is what lets a writer and a later reader
+  !> derive the same name from their own clock state with no bookkeeping in
+  !> between. Applying it to already-normalised input changes nothing, so it is
+  !> safe to call on either side.
+  !>
+  !> days_in_year is 365 or 366 and carries the leap flag; the month lengths are
+  !> the same table g_clock keeps, repeated here so this stays free of model
+  !> dependencies and can be tested on its own.
+  !>
+  !> sec_of_day is an input even though the stamp has no time of day, because
+  !> the normalisation needs it: it is what says whether the instant is the end
+  !> of a day and therefore belongs to the next one. Two instants inside the
+  !> same day get the same stamp.
+  pure function calendar_stamp(year, day_of_year, sec_of_day, days_in_year) result(stamp)
+    integer, intent(in) :: year, day_of_year, sec_of_day, days_in_year
+    character(:), allocatable :: stamp
+    ! EO parameters
+    integer, parameter :: month_len(12,0:1) = reshape( &
+         [31,28,31,30,31,30,31,31,30,31,30,31, &
+          31,29,31,30,31,30,31,31,30,31,30,31], [12,2])
+    integer :: yy, mm, dd, doy, leap, i, elapsed
+    character(10) :: buf
+
+    yy   = year
+    doy  = day_of_year
+    leap = max(0, min(1, days_in_year-365))
+
+    ! end of a day is the start of the next one ...
+    if(sec_of_day >= 86400) doy = doy+1
+    ! ... and the end of the last day of a year is 1 January
+    if(doy > 365+leap) then
+      doy = 1
+      yy = yy+1
+      leap = 0 ! 1 January is 1 January in either kind of year
+    end if
+
+    ! day of year -> month and day in month
+    mm = 1
+    dd = doy
+    elapsed = 0
+    do i=1, 12
+      if(doy > elapsed .and. doy <= elapsed+month_len(i,leap)) then
+        mm = i
+        dd = doy-elapsed
+        exit
+      end if
+      elapsed = elapsed+month_len(i,leap)
+    end do
+
+    write(buf, '(i4.4,"-",i2.2,"-",i2.2)') yy, mm, dd
+    stamp = buf
+  end function calendar_stamp
+
+
 end module fortran_utils

--- a/src/io_fesom_file.F90
+++ b/src/io_fesom_file.F90
@@ -35,6 +35,10 @@ module io_fesom_file_module
     type(var_info) var_infos(20); integer :: nvar_infos = 0 ! todo: allow dynamically allocated size without messing with shallow copied pointers
     type(dim_info), allocatable :: used_mesh_dims(:) ! the dims we add for our variables, we need to identify them when adding our mesh related variables
     integer :: rec_cnt = -1
+    !> Record to read from the attached file. 0 means "the last one", which is
+    !> the only sensible default for a file whose record count is all we know.
+    !> io_restart overrides it once it has matched a record against the clock.
+    integer :: read_rec = 0
     integer :: iorank = 0
     integer :: fesom_file_index
     type(thread_type) thread
@@ -44,6 +48,7 @@ module io_fesom_file_module
     logical gather_and_write
   contains
     procedure, public :: async_read_and_scatter_variables, async_gather_and_write_variables, join, init, is_iorank, rec_count, time_varindex, time_dimindex
+    procedure, public :: set_read_record, read_record
     procedure, public :: read_variables_raw, write_variables_raw
     procedure, public :: close_file ! inherited procedures we overwrite
     procedure, public :: read_and_scatter_variables
@@ -119,6 +124,30 @@ contains
     
     x = this%rec_cnt
   end function rec_count
+
+
+  !> Pin the record the next read takes its data from. Restart files written by
+  !> FESOM 2.8 and later hold a single record, so this is always 1 for them; it
+  !> exists for the files older versions wrote, which hold every restart of a
+  !> year and where the wanted record has to be matched against the clock
+  !> Reset by close_file, so it never leaks into the next file.
+  subroutine set_read_record(this, idx)
+    class(fesom_file_type), intent(inout) :: this
+    integer, intent(in) :: idx
+    this%read_rec = idx
+  end subroutine set_read_record
+
+
+  !> Record the next read uses: the pinned one, or the last in the file.
+  function read_record(this) result(x)
+    class(fesom_file_type), intent(inout) :: this
+    integer x
+    if(this%read_rec > 0) then
+      x = this%read_rec
+    else
+      x = this%rec_count()
+    end if
+  end function read_record
 
 
   function time_varindex(this) result(x)
@@ -255,7 +284,7 @@ contains
     total_scatter_time = 0.0d0
     total_barrier_time = 0.0d0
 
-    last_rec_idx = this%rec_count()
+    last_rec_idx = this%read_record()
     
     do i=1, this%nvar_infos
       var => this%var_infos(i)
@@ -612,7 +641,7 @@ contains
     ! Every reader has the same file open and reads the same record count, so
     ! they agree without a broadcast -- the same argument the write path uses.
     last_rec_idx = 0
-    if(this%is_reader()) last_rec_idx = this%rec_count()
+    if(this%is_reader()) last_rec_idx = this%read_record()
 
     do i=1, this%nvar_infos
       var => this%var_infos(i)
@@ -1113,6 +1142,7 @@ use nvfortran_subarray_workaround_module
     this%thread_running = .false.    
    
     this%rec_cnt = -1 ! reset state (should probably be done in all the open_ procedures, not here)
+    this%read_rec = 0
     call this%netcdf_file_type%close_file()
   end subroutine  
 

--- a/src/io_netcdf_file_module.F90
+++ b/src/io_netcdf_file_module.F90
@@ -458,7 +458,12 @@ contains
 
     this%filepath = filepath
 
-    cmode = ior(nf_noclobber, ior(nf_netcdf4, nf_classic_model))
+    ! nf_clobber, not nf_noclobber: the callers (restart writing) name a file
+    ! after the instant it holds, so an existing file at that name is the debris
+    ! of an earlier attempt at the same instant and must be replaced. Refusing
+    ! made a job that had died mid-write -- out of disk quota, out of wall time --
+    ! unrestartable without hand-deleting files first.
+    cmode = ior(nf_clobber, ior(nf_netcdf4, nf_classic_model))
     call assert_nc( nf_create(filepath, cmode, this%ncid) , __LINE__)
         
     ! create our dims in the file

--- a/src/io_restart.F90
+++ b/src/io_restart.F90
@@ -1,6 +1,6 @@
 MODULE io_RESTART
   use restart_file_group_module
-  use io_fesom_file_module, only: parallel_write_enabled, set_parallel_write
+  use io_fesom_file_module, only: parallel_write_enabled, set_parallel_write, fesom_file_type
   use restart_derivedtype_module
   use g_clock
   use g_config
@@ -56,17 +56,36 @@ MODULE io_RESTART
 ! Helper functions for constructing restart file paths
 !--------------------------------------------------------------------------------------------
 
-! Build NetCDF restart file path
-pure function nc_restart_path(component, year, root_path) result(path)
+! Build NetCDF restart file path: one restart instant per file, stamped with the
+! date of that instant (see calendar_stamp in fortran_utils for how the clock
+! state is turned into that stamp, and why the writer and a later reader agree
+! on it). The ".nc" suffix is chopped off again by the read and write routines to
+! get the directory that holds the per-variable files; it is kept here because
+! that is the name the rest of the code and the user see.
+function nc_restart_path(component, root_path) result(path)
+  use fortran_utils, only: calendar_stamp
+  implicit none
+  character(len=*), intent(in) :: component, root_path
+  character(:), allocatable :: path
+
+  path = trim(root_path) // trim(runid) // '.' // &
+         calendar_stamp(yearnew, daynew, nint(timenew), 365+fleapyear) // &
+         '.' // trim(component) // '.restart.nc'
+end function nc_restart_path
+
+! Pre-2.8 name of a restart file: one file per year, holding every restart
+! record written during that year. Only used to keep reading restarts written by
+! an older FESOM; nothing writes this layout any more.
+pure function nc_restart_path_legacy(component, year, root_path) result(path)
   implicit none
   character(len=*), intent(in) :: component, root_path
   integer, intent(in) :: year
   character(:), allocatable :: path
   character(4) :: cyear
-  
+
   write(cyear, '(i4)') year
   path = trim(root_path) // trim(runid) // '.' // cyear // '.' // trim(component) // '.restart.nc'
-end function nc_restart_path
+end function nc_restart_path_legacy
 
 ! Build raw restart directory path
 pure function build_raw_restart_dirpath(root_path) result(path)
@@ -376,15 +395,23 @@ subroutine read_initial_conditions(which_readr, ice, dynamics, tracers, partit, 
   character(:), allocatable :: read_raw_dirpath, read_raw_infopath
   character(:), allocatable :: read_bin_dirpath, read_bin_infopath
   character(:), allocatable :: read_oce_path, read_ice_path, read_bio_path
+  character(:), allocatable :: legacy_oce_path, legacy_ice_path, legacy_bio_path
   
   ! Build paths for reading using RestartInPath
   read_raw_dirpath = build_raw_restart_dirpath(RestartInPath)//"/np"//int_to_txt(partit%npes)
   read_raw_infopath = build_raw_restart_infopath(RestartInPath)//"/np"//int_to_txt(partit%npes)//".info"
   read_bin_dirpath = build_bin_restart_dirpath(RestartInPath)//"/np"//int_to_txt(partit%npes)
   read_bin_infopath = build_bin_restart_infopath(RestartInPath)//"/np"//int_to_txt(partit%npes)//".info"
-  read_oce_path = nc_restart_path('oce', yearold, RestartInPath)
-  read_ice_path = nc_restart_path('ice', yearold, RestartInPath)
-  read_bio_path = nc_restart_path('bio', yearold, RestartInPath)
+  ! Restart to read: the file stamped with the instant the clock file points at.
+  ! yearold, not yearnew, addresses the legacy fallback, because a pre-2.8 restart
+  ! file is named after the year the record was written in, which for a restart at
+  ! a year boundary is the year that just ended.
+  read_oce_path = nc_restart_path('oce', RestartInPath)
+  read_ice_path = nc_restart_path('ice', RestartInPath)
+  read_bio_path = nc_restart_path('bio', RestartInPath)
+  legacy_oce_path = nc_restart_path_legacy('oce', yearold, RestartInPath)
+  legacy_ice_path = nc_restart_path_legacy('ice', yearold, RestartInPath)
+  legacy_bio_path = nc_restart_path_legacy('bio', yearold, RestartInPath)
 
   ! Initialize file groups for reading
   call ini_ocean_io(dynamics, tracers, partit, mesh)
@@ -442,16 +469,18 @@ subroutine read_initial_conditions(which_readr, ice, dynamics, tracers, partit, 
     
     ! Read OCEAN restart
     if (partit%mype==RAW_RESTART_METADATA_RANK) print *, achar(27)//'[1;33m'//' --> read restarts from netcdf file: ocean'//achar(27)//'[0m'
-    call read_netcdf_restarts(read_oce_path, oce_files, partit%MPI_COMM_FESOM, partit%mype)
+    call read_netcdf_restarts(read_oce_path, legacy_oce_path, oce_files, partit%MPI_COMM_FESOM, partit%mype)
     
     ! Read ICE/ICEPACK restart
     if (use_ice) then
 #if defined(__icepack)   
         if (partit%mype==RAW_RESTART_METADATA_RANK) print *, achar(27)//'[1;33m'//' --> read restarts from netcdf file: icepack'//achar(27)//'[0m'
-        call read_netcdf_restarts(nc_restart_path('icepack', yearold, RestartInPath), icepack_files, partit%MPI_COMM_FESOM, partit%mype)
+        call read_netcdf_restarts(nc_restart_path('icepack', RestartInPath), &
+                                  nc_restart_path_legacy('icepack', yearold, RestartInPath), &
+                                  icepack_files, partit%MPI_COMM_FESOM, partit%mype)
 #else            
         if (partit%mype==RAW_RESTART_METADATA_RANK) print *, achar(27)//'[1;33m'//' --> read restarts from netcdf file: ice'//achar(27)//'[0m'
-        call read_netcdf_restarts(read_ice_path, ice_files, partit%MPI_COMM_FESOM, partit%mype)            
+        call read_netcdf_restarts(read_ice_path, legacy_ice_path, ice_files, partit%MPI_COMM_FESOM, partit%mype)
 #endif
     end if 
 
@@ -459,7 +488,7 @@ subroutine read_initial_conditions(which_readr, ice, dynamics, tracers, partit, 
     ! Read RECOM restarts
     if (REcoM_restart) then
         if (partit%mype==RAW_RESTART_METADATA_RANK) print *, achar(27)//'[1;33m'//' --> read restarts from netcdf file: bio'//achar(27)//'[0m'
-        call read_netcdf_restarts(read_bio_path, bio_files, partit%MPI_COMM_FESOM, partit%mype)
+        call read_netcdf_restarts(read_bio_path, legacy_bio_path, bio_files, partit%MPI_COMM_FESOM, partit%mype)
     end if
 #endif
 
@@ -523,10 +552,6 @@ subroutine write_initial_conditions(istep, nstart, ntotal, which_readr, ice, dyn
   write_raw_infopath = build_raw_restart_infopath(RestartOutPath)//"/np"//int_to_txt(partit%npes)//".info"
   write_bin_dirpath = build_bin_restart_dirpath(RestartOutPath)//"/np"//int_to_txt(partit%npes)
   write_bin_infopath = build_bin_restart_infopath(RestartOutPath)//"/np"//int_to_txt(partit%npes)//".info"
-  write_oce_path = nc_restart_path('oce', yearnew, RestartOutPath)
-  write_ice_path = nc_restart_path('ice', yearnew, RestartOutPath)
-  write_icepack_path = nc_restart_path('icepack', yearnew, RestartOutPath)
-  write_bio_path = nc_restart_path('bio', yearnew, RestartOutPath)
   
   !_____________________________________________________________________________
   ! Initialize output directories on first call
@@ -618,6 +643,14 @@ subroutine write_initial_conditions(istep, nstart, ntotal, which_readr, ice, dyn
 
   ! Write restart files
   if(is_portable_restart_write) then
+
+    ! Built here rather than once at the top of the routine: the stamp moves with
+    ! the clock, so every restart event in a run gets its own set of files, and
+    ! this is the only branch that needs them.
+    write_oce_path     = nc_restart_path('oce',     RestartOutPath)
+    write_ice_path     = nc_restart_path('ice',     RestartOutPath)
+    write_icepack_path = nc_restart_path('icepack', RestartOutPath)
+    write_bio_path     = nc_restart_path('bio',     RestartOutPath)
 
   ! --> synchronizes tracer data within fesom groups
 
@@ -735,6 +768,12 @@ end subroutine write_initial_conditions
 !
 !
 !_______________________________________________________________________________
+! One restart instant per file: `path` is stamped with the date of the instant
+! being written, so a set of files is created fresh on every restart event and
+! holds exactly one record. There is no create-versus-append decision left --
+! the only way to arrive at a file that already exists is to rerun the same
+! instant, which must overwrite. That is also why open_write_create clobbers:
+! a run resubmitted over the wreckage of a crashed one has to be able to write.
 subroutine write_netcdf_restarts(path, filegroup, istep)
   use fortran_utils
   character(len=*), intent(in) :: path
@@ -745,7 +784,6 @@ subroutine write_netcdf_restarts(path, filegroup, istep)
   integer i
   character(:), allocatable :: dirpath
   character(:), allocatable :: filepath
-  logical file_exists
   integer mpierr_par
 
   cstep = globalstep+istep
@@ -762,40 +800,24 @@ subroutine write_netcdf_restarts(path, filegroup, istep)
       ! take part in the create and in every put_var. Non-writers skip it and
       ! only join the redistribution inside the write call.
       !
-      ! The path/create-vs-append decision is taken identically on every writer:
-      ! they inspect the same filesystem and hold the same `path` state, so no
-      ! broadcast is needed. mkdir is idempotent and only rank 0 calls it, with
-      ! a barrier afterwards so no writer races ahead to create inside a
-      ! directory that does not exist yet.
+      ! mkdir is idempotent and only rank 0 calls it, with a barrier afterwards
+      ! so no writer races ahead to create inside a directory that does not
+      ! exist yet.
       if(filegroup%files(i)%is_writer()) then
         if(filegroup%files(i)%is_attached()) call filegroup%files(i)%close_file()
-
-        dirpath = path(1:len(path)-3)
-        filepath = dirpath//"/"//filegroup%files(i)%varname//".nc"
-
-        if(filegroup%files(i)%path == "" .or. (.not. filegroup%files(i)%must_exist_on_read)) then
-          inquire(file=filepath, exist=file_exists)
-          if(file_exists) then
-            filegroup%files(i)%path = filepath
-          else if(.not. filegroup%files(i)%must_exist_on_read) then
-            filegroup%files(i)%path = ""
-          end if
-        end if
       end if
 
-      if(filegroup%files(i)%is_lead_writer()) call mkdir(path(1:len(path)-3))
+      dirpath = path(1:len(path)-3)
+      filepath = dirpath//"/"//filegroup%files(i)%varname//".nc"
+
+      if(filegroup%files(i)%is_lead_writer()) call mkdir(dirpath)
       if(filegroup%files(i)%is_writer()) &
          call MPI_Barrier(filegroup%files(i)%writer_comm(), mpierr_par)
 
       if(filegroup%files(i)%is_writer()) then
-        if(filegroup%files(i)%path .ne. filepath) then
-          filegroup%files(i)%path = filepath
-          call filegroup%files(i)%open_write_create_par(filegroup%files(i)%path, &
-                                                        filegroup%files(i)%writer_comm())
-        else
-          call filegroup%files(i)%open_write_append_par(filegroup%files(i)%path, &
-                                                        filegroup%files(i)%writer_comm())
-        end if
+        filegroup%files(i)%path = filepath
+        call filegroup%files(i)%open_write_create_par(filegroup%files(i)%path, &
+                                                      filegroup%files(i)%writer_comm())
 
         ! iter and time are per-record scalars, but they are in COLLECTIVE access
         ! mode like every other variable, and writing them extends the unlimited
@@ -820,26 +842,12 @@ subroutine write_netcdf_restarts(path, filegroup, istep)
       dirpath = path(1:len(path)-3) ! chop of the ".nc" suffix
       filepath = dirpath//"/"//filegroup%files(i)%varname//".nc"
 
-      if(filegroup%files(i)%path == "" .or. (.not. filegroup%files(i)%must_exist_on_read)) then
-        ! the path to an existing restart file is not set in read_netcdf_restarts if we had a restart from a raw restart
-        ! OR we might have skipped the file when reading restarts and it does not exist at all
-        inquire(file=filepath, exist=file_exists)
-        if(file_exists) then
-          filegroup%files(i)%path = filepath
-        else if(.not. filegroup%files(i)%must_exist_on_read) then
-          filegroup%files(i)%path = ""
-        end if
-      end if
-      if(filegroup%files(i)%path .ne. filepath) then
-        ! execute_command_line with mkdir sometimes fails, use a custom implementation around mkdir from C instead
-        call mkdir(dirpath)
-        filegroup%files(i)%path = filepath
-        call filegroup%files(i)%open_write_create(filegroup%files(i)%path)
-      else
-        call filegroup%files(i)%open_write_append(filegroup%files(i)%path) ! todo: keep the file open between writes
-      end if
+      ! execute_command_line with mkdir sometimes fails, use a custom implementation around mkdir from C instead
+      call mkdir(dirpath)
+      filegroup%files(i)%path = filepath
+      call filegroup%files(i)%open_write_create(filegroup%files(i)%path)
 
-      write(*,*) 'writing restart record ', filegroup%files(i)%rec_count()+1, ' to ', filegroup%files(i)%path
+      write(*,*) 'writing restart to ', filegroup%files(i)%path
       call filegroup%files(i)%write_var(filegroup%files(i)%iter_varindex, [filegroup%files(i)%rec_count()+1], [1], [cstep])
       ! todo: write time via the fesom_file_type
       call filegroup%files(i)%write_var(filegroup%files(i)%time_varindex(), [filegroup%files(i)%rec_count()+1], [1], [ctime])
@@ -1014,8 +1022,113 @@ end subroutine finalize_restart
 !
 !
 !_______________________________________________________________________________
-subroutine read_netcdf_restarts(path, filegroup, mpicomm, mype)
+! Which of the two restart layouts is actually on disk.
+!
+! Preferred is the date-stamped one this version writes. A restart directory
+! left behind by an older FESOM is named after the year instead and holds every
+! restart record of that year in one file per variable; those are still read, so
+! a chain of runs does not have to be broken to upgrade. Nothing writes that
+! layout any more.
+!
+! One rank inspects the filesystem and tells the others, rather than every rank
+! inquiring: the answer selects a collective open further down, so all ranks
+! have to agree on it even if the filesystem hands out different answers to
+! different clients while a directory is being created.
+function resolve_read_path(path, legacy_path, filegroup, mpicomm, mype) result(read_path)
+  character(len=*), intent(in) :: path, legacy_path
+  type(restart_file_group), intent(in) :: filegroup
+  integer, intent(in) :: mpicomm, mype
+  character(:), allocatable :: read_path
+  ! EO parameters
+
+  if(restart_group_exists(path, filegroup, mpicomm, mype)) then
+    read_path = path
+  else if(restart_group_exists(legacy_path, filegroup, mpicomm, mype)) then
+    read_path = legacy_path
+    if(mype == RAW_RESTART_METADATA_RANK) then
+      ! Report the directories, not the internal ".nc"-suffixed handles: what is
+      ! on disk, and what the user would look for, is the directory.
+      write(*,*) 'restart: no ', path(1:len(path)-3)
+      write(*,*) 'restart: falling back to the pre-2.8 yearly restart ', legacy_path(1:len(legacy_path)-3)
+    end if
+  else
+    ! Neither is there. Hand back the preferred name so the per-file handling
+    ! below reports the miss against the name the run actually asked for.
+    read_path = path
+  end if
+end function resolve_read_path
+!
+!_______________________________________________________________________________
+! Is a restart for this file group sitting at `path`?
+!
+! Probed with a file that has to be there if the restart is there at all: an
+! optional variable may legitimately be missing, and treating that as a missing
+! restart would send the run off to the wrong source. One rank inspects and
+! tells the others, for the reason given on resolve_read_path.
+function restart_group_exists(path, filegroup, mpicomm, mype) result(exists)
   character(len=*), intent(in) :: path
+  type(restart_file_group), intent(in) :: filegroup
+  integer, intent(in) :: mpicomm, mype
+  logical :: exists
+  ! EO parameters
+  integer :: probe, i, mpierr, found
+  logical :: file_exists
+
+  probe = 0
+  do i=1, filegroup%nfiles
+    if(filegroup%files(i)%must_exist_on_read) then
+      probe = i
+      exit
+    end if
+  end do
+
+  found = 0
+  if(probe > 0 .and. mype == RAW_RESTART_METADATA_RANK) then
+    inquire(file=path(1:len(path)-3)//"/"//filegroup%files(probe)%varname//".nc", exist=file_exists)
+    if(file_exists) found = 1
+  end if
+  call MPI_Bcast(found, 1, MPI_INTEGER, RAW_RESTART_METADATA_RANK, mpicomm, mpierr)
+  exists = (found == 1)
+end function restart_group_exists
+!
+!_______________________________________________________________________________
+! Pin the record this file is read from: the one whose time stamp matches the
+! clock, searched from the back.
+!
+! A restart file written by this version holds a single record and the search
+! ends immediately. A pre-2.8 file holds every restart of its year, and the read
+! used to take the last record unconditionally -- so setting the clock back to
+! an earlier restart point silently loaded the state of the latest one instead.
+! Falling back to the last record when nothing matches keeps that old behaviour
+! for the case it was tolerable in, restarting with a changed time step, but
+! says so.
+subroutine pin_restart_record(f, varname, report)
+  class(fesom_file_type), intent(inout) :: f
+  character(len=*), intent(in) :: varname
+  logical, intent(in) :: report
+  ! EO parameters
+  integer :: k
+  real(kind=WP) :: rtime
+
+  do k=f%rec_count(), 1, -1
+    call f%read_var1(f%time_varindex(), [k], rtime)
+    if(int(rtime) == int(ctime)) then
+      call f%set_read_record(k)
+      return
+    end if
+  end do
+
+  call f%set_read_record(f%rec_count())
+  if(report) then
+    write(*,*) 'restart '//trim(varname)//' WARNING: no record matches the clock time', ctime
+    write(*,*) '         using the last of ', f%rec_count(), ' records instead'
+  end if
+end subroutine pin_restart_record
+!
+!_______________________________________________________________________________
+subroutine read_netcdf_restarts(path, legacy_path, filegroup, mpicomm, mype)
+  character(len=*), intent(in) :: path        !< date-stamped restart, one instant per file
+  character(len=*), intent(in) :: legacy_path !< pre-2.8 name, tried only if `path` is not there
   type(restart_file_group), intent(inout) :: filegroup
   integer, intent(in) :: mpicomm
   integer, intent(in) :: mype
@@ -1023,6 +1136,7 @@ subroutine read_netcdf_restarts(path, filegroup, mpicomm, mype)
   real(kind=WP) rtime
   integer i
   character(:), allocatable :: dirpath
+  character(:), allocatable :: read_path
   integer mpistatus(MPI_STATUS_SIZE)
   logical file_exists
   logical, allocatable :: skip_file(:)
@@ -1032,6 +1146,8 @@ subroutine read_netcdf_restarts(path, filegroup, mpicomm, mype)
   
   ! Calculate current time from clock (seconds from beginning of year)
   ctime = timeold + (dayold - 1.0_WP) * 86400.0_WP
+
+  read_path = resolve_read_path(path, legacy_path, filegroup, mpicomm, mype)
   
   allocate(skip_file(filegroup%nfiles))
   skip_file = .false.
@@ -1040,7 +1156,7 @@ subroutine read_netcdf_restarts(path, filegroup, mpicomm, mype)
     current_iorank_snd = 0
     current_iorank_rcv = 0
     if( filegroup%files(i)%is_iorank() ) then
-      dirpath = path(1:len(path)-3) ! chop of the ".nc" suffix
+      dirpath = read_path(1:len(read_path)-3) ! chop of the ".nc" suffix
       if(filegroup%files(i)%path .ne. dirpath//"/"//filegroup%files(i)%varname//".nc") then
         filegroup%files(i)%path = dirpath//"/"//filegroup%files(i)%varname//".nc"
 
@@ -1073,11 +1189,10 @@ subroutine read_netcdf_restarts(path, filegroup, mpicomm, mype)
     end if
 
     ! Collective read: every reader opens the file for itself. The path is
-    ! derived from `path` and the file's own varname, both of which every rank
-    ! holds, so the readers agree without a broadcast -- the same argument the
-    ! collective write path makes about create-versus-append.
+    ! derived from `read_path` and the file's own varname, both of which every
+    ! rank holds, so the readers agree without a broadcast.
     if(parallel_write_enabled() .and. .not. skip_file(i)) then
-      dirpath = path(1:len(path)-3)                       ! chop the ".nc" suffix
+      dirpath = read_path(1:len(read_path)-3)             ! chop the ".nc" suffix
       filegroup%files(i)%path = dirpath//"/"//filegroup%files(i)%varname//".nc"
       if(filegroup%files(i)%is_reader()) then
         if(filegroup%files(i)%is_attached()) call filegroup%files(i)%close_file()
@@ -1120,6 +1235,19 @@ subroutine read_netcdf_restarts(path, filegroup, mpicomm, mype)
     !  https://github.com/FESOM/fesom2/pull/801                               !
     ! ========================================================================!
 
+    ! Choose the record BEFORE reading, on exactly the ranks that hold the file
+    ! open. They all inspect the same file and reach the same answer, so this
+    ! needs no broadcast -- the same argument the reader set uses for the record
+    ! count.
+    if(.not. skip_file(i)) then
+      if(merge(filegroup%files(i)%is_reader(), filegroup%files(i)%is_iorank(), &
+               parallel_write_enabled())) then
+        ! Report from the first file only: the record layout is the same for
+        ! every variable of a group, and a group has hundreds of them.
+        call pin_restart_record(filegroup%files(i), filegroup%files(i)%varname, i == 1)
+      end if
+    end if
+
     if(.not. skip_file(i)) then
       call filegroup%files(i)%read_and_scatter_variables()
     end if
@@ -1137,13 +1265,14 @@ subroutine read_netcdf_restarts(path, filegroup, mpicomm, mype)
     ! n_writers_restart -- so this must be is_lead_reader, not is_lead_writer.
     if(merge(filegroup%files(i)%is_lead_reader(), filegroup%files(i)%is_iorank(), &
              parallel_write_enabled())) then
-      write(*,*) 'restart from record ', filegroup%files(i)%rec_count(), ' of ', filegroup%files(i)%rec_count(), filegroup%files(i)%path
+      write(*,*) 'restart from record ', filegroup%files(i)%read_record(), ' of ', &
+                 filegroup%files(i)%rec_count(), filegroup%files(i)%path
 
-      ! read the last entry from the iter variable
-      call filegroup%files(i)%read_var1(filegroup%files(i)%iter_varindex, [filegroup%files(i)%rec_count()], globalstep)
+      ! read the selected record's iter variable
+      call filegroup%files(i)%read_var1(filegroup%files(i)%iter_varindex, [filegroup%files(i)%read_record()], globalstep)
 
-      ! read the last entry from the time variable
-      call filegroup%files(i)%read_var1(filegroup%files(i)%time_varindex(), [filegroup%files(i)%rec_count()], rtime)
+      ! read the selected record's time variable
+      call filegroup%files(i)%read_var1(filegroup%files(i)%time_varindex(), [filegroup%files(i)%read_record()], rtime)
       ! On the collective path the close is done below by the whole reader set.
       if(.not. parallel_write_enabled()) call filegroup%files(i)%close_file()
 

--- a/test/fortran/fortran_utils_tests.pf
+++ b/test/fortran/fortran_utils_tests.pf
@@ -40,5 +40,77 @@ contains
   end subroutine
 
 
+  ! calendar_stamp: the name a restart file gets from the clock state.
+  ! The cases that matter are the ones where the writer's clock state and the
+  ! reader's differ in representation but mean the same instant.
+
+  @test
+  subroutine test_stamp_of_a_plain_date
+    ! 1 March 1958 is day 60 of a non-leap year
+    @assertEqual("1958-03-01", calendar_stamp(1958, 60, 0, 365))
+  end subroutine
+
+
+  @test
+  subroutine test_end_of_day_is_start_of_next_day
+    ! what the writer holds at the end of 28 February ...
+    @assertEqual("1958-03-01", calendar_stamp(1958, 59, 86400, 365))
+    ! ... and what the reader holds after clock_init normalised it
+    @assertEqual("1958-03-01", calendar_stamp(1958, 60, 0, 365))
+  end subroutine
+
+
+  @test
+  subroutine test_end_of_year_rolls_into_january
+    ! the writer's state at the end of 31 December 1958
+    @assertEqual("1959-01-01", calendar_stamp(1958, 365, 86400, 365))
+    ! the reader's state, normalised into the next year by clock_finish
+    @assertEqual("1959-01-01", calendar_stamp(1959, 1, 0, 365))
+  end subroutine
+
+
+  @test
+  subroutine test_end_of_leap_year_rolls_into_january
+    @assertEqual("1961-01-01", calendar_stamp(1960, 366, 86400, 366))
+  end subroutine
+
+
+  @test
+  subroutine test_leap_day_is_not_shifted_into_march
+    ! day 60 is 29 February in a leap year, 1 March otherwise
+    @assertEqual("1960-02-29", calendar_stamp(1960, 60, 0, 366))
+    @assertEqual("1960-03-01", calendar_stamp(1960, 61, 0, 366))
+  end subroutine
+
+
+  @test
+  subroutine test_day_366_of_a_leap_year_is_31_december
+    @assertEqual("1960-12-31", calendar_stamp(1960, 366, 0, 366))
+  end subroutine
+
+
+  @test
+  subroutine test_instants_inside_a_day_share_a_stamp
+    ! the stamp is a date, so anything short of the end of the day is that date
+    @assertEqual("1958-03-01", calendar_stamp(1958, 60, 21600, 365))
+    @assertEqual("1958-03-01", calendar_stamp(1958, 60, 84600, 365))
+  end subroutine
+
+
+  @test
+  subroutine test_stamp_is_idempotent_under_normalisation
+    ! the read side applies the stamp to clock state the clock module has
+    ! already normalised; that must not shift the date a second time
+    @assertEqual(calendar_stamp(1958, 59, 86400, 365), calendar_stamp(1958, 60, 0, 365))
+    @assertEqual(calendar_stamp(1958, 365, 86400, 365), calendar_stamp(1959, 1, 0, 365))
+  end subroutine
+
+
+  @test
+  subroutine test_first_and_last_day_of_a_year
+    @assertEqual("1958-01-01", calendar_stamp(1958, 1, 0, 365))
+    @assertEqual("1958-12-31", calendar_stamp(1958, 365, 0, 365))
+  end subroutine
+
 
 end module


### PR DESCRIPTION
Restart files are now one model state per file, named after the date of that state. This closes two long standing issues that both come out of the old layout.

Closes #279
Closes #533

## The old layout

A netCDF restart was one directory per year, holding every restart record written during that year in one file per variable. Two problems follow:

**Only the last record was ever readable.** Every read path took `rec_count()` unconditionally, so setting the clock back to an earlier restart point ran on silently with the state of the latest one. The hard error reported in #279 has since been downgraded to a warning, which arguably made it worse: the run now continues with the wrong state instead of stopping.

**Resubmitting after a crash could not write.** The create/append decision came from the file's cached path plus an `inquire` that was skipped whenever the restart had been read from a different directory, which is the normal esm-tools layout. The create then ran with `NC_NOCLOBBER` and aborted on the debris of the killed run.

## What this changes

A restart set is named after the instant it holds and holds exactly one record:

```
fesom.1959-01-01.oce.restart/    ssh.nc, temp.nc, salt.nc, ...
fesom.1959-01-01.ice.restart/    area.nc, hice.nc, ...
```

Restarts more frequent than daily share a name and the later one wins. That is no worse than the old layout, where only the last of them was reachable anyway.

The date is the instant the state belongs to. A run finishing at the end of 1958 leaves a restart called `1959-01-01`, which is the moment the next run continues from and the moment the second row of the clock file names. Picking an earlier restart is now a matter of setting the clock to its date.

Other changes that follow:

- `write_netcdf_restarts` always creates. With one instant per file the only way to reach an existing file is to rerun that instant, which must overwrite, so the create/append decision is gone rather than repaired. `open_write_create` clobbers for the same reason.
- The read picks the record matching the clock instead of the last one. For a file this version wrote that is a formality. It is what makes an earlier restart reachable in the files older versions wrote.
- `RestartInPath` and `RestartOutPath` were read by the namelist but missing from `config/namelist.config`.

## Backwards compatibility

Restarts written before 2.8 are still read. If no date-stamped restart is found for the requested instant, the yearly name is tried, and the record matching the clock is picked out of it. Nothing writes that layout any more, so a chain of runs does not have to be broken to upgrade.

## Verification

Real runs on the pi mesh, 2 ranks, cold start plus restart:

| Case | Result |
| --- | --- |
| Cold start, then restart | writes `1948-01-02`, reads it back as record 1 of 1, writes `1948-01-03` |
| Legacy yearly file, clock on the first of two records | `restart from record 1 of 2`, continued iter 36 to 72 |
| Same file, clock on the second record | `restart from record 2 of 2`, continued iter 72 to 108 |
| Single old-named restart handed over on its own | falls back, reads, continues |
| Same, with raw restarts enabled | raw path unchanged, still writes date-stamped netCDF restarts |
| Resubmit over a truncated leftover file | overwrites cleanly, no `NC_NOCLOBBER` |

The first legacy case is the one that matters most. Old FESOM would have taken record 2 there and silently continued from the wrong state.

The date arithmetic sits in `fortran_utils` as `calendar_stamp`, free of model dependencies, with unit tests covering the year boundary in a leap and a non-leap year, the leap day itself, and the idempotency the read side depends on.

`g_clock` already carries `month` and `day_in_month`, but they are derived from `daynew` without the end-of-day and end-of-year normalisation, which is what makes them unusable here. A run ending at `86400.0 1 1948` has `daynew = 1`, so `month`/`day_in_month` say 1 January while the instant is 1948-01-02 00:00, which is what the reader reconstructs after `clock_init` normalises. Naming the file from them would have made the writer and the reader disagree on exactly the midnight case that almost every restart lands on. The other consumers of `month`/`day_in_month` want the un-normalised convention, `gen_events.F90` for instance tests `day_in_month==num_day_in_month(...) .and. timenew==86400`, so this does not replace them.

## Downstream

esm-tools looks for the old restart names and will need a corresponding update. Happy to open an issue there once this direction is agreed.

## Left out on purpose

The raw and derived-type binary restarts are untouched. They are per-run core dumps tied to the process count and are overwritten on every write, so the naming question does not arise for them.

A raw restart is still preferred over the netCDF one whenever it is present, which means setting the clock back has no effect until `fesom_raw_restart` is removed. That is the first thing @hegish had to rule out in #279, so it is arguably part of that issue, but it is a behavioural change to a different mechanism that is on by default, and it belongs in its own PR where it can be tested properly. The docs now state the behaviour so it is at least discoverable. Happy to do it separately.

