### PR TITLE
docs: how to debug an iceberg run

### DIFF
--- a/docs/general_configuration/general_configuration.rst
+++ b/docs/general_configuration/general_configuration.rst
@@ -182,5 +182,15 @@ iceberg holding the geometry, the position, the velocity, the drag
 coefficients and densities, the calving day and the grounded and melted
 flags. When
 ``use_icesheet_coupling=.true.`` the restart also carries the state needed to
-exchange calving with an ice-sheet model. Setting ``lverbose_icb=.true.``
-prints per-iceberg diagnostics.
+exchange calving with an ice-sheet model.
+
+When a run looks wrong, for example because trajectories are implausible or
+the ocean temperature blows up near icebergs, the first things to look at are
+the three-dimensional iceberg heat flux, available as the ``ibhf`` output
+stream, and the two state flags that stop an iceberg from drifting: the
+grounded flag described above and the frozen-in flag, which is set when the
+surrounding sea ice is thick and compact enough to lock the iceberg in.
+Setting ``lverbose_icb=.true.`` prints per-iceberg diagnostics and is the way
+to check that the cell saturation mechanism set by ``cell_saturation`` is
+behaving, which is the usual cause when the freshwater input distorts a small
+coastal cell.


### PR DESCRIPTION
Follow-up to the review comment on #1037.

@ackerlar described the debugging path he actually uses, which is more useful than the bare statement that `lverbose_icb` prints diagnostics. This writes it down: the three-dimensional iceberg heat flux (`ibhf` output stream) and the grounded and frozen-in flags first, then the verbose output to check the cell saturation mechanism behind `cell_saturation`.

Checked against the code: `ibhf` is defined as a stream in `io_meandata.F90`, `frozen_in` is set by `iceberg_frozen` in `icb_dyn.F90` from the pressure and concentration sills, `grounded` is in `icb_modules.F90`, and `cell_saturation` drives the coastal-point logic in `icb_step.F90`.

@ackerlar please check that I described the frozen-in condition and the cell saturation purpose the way you meant them.