### PR TITLE
Resolve relative forcing file names against a new ForcingDataPath

### DIFF
--- a/cmake/FesomTesting.cmake
+++ b/cmake/FesomTesting.cmake
@@ -70,6 +70,9 @@ function(update_common_paths_with_mesh NAMELIST_IN NAMELIST_OUT TEST_DATA_DIR RE
     # preserved via the "\\1" backreference.
     string(REGEX REPLACE "([^A-Za-z0-9_])MeshPath[ \t]*=[ \t]*'[^']*'" "\\1MeshPath='${TEST_DATA_DIR}/MESHES/${MESH_NAME}/'" CONTENT "${CONTENT}")
     string(REGEX REPLACE "([^A-Za-z0-9_])ClimateDataPath[ \t]*=[ \t]*'[^']*'" "\\1ClimateDataPath='${TEST_DATA_DIR}/'" CONTENT "${CONTENT}")
+    # Forcing file names in namelist.forcing are bare, so this must point at the
+    # dataset directory itself. CORE2 is the default; the JRA variant repoints it.
+    string(REGEX REPLACE "([^A-Za-z0-9_])ForcingDataPath[ \t]*=[ \t]*'[^']*'" "\\1ForcingDataPath='${TEST_DATA_DIR}/FORCING/CORE2/'" CONTENT "${CONTENT}")
     string(REGEX REPLACE "([^A-Za-z0-9_])ResultPath[ \t]*=[ \t]*'[^']*'" "\\1ResultPath='${RESULT_DIR}/'" CONTENT "${CONTENT}")
     string(REGEX REPLACE "([^A-Za-z0-9_])fwf_path[ \t]*=[ \t]*'[^']*'" "\\1fwf_path='${TEST_DATA_DIR}/MESHES/${MESH_NAME}/'" CONTENT "${CONTENT}")
     string(REGEX REPLACE "([^A-Za-z0-9_])age_tracer_path[ \t]*=[ \t]*'[^']*'" "\\1age_tracer_path='${TEST_DATA_DIR}/MESHES/${MESH_NAME}/'" CONTENT "${CONTENT}")
@@ -261,9 +264,9 @@ endfunction()
 # Function to configure namelist.forcing for the bundled JRA55 test dataset.
 # The stock config/namelist.forcing.JRA points at absolute Levante pool paths
 # (/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/...); this rewrites them to the
-# bundled tests/data/FORCING/JRA55 tree. Paths are made RELATIVE (no leading '/')
-# so FESOM's make_full_path() prepends ClimateDataPath (=tests/data/), exactly as
-# the CORE2 variant resolves 'FORCING/CORE2/...'. The forcing file names, variable
+# bundled tests/data/FORCING/JRA55 tree. Paths are reduced to BARE FILE NAMES so
+# FESOM's make_full_path() prepends ForcingDataPath, which the caller repoints at
+# tests/data/FORCING/JRA55/ below. The forcing file names, variable
 # names, time-axis reference (nm_nc_iyear=1900, nm_nc_freq=1 -- the bundled axis is
 # already in days) and the .true. l_* switches are taken as-is from the config
 # variant. The paired include_fleapyear=.true. (gregorian calendar) is applied by
@@ -276,12 +279,12 @@ function(update_namelist_forcing_jra NAMELIST_IN NAMELIST_OUT)
     # pool-prefix replacement below.
     string(REGEX REPLACE
         "/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1\\.4\\.0/CORE2_runoff\\.nc"
-        "FORCING/JRA55/runoff.nc" CONTENT "${CONTENT}")
+        "runoff.nc" CONTENT "${CONTENT}")
 
-    # All remaining absolute pool paths -> bundled tree, relative to ClimateDataPath.
+    # All remaining absolute pool paths -> bare names, resolved via ForcingDataPath.
     string(REGEX REPLACE
         "/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1\\.4\\.0/"
-        "FORCING/JRA55/" CONTENT "${CONTENT}")
+        "" CONTENT "${CONTENT}")
 
     file(WRITE "${NAMELIST_OUT}" "${CONTENT}")
 endfunction()
@@ -578,6 +581,11 @@ function(add_fesom_test_with_options TEST_NAME MESH_NAME STEP_PER_DAY RUN_LENGTH
             update_namelist_forcing_jra(
                 "${FESOM_TESTING_ROOT}/config/namelist.forcing.JRA"
                 "${TEST_RUN_DIR}/namelist.forcing")
+            # The bare file names above resolve against ForcingDataPath, which
+            # configure_fesom_namelists_with_options() left pointing at CORE2.
+            file(READ "${TEST_RUN_DIR}/namelist.config" CONFIG_CONTENT)
+            string(REGEX REPLACE "([^A-Za-z0-9_])ForcingDataPath[ \t]*=[ \t]*'[^']*'" "\\1ForcingDataPath='${TEST_DATA_DIR}/FORCING/JRA55/'" CONFIG_CONTENT "${CONFIG_CONTENT}")
+            file(WRITE "${TEST_RUN_DIR}/namelist.config" "${CONFIG_CONTENT}")
         else()
             message(FATAL_ERROR "add_fesom_test_with_options(${TEST_NAME}): unknown FORCING '${FESOM_TEST_FORCING}' (expected 'CORE2' or 'JRA')")
         endif()

--- a/config/namelist.config
+++ b/config/namelist.config
@@ -48,6 +48,7 @@ yearnew = 1958                 ! initial year
 &paths
 MeshPath         = '/pool/data/AWICM/FESOM2/MESHES_FESOM2.1/core2/'   ! path to mesh files (nod2d.out, elem2d.out, etc.)
 ClimateDataPath  = '/pool/data/AWICM/FESOM2/INITIAL/phc3.0/'          ! path to initial conditions (temperature, salinity)
+ForcingDataPath  = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/'  ! path prepended to relative file names in namelist.forcing
 ResultPath       = '/work/ab0246/$USER/runtime/fesom2/'               ! path for output files and fesom.clock file
 RestartInPath    = ''                                                 ! where restarts are read from; empty means ResultPath
 RestartOutPath   = ''                                                 ! where restarts are written to; empty means ResultPath

--- a/config/namelist.forcing
+++ b/config/namelist.forcing
@@ -11,6 +11,11 @@
 ! - Runoff and salinity restoring
 ! - Chlorophyll data for shortwave penetration
 ! ============================================================================
+! ----------------------------------------------------------------------------
+! File names below are relative to ForcingDataPath in namelist.config. A name
+! starting with '/' is used as given, which is how files outside the forcing
+! tree (for example the Sweeney chlorophyll climatology) are pointed at.
+! ----------------------------------------------------------------------------
 
 ! ============================================================================
 ! BULK FORMULAE EXCHANGE COEFFICIENTS
@@ -80,16 +85,16 @@ age_start_year    = 2000     ! year to start age tracer (tracer age = 0 at this 
 ! ============================================================================
 &nam_sbc
    ! --- Forcing file paths ---
-   nm_xwind_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/uas.'        ! name of file with zonal wind speeds
-   nm_ywind_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/vas.'        ! name of file with meridional wind speeds
-   nm_xstre_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/uas.'        ! name of file with zonal wind stress
-   nm_ystre_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/vas.'        ! name of file with meridional wind stress
-   nm_humi_file  = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/huss.'       ! name of file with air humidity
-   nm_qsr_file   = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/rsds.'       ! name of file with short wave radiation
-   nm_qlw_file   = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/rlds.'       ! name of file with long wave radiation
-   nm_tair_file  = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/tas.'        ! name of file with 2m air temperature
-   nm_prec_file  = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/prra.'       ! name of file with total precipitation
-   nm_snow_file  = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/prsn.'       ! name of file with snow precipitation
+   nm_xwind_file = 'uas.'        ! name of file with zonal wind speeds
+   nm_ywind_file = 'vas.'        ! name of file with meridional wind speeds
+   nm_xstre_file = 'uas.'        ! name of file with zonal wind stress
+   nm_ystre_file = 'vas.'        ! name of file with meridional wind stress
+   nm_humi_file  = 'huss.'       ! name of file with air humidity
+   nm_qsr_file   = 'rsds.'       ! name of file with short wave radiation
+   nm_qlw_file   = 'rlds.'       ! name of file with long wave radiation
+   nm_tair_file  = 'tas.'        ! name of file with 2m air temperature
+   nm_prec_file  = 'prra.'       ! name of file with total precipitation
+   nm_snow_file  = 'prsn.'       ! name of file with snow precipitation
 
    ! --- Variable names in netCDF forcing files ---
    nm_xwind_var  = 'uas'      ! name of variable in file with wind
@@ -127,12 +132,12 @@ age_start_year    = 2000     ! year to start age tracer (tracer age = 0 at this 
    ! --- Runoff configuration ---
    runoff_climatology=.true.
    runoff_data_source = 'CORE2'       ! runoff data source: 'Dai09', 'JRA55', 'CORE1', 'CORE2' or 'NONE'
-   nm_runoff_file     = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/CORE2_runoff.nc'  ! CORE2 monthly climatology with runoff_climatology=.true.
-   !nm_runoff_file     = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/friver.'  ! Dai09/JRA55 with runoff_climatology=.false.: prefix, year and '.nc' are appended (friver.1958.nc).
+   nm_runoff_file     = 'CORE2_runoff.nc'  ! CORE2 monthly climatology with runoff_climatology=.true.
+   !nm_runoff_file     = 'friver.'  ! Dai09/JRA55 with runoff_climatology=.false.: prefix, year and '.nc' are appended (friver.1958.nc).
 
    ! --- Sea surface salinity restoring ---
    sss_data_source  = 'CORE2'  ! SSS restoring data source: 'CORE2', 'WOA', or 'NONE'
-   nm_sss_data_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/PHC2_salx.nc'  ! path to SSS restoring data file, e.g. PHC2_salx.nc
+   nm_sss_data_file = 'PHC2_salx.nc'  ! path to SSS restoring data file, e.g. PHC2_salx.nc
 
    ! --- Chlorophyll data for shortwave penetration ---
    chl_data_source  = 'Sweeney'   ! chlorophyll data source: 'Sweeney' (monthly climatology) or 'None' (constant)

--- a/config/namelist.forcing.CORE2
+++ b/config/namelist.forcing.CORE2
@@ -1,4 +1,8 @@
 ! This is the namelist file for forcing
+!
+! File names below are relative to ForcingDataPath in namelist.config, which
+! for this setup should point at the CORE2 forcing directory. A name starting
+! with '/' is used as given.
 
 &forcing_exchange_coeff
 Ce_atm_oce=0.00175 ! exchange coeff. of latent heat over open water
@@ -36,15 +40,15 @@ age_start_year=2000
 /
 
 &nam_sbc
-   nm_xwind_file = 'FORCING/CORE2/u_10.'        ! name of file with winds
-   nm_ywind_file = 'FORCING/CORE2/v_10.'        ! name of file with winds
-   nm_humi_file  = 'FORCING/CORE2/q_10.'        ! name of file with humidity
-   nm_qsr_file   = 'FORCING/CORE2/ncar_rad.'    ! name of file with solar heat
-   nm_qlw_file   = 'FORCING/CORE2/ncar_rad.'    ! name of file with Long wave
-   nm_tair_file  = 'FORCING/CORE2/t_10.'        ! name of file with 2m air temperature
-   nm_prec_file  = 'FORCING/CORE2/ncar_precip.' ! name of file with total precipitation
-   nm_snow_file  = 'FORCING/CORE2/ncar_precip.' ! name of file with snow precipitation
-   nm_mslp_file  = 'FORCING/CORE2/slp.'         ! air_pressure_at_sea_level
+   nm_xwind_file = 'u_10.'        ! name of file with winds
+   nm_ywind_file = 'v_10.'        ! name of file with winds
+   nm_humi_file  = 'q_10.'        ! name of file with humidity
+   nm_qsr_file   = 'ncar_rad.'    ! name of file with solar heat
+   nm_qlw_file   = 'ncar_rad.'    ! name of file with Long wave
+   nm_tair_file  = 't_10.'        ! name of file with 2m air temperature
+   nm_prec_file  = 'ncar_precip.' ! name of file with total precipitation
+   nm_snow_file  = 'ncar_precip.' ! name of file with snow precipitation
+   nm_mslp_file  = 'slp.'         ! air_pressure_at_sea_level
    nm_xwind_var  = 'U_10_MOD'   ! name of variable in file with wind
    nm_ywind_var  = 'V_10_MOD'   ! name of variable in file with wind
    nm_humi_var   = 'Q_10_MOD'   ! name of variable in file with humidity
@@ -71,13 +75,13 @@ age_start_year=2000
    l_cloud=.false.
    l_snow=.true.
    runoff_data_source ='CORE2'  !Dai09, CORE2
-   nm_runoff_file     ='FORCING/CORE2/runoff.nc'
+   nm_runoff_file     ='runoff.nc'
    sss_data_source    ='CORE2'
-   nm_sss_data_file   ='FORCING/CORE2/PHC2_salx.nc'
+   nm_sss_data_file   ='PHC2_salx.nc'
    chl_data_source    ='None' !'Sweeney' monthly chlorophyll climatology or 'NONE' for constant chl_const (below). Make use_sw_pene=.TRUE. in namelist.config!
-   nm_chl_data_file   ='FORCING/Sweeney/Sweeney_2005.nc'
+   nm_chl_data_file   ='/pool/data/AWICM/FESOM2/FORCING/Sweeney/Sweeney_2005.nc'
    chl_const          = 0.1
    use_runoff_mapper  = .FALSE.
-   runoff_basins_file = 'FORCING/CORE2/runoff_maps_regular.nc'
+   runoff_basins_file = 'runoff_maps_regular.nc'
    runoff_radius      = 500000.
 /

--- a/docs/general_configuration/general_configuration.rst
+++ b/docs/general_configuration/general_configuration.rst
@@ -30,6 +30,7 @@ Section &paths
 
 - **MeshPath** location of the unstructured grid description (``nod2d.out``, ``elem2d.out``, depth files, etc.).
 - **ClimateDataPath** directory containing initial hydrography and optional restoring climatologies.
+- **ForcingDataPath** directory containing the atmospheric forcing dataset. File names in ``namelist.forcing`` are given bare and resolved against this path; a name starting with ``/`` is used as given.
 - **TideForcingPath** directory for external tidal potential files if tides are used.
 - **ResultPath** root directory for all model output, including ``<runid>.clock``.
 - **RestartInPath**, **RestartOutPath** allow separating where restarts are read from and where they are written. If they are left empty, both default to ``ResultPath``; the setup routine adds trailing slashes automatically.

--- a/docs/getting_started/getting_started.rst
+++ b/docs/getting_started/getting_started.rst
@@ -254,6 +254,8 @@ In ``namelist.config``, the options that you might want to change for your first
 
 - ``ClimateDataPath``: path to the folder with the file with model temperature and salinity initial conditions (e.g. ``/youdir/FESOM2_one_year_input/input/phc3.0/``). The name of the file with initial conditions is defined in `namelist.oce`, but during first runs you probably don't want to change it;
 
+- ``ForcingDataPath``: path to the folder with the atmospheric forcing files (e.g. ``/youdir/FESOM2_one_year_input/forcing/``, slash at the end is important!). The file names in ``namelist.forcing`` are relative to it;
+
 - ``ResultPath``: path to your results folder. The output of the model will be stored there.
 
 More detailed explanation of options in the ``namelist.config`` is in the section :ref:`chap_general_configuration`.

--- a/src/gen_modules_config.F90
+++ b/src/gen_modules_config.F90
@@ -26,12 +26,13 @@ module g_config
 ! kh 01.03.21 paths in test environments can easily become longer than 100 characters (the former value) 
   character(MAX_PATH)        :: MeshPath='./mesh/'
   character(MAX_PATH)        :: ClimateDataPath='./hydrography/'
+  character(MAX_PATH)        :: ForcingDataPath='./forcing/'
   character(MAX_PATH)        :: TideForcingPath='./tide_forcing/'
   character(MAX_PATH)        :: ResultPath='./result/'
   character(MAX_PATH)        :: RestartInPath=''
   character(MAX_PATH)        :: RestartOutPath=''
   character(20)              :: MeshId='NONE'
-  namelist /paths/  MeshPath, ClimateDataPath, &
+  namelist /paths/  MeshPath, ClimateDataPath, ForcingDataPath, &
        TideForcingPath, ResultPath, MeshId, &
        RestartInPath, RestartOutPath
        

--- a/src/gen_surface_forcing.F90
+++ b/src/gen_surface_forcing.F90
@@ -42,7 +42,7 @@ MODULE g_sbf
    USE g_comm_auto
    USE g_support
    USE g_rotate_grid
-   USE g_config, only: dummy, ClimateDataPath, dt, flag_debug
+   USE g_config, only: dummy, ForcingDataPath, dt, flag_debug
    USE g_clock,  only: timeold, timenew, dayold, daynew, yearold, yearnew, cyearnew
    USE g_forcing_arrays,    only: runoff, chl
 #if defined (__recom)
@@ -622,8 +622,8 @@ CONTAINS
       character(len=MAX_PATH) :: full_path
       
       if (len_trim(filename) > 0 .and. filename(1:1) /= '/') then
-         ! Relative path - prepend ClimateDataPath
-         full_path = trim(ClimateDataPath) // trim(filename)
+         ! Relative path - prepend ForcingDataPath
+         full_path = trim(ForcingDataPath) // trim(filename)
       else
          ! Absolute path or empty - use as is
          full_path = filename
@@ -1430,7 +1430,7 @@ CONTAINS
                 write(error_unit,*) '            runoff_data_source = ', trim(runoff_data_source)
                 write(error_unit,*) '            nm_runoff_file     = ', trim(nm_runoff_file)
                 write(error_unit,*) '        a nm_runoff_file without a leading ''/'' is taken as relative and gets'
-                write(error_unit,*) '        ClimateDataPath prepended, which is why an unrelated path may appear'
+                write(error_unit,*) '        ForcingDataPath prepended, so check that it points at your forcing tree'
                 write(error_unit,*) '        above. give an absolute path to avoid this.'
                 write(error_unit,*) '____________________________________________________________________'
                 write(error_unit,*) achar(27)//'[0m'
@@ -1464,7 +1464,7 @@ CONTAINS
                 write(error_unit,*) '            runoff_data_source = ', trim(runoff_data_source)
                 write(error_unit,*) '            nm_runoff_file     = ', trim(nm_runoff_file)
                 write(error_unit,*) '        a nm_runoff_file without a leading ''/'' is taken as relative and gets'
-                write(error_unit,*) '        ClimateDataPath prepended, which is why an unrelated path may appear'
+                write(error_unit,*) '        ForcingDataPath prepended, so check that it points at your forcing tree'
                 write(error_unit,*) '        above. give an absolute path to avoid this.'
                 write(error_unit,*) '____________________________________________________________________'
                 write(error_unit,*) achar(27)//'[0m'

--- a/src/gen_surface_forcing.F90
+++ b/src/gen_surface_forcing.F90
@@ -42,7 +42,7 @@ MODULE g_sbf
    USE g_comm_auto
    USE g_support
    USE g_rotate_grid
-   USE g_config, only: dummy, ForcingDataPath, dt, flag_debug
+   USE g_config, only: dummy, ClimateDataPath, ForcingDataPath, dt, flag_debug
    USE g_clock,  only: timeold, timenew, dayold, daynew, yearold, yearnew, cyearnew
    USE g_forcing_arrays,    only: runoff, chl
 #if defined (__recom)
@@ -617,18 +617,38 @@ CONTAINS
       if (l_cloud) sbc_flfi(i_cloud)%var_name=ADJUSTL(trim(nm_cloud_var))
    END SUBROUTINE nc_sbc_ini_fillnames
 
-   function make_full_path(filename) result(full_path)
-      character(len=*), intent(in) :: filename
+   function prepend_path(base, filename) result(full_path)
+      character(len=*), intent(in) :: base, filename
       character(len=MAX_PATH) :: full_path
-      
+
       if (len_trim(filename) > 0 .and. filename(1:1) /= '/') then
-         ! Relative path - prepend ForcingDataPath
-         full_path = trim(ForcingDataPath) // trim(filename)
+         ! Relative path - prepend the given base directory
+         full_path = trim(base) // trim(filename)
       else
          ! Absolute path or empty - use as is
          full_path = filename
       endif
+   end function prepend_path
+
+   ! Resolve a file name from the nam_sbc group of namelist.forcing, i.e. part
+   ! of an atmospheric forcing dataset. Relative names are taken from
+   ! ForcingDataPath.
+   function make_full_path(filename) result(full_path)
+      character(len=*), intent(in) :: filename
+      character(len=MAX_PATH) :: full_path
+
+      full_path = prepend_path(ForcingDataPath, filename)
    end function make_full_path
+
+   ! Resolve a file name from the nam_rsbc group of namelist.recom. These are
+   ! REcoM climatologies (dust, aeolian nitrogen, atmospheric CO2), not part of
+   ! the forcing dataset, so relative names stay on ClimateDataPath.
+   function make_clim_path(filename) result(full_path)
+      character(len=*), intent(in) :: filename
+      character(len=MAX_PATH) :: full_path
+
+      full_path = prepend_path(ClimateDataPath, filename)
+   end function make_clim_path
 
    SUBROUTINE nc_sbc_ini(partit, mesh)
       !!---------------------------------------------------------------------
@@ -1961,7 +1981,7 @@ SUBROUTINE sbc_do_recom(partit, mesh)
                 end if
 
         else !Transient CO2 from file        
-            filename=trim(make_full_path(nm_co2_data_file))
+            filename=trim(make_clim_path(nm_co2_data_file))
 #if defined(__usetp)
         if (partit%my_fesom_group==0) then
 #endif
@@ -2041,7 +2061,7 @@ SUBROUTINE sbc_do_recom(partit, mesh)
             i=month
             if (mstep > 1) i=i+1
             if (i > 12) i=1
-            filename=trim(make_full_path(nm_fe_data_file))
+            filename=trim(make_clim_path(nm_fe_data_file))
 #if defined(__usetp)
         if (partit%my_fesom_group==0) then
 #endif 
@@ -2071,7 +2091,7 @@ SUBROUTINE sbc_do_recom(partit, mesh)
 !            if (mstep > 1) i=i+1 
 !            if (i > 12) i=1
 !            if (mype==0) write(*,*) 'Updating iron climatology for month ', i 
-            filename=trim(make_full_path(nm_aen_data_file))
+            filename=trim(make_clim_path(nm_aen_data_file))
 #if defined(__usetp)
         if (partit%my_fesom_group==0) then
 #endif

--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -3010,6 +3010,7 @@ subroutine create_new_file(entry, ice, dynamics, partit, mesh)
     call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'MeshPath', trim(MeshPath)), __LINE__)
     call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'mesh_representative_checksum', mesh%representative_checksum), __LINE__)
     call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'ClimateDataPath', trim(ClimateDataPath)), __LINE__)
+    call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'ForcingDataPath', trim(ForcingDataPath)), __LINE__)
     call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'which_ALE', trim(which_ALE)), __LINE__)
     call assert_nf( nf90_put_att(entry%ncid, nf90_global, global_attributes_prefix//'mix_scheme', trim(mix_scheme)), __LINE__)
     ! Global attributes already set above


### PR DESCRIPTION
Closes #1020.

## Problem

`make_full_path` prepended `ClimateDataPath` to any `nm_*_file` that does not start with `/`. `ClimateDataPath` is the temperature and salinity initial-conditions directory and has no relationship to surface forcing, yet it was the fallback for all 34 `make_full_path` call sites. A relative forcing path therefore resolved somewhere meaningless, which is the underlying cause of the confusing error that #853 fixed the symptom of.

## Change

Add `ForcingDataPath` to the `&paths` group and let `namelist.forcing` carry bare file names:

```
&paths
MeshPath         = '.../MESHES_FESOM2.1/core2/'
ClimateDataPath  = '.../INITIAL/phc3.0/'
ForcingDataPath  = '.../FORCING/JRA55-do-v1.4.0/'
ResultPath       = '.../runtime/fesom2/'
/
```

```
nm_xwind_file  = 'uas.'
nm_tair_file   = 'tas.'
nm_runoff_file = 'friver.'
```

Absolute paths still pass through untouched, so files outside the forcing tree, such as the Sweeney chlorophyll climatology, keep working. In `namelist.forcing.CORE2` that file is now given absolutely, since it sits outside the CORE2 directory.

`namelist.forcing.ncep2`'s two relative entries turned out to be empty strings, so it needed no change. The remaining forcing namelists were already fully absolute and are untouched.

## Not every relative name is a forcing file

`make_full_path` was serving two different classes of file. The `nam_sbc` entries in `namelist.forcing` belong to an atmospheric forcing dataset, but `nm_fe_data_file`, `nm_aen_data_file` and `nm_co2_data_file` come from `nam_rsbc` in `namelist.recom` and are REcoM climatologies that sit with the initial conditions, not with the forcing.

Redirecting all of them broke the REcoM CI job, which deletes the `nam_rsbc` block outright and relies on the Fortran default `DustClimMonthlyAlbani.nc` resolving against `ClimateDataPath`. The resolver is therefore split in two over a shared `prepend_path`: `make_full_path` for `nam_sbc`, and `make_clim_path` for `nam_rsbc`, which keeps the old `ClimateDataPath` behaviour.

## mkrun does not know about ForcingDataPath

`mkrun` writes `MeshPath`, `ClimateDataPath` and friends from `setups/paths.yml`, but has no notion of `ForcingDataPath`, so a generated setup inherits whatever ships in `config/namelist.config`. That is harmless today, because `mkrun` expands the `nam_sbc` names to absolute paths itself, but it means the new entry is silently ignored there. `setups/paths.yml` already carries a per-machine `forcing:` section, so teaching mkfesom to write `ForcingDataPath` from it would be the natural follow-up.

## The test harness depended on the old behaviour

The issue assumed nothing relied on the current resolution. That is not the case: `cmake/FesomTesting.cmake` set `ClimateDataPath` to `tests/data/` specifically so that `FORCING/CORE2/...` and `FORCING/JRA55/...` would resolve from there, with a comment saying so. It now sets `ForcingDataPath` to the dataset directory instead, and the JRA variant repoints it to `FORCING/JRA55/` after swapping in its namelist.

The forcing root is also written as a netCDF global attribute next to `ClimateDataPath`, which on its own no longer identifies which forcing a run used.

## Verification

- Full build clean with gfortran.
- All six `integration_pi` tests pass: mpi2, mpi8, cavity, cvmix_tke, cvmix_kpp, output_restamp.
- Confirmed every converted entry routes through `make_full_path`, and that each bare name resolves to a real file in `tests/data/FORCING/CORE2/`.
- The JRA variant is reasoned through rather than run, because `tests/data/FORCING/JRA55/` is not present in this checkout.
- The REcoM job is not runnable locally; the fix restores `make_clim_path` to exactly `main`'s resolution for the three `nam_rsbc` entries, and every `nam_sbc` name in that job is already absolute.

