### PR TITLE
gen_ic3d: note why the IC read needs a contiguous buffer

### DIFF
--- a/docs/getting_started/getting_started.rst
+++ b/docs/getting_started/getting_started.rst
@@ -295,6 +295,13 @@ In the job file, the changes are done based on the HPC you are using. For ``leva
 
 - ``#SBATCH -A <account>``: define your project account.
 
+.. note::
+   The job scripts also set the stack size with ``ulimit -s`` before launching the model.
+   Keep that line and keep the limit generous (``unlimited`` where the site allows it).
+   Some compilers put large array temporaries on the stack, and reading a high-resolution
+   initial-condition or forcing file can need a few hundred MiB of it. Too small a limit
+   shows up as a segmentation fault during initialisation, not as an out-of-memory error.
+
 
 On ``levante`` the submission of your job is done by executing the following command:
 
@@ -560,6 +567,16 @@ Model blows up
 --------------
 
 There could by many reasons for this, but the first thing to try is to reduce time step or/and increase model viscosity for short period of time. Have a look at `Model spinup / Cold start at higher resolutions`_ for instructions.
+
+Segmentation fault during initialisation
+----------------------------------------
+
+A segmentation fault while the model is still reading its input, with no out-of-memory
+message, is often just too small a stack. Some compilers place large array temporaries on
+the stack (ifort does, gfortran does not), so the same setup can run with one compiler and
+crash with another, or run with a coarse climatology and crash with a high-resolution one.
+Raise the limit in the job script, ``ulimit -s unlimited`` where the site allows it and a
+few hundred MiB otherwise, and resubmit.
 
 
 Docker based installation

--- a/src/gen_ic3d.F90
+++ b/src/gen_ic3d.F90
@@ -398,6 +398,10 @@ CONTAINS
          nf_edges(3)=nc_Ndepth         
          ! read into a contiguous rank-1 WP buffer, then reshape into the strided destination
          ! (generic nf_get_vara_x only resolves rank-1 actuals; NetCDF Fortran order has the first dim fastest)
+         ! Keep the contiguous buffer. Passing ncdata(2:nc_Nlon-1,:,:) directly makes the compiler
+         ! build a copy-in/copy-out temporary of the whole field, which ifort puts on the stack:
+         ! EN4 (1440x720x42 doubles = 332 MiB) then overflows the 200 MiB stack our run scripts set
+         ! and segfaults on rank 0, while PHC (16 MiB) fits. gfortran heap-allocates it and survives.
          allocate(ncdata_inner((nc_Nlon-2)*nc_Nlat*nc_Ndepth))
          iost = nf_get_vara_x(ncid, id_data, nf_start, nf_edges, ncdata_inner)
          ncdata(2:nc_Nlon-1,:,:) = reshape(ncdata_inner, [nc_Nlon-2, nc_Nlat, nc_Ndepth])


### PR DESCRIPTION
Comment only, no behaviour change.

Starting from EN4 initial conditions used to segfault on rank 0 with the Intel build while working fine with GNU. Cause: `getcoeffld` passed the strided section `ncdata(2:nc_Nlon-1,:,:)` straight to the netCDF read. With an implicit interface the compiler has to build a copy-in/copy-out temporary of the whole field, and ifort puts that temporary on the stack.

- EN4, 1440x720x42 doubles = 332 MiB -> overflows the 200 MiB stack our run scripts set (`ulimit -s 204800`), SIGSEGV
- PHC, 360x180x33 = 16 MiB -> fits, which is why only some inputs ever failed
- gfortran heap-allocates the temporary, hence the compiler split

Reproducer under the levante Intel flags: passing the strided section to an external routine segfaults at 200 MiB stack; the same source under gfortran runs. Nothing to fix in the code -- 5a91ce60 already replaced this with the contiguous rank-1 `ncdata_inner` buffer when adding single-precision support, and that version is safe. This just records why the buffer has to stay, so it does not get simplified back.