### PR TITLE
ice: scale the mass-matrix sanity tolerance with the working precision

### DIFF
--- a/src/ice_fct.F90
+++ b/src/ice_fct.F90
@@ -1175,6 +1175,10 @@ SUBROUTINE ice_mass_matrix_fill(ice, partit, mesh)
     integer                             :: n, k, row
     integer                             :: elem, elnodes(3), q, offset, ipos
     real(kind=WP)                       :: aa
+    ! Row sum and area each accumulate O(nn_num) rounded terms, so the mismatch
+    ! scales with the area. An absolute tolerance is unreachable for WP=real32.
+    ! Not a parameter: nvfortran rejects spacing() in an initialization expression.
+    real(kind=WP)                       :: mass_matrix_rtol
     integer                             :: flag=0, iflag=0
     !___________________________________________________________________________
     ! pointer on necessary derived types
@@ -1184,6 +1188,7 @@ SUBROUTINE ice_mass_matrix_fill(ice, partit, mesh)
 #include "associate_part_ass.h"
 #include "associate_mesh_ass.h"
     mass_matrix => ice%work%fct_massmatrix(:)
+    mass_matrix_rtol=100.0_WP*spacing(1.0_WP)
     !
     ! a)
 !$OMP PARALLEL DEFAULT(SHARED) PRIVATE(n, k, row, elem, elnodes, q, offset, ipos, aa)
@@ -1243,8 +1248,7 @@ SUBROUTINE ice_mass_matrix_fill(ice, partit, mesh)
         offset=ssh_stiff%rowptr(q)-ssh_stiff%rowptr(1)+1
         n=ssh_stiff%rowptr(q+1)-ssh_stiff%rowptr(1)
         aa=sum(mass_matrix(offset:n))
-        !!PS if(abs(area(1,q)-aa)>.1_WP) then
-        if(abs(area(ulevels_nod2d(q),q)-aa)>.1_WP) then
+        if(abs(area(ulevels_nod2d(q),q)-aa)>mass_matrix_rtol*area(ulevels_nod2d(q),q)) then
 !$OMP CRITICAL
             iflag=q
             flag=1

--- a/src/icepack_drivers/icedrv_advection.F90
+++ b/src/icepack_drivers/icedrv_advection.F90
@@ -145,6 +145,10 @@ submodule (icedrv_main) icedrv_advection
         integer(kind=int_kind)                 :: elem, elnodes(3), q, offset, col, ipos
         integer(kind=int_kind), allocatable    :: col_pos(:)
         real(kind=dbl_kind)                    :: aa
+        ! Row sum and area each accumulate O(nn_num) rounded terms, so the mismatch
+        ! scales with the area. An absolute tolerance is unreachable for WP=real32.
+        ! Not a parameter: nvfortran rejects spacing() in an initialization expression.
+        real(kind=WP)                          :: mass_matrix_rtol
         integer(kind=int_kind)                 :: flag=0 ,iflag=0
         type(t_mesh), intent(in), target       :: mesh
       
@@ -174,11 +178,12 @@ submodule (icedrv_main) icedrv_advection
         enddo
       
         ! TEST: area == sum of row entries in mass_matrix:
+        mass_matrix_rtol = 100.0_WP*spacing(1.0_WP)
         do q = 1, nx_nh
            offset = ssh_stiff%rowptr(q)   - ssh_stiff%rowptr(1) + 1
            n      = ssh_stiff%rowptr(q+1) - ssh_stiff%rowptr(1)
            aa     = sum(mass_matrix(offset:n))
-           if ( abs(area(1,q)-aa) > p1) then
+           if ( abs(area(1,q)-aa) > mass_matrix_rtol*area(1,q)) then
               iflag = q
               flag  = 1
            endif


### PR DESCRIPTION
Fixes #1041.

The mass-matrix row sum and the nodal area each accumulate O(nn_num) rounded
terms, so their mismatch scales with the area. The absolute 0.1 m^2 bound is
unreachable for `WP=real32`, so every rank of every SP run printed
`#### MASS MATRIX PROBLEM`. Replaced by `100 * spacing(1.0_WP) * area`.

**Why 100 eps.** Instrumented the check to report the max relative mismatch on
the pi mesh: **2.7 eps in SP, 2.5 eps in DP** — the same multiple of eps in both,
i.e. pure accumulation roundoff. The accumulation length is node valence, which
is bounded by the triangulation rather than mesh size (max 8 on pi, 9 on
AWICM_LR, 8 on AWICM_HR), so that measurement carries to production meshes and
100 eps keeps ~37x margin. A real assembly fault is O(0.1) relative; injecting a
1e-3 fault still trips the check in both precisions.

Note this check cannot see mesh-metric error — it compares two accumulations of
the same `elem_area` values, so SP coordinate-differencing error cancels exactly.

Two implementation constraints, hence a runtime local rather than a `parameter`:
nvfortran rejects `spacing()` in an initialization expression (NVHPC is a
supported compiler), and `epsilon()` is shadowed tree-wide by the AB2 offset
variable in `o_PARAM`.

Second commit applies the same change to the icepack copy of the check. That one
is `USE_ICEPACK=ON` only (off by default, and SP+icepack does not currently
build), so it is consistency rather than a live fix — droppable if you want this
minimal.

Verified: DP and SP local CTest suites 13/13 each with no `MASS MATRIX PROBLEM`
lines
