### PR TITLE
Add snowmelt_tgate and alb_tramp switches to the coupled ice thermodynamics

### DIFF
--- a/src/MOD_ICE.F90
+++ b/src/MOD_ICE.F90
@@ -91,6 +91,13 @@ TYPE T_ICE_THERMO
     ! 0 (default) keeps the legacy step function at hsn > 1 mm.
     ! Typical CICE-style values are 0.02-0.05 m.
     real(kind=WP) :: h_snowscale = 0.0_WP
+    ! Coupled snow melt on sea ice requires a surface temperature above 273 K
+    ! (.true., legacy). .false. melts snow on the energy budget alone, as the
+    ! uncoupled branch does.
+    logical       :: snowmelt_tgate = .true.
+    ! Width [K] of a linear transition from frozen to melting snow and ice
+    ! albedo below 273.15 K. 0 (default) keeps the step at 273.15 K.
+    real(kind=WP) :: alb_tramp = 0.0_WP
     real(kind=WP) :: h_ml  = 2.5_WP    ! thickness of uppermost layer deacides how much heat is available
 
     ! --- additional namelist parameters (Frank.Kauker(at)awi.de 2023/04/04)
@@ -604,13 +611,13 @@ subroutine ice_init(ice, partit, mesh)
     namelist /ice_dyn/ whichEVP, Pstar, ellipse, c_pressure, delta_min, evp_rheol_steps, &
                        Cd_oce_ice, ice_gamma_fct, ice_diff, theta_io, ice_ave_steps, &
                        alpha_evp, beta_evp, c_aevp
-    logical        :: snowdist, new_iclasses, use_meltponds
+    logical        :: snowdist, new_iclasses, use_meltponds, snowmelt_tgate
     integer        :: open_water_albedo, iclasses
     real(kind=WP)  :: Sice, h0, h0_s, emiss_ice, emiss_wat, albsn, albsnm, albi, &
-                      albim, albw, con, consn, hmin, armin, c_melt, h_cutoff, h_ml, h_snowscale
+                      albim, albw, con, consn, hmin, armin, c_melt, h_cutoff, h_ml, h_snowscale, alb_tramp
     namelist /ice_therm/ Sice, iclasses, h0, h0_s, hmin, armin,  emiss_ice, emiss_wat, albsn, albsnm, albi, &
                          albim, albw, con, consn,  snowdist, new_iclasses, open_water_albedo, c_melt, h_cutoff, h_ml, use_meltponds, &
-                         h_snowscale
+                         h_snowscale, snowmelt_tgate, alb_tramp
 
     !___________________________________________________________________________
     ! pointer on necessary derived types
@@ -654,6 +661,8 @@ subroutine ice_init(ice, partit, mesh)
     albw             = ice%thermo%albw
     h_ml             = ice%thermo%h_ml
     h_snowscale      = ice%thermo%h_snowscale
+    snowmelt_tgate   = ice%thermo%snowmelt_tgate
+    alb_tramp        = ice%thermo%alb_tramp
     snowdist         = ice%thermo%snowdist
     new_iclasses     = ice%thermo%new_iclasses
     open_water_albedo= ice%thermo%open_water_albedo
@@ -715,6 +724,8 @@ subroutine ice_init(ice, partit, mesh)
     ice%thermo%albw     = albw
     ice%thermo%h_ml     = h_ml
     ice%thermo%h_snowscale = h_snowscale
+    ice%thermo%snowmelt_tgate = snowmelt_tgate
+    ice%thermo%alb_tramp = alb_tramp
     ice%thermo%snowdist = snowdist
     ice%thermo%new_iclasses=new_iclasses
     ice%thermo%open_water_albedo=open_water_albedo

--- a/src/ice_thermo_cpl.F90
+++ b/src/ice_thermo_cpl.F90
@@ -376,7 +376,9 @@ contains
 #if defined (__oifs) || defined (__ifsinterface)
     !---- new condition added - surface temperature must be
     !----                       larger than 273K to melt snow
-    if (t.gt.273_WP) then
+    !---- (snowmelt_tgate=.false. drops the condition and melts snow on the
+    !----  energy budget alone, as the uncoupled branch below does)
+    if (t.gt.273_WP .or. .not. ice%thermo%snowmelt_tgate) then
         dsnow = A*min(Qatmice-Qicecon,0._WP)
         dsnow = max(dsnow*rhoice/rhosno,-hsn)
     else
@@ -656,6 +658,7 @@ contains
   real(kind=WP) :: alpha_snow          ! 0..1 snow-cover blend weight
   real(kind=WP) :: alb_snow, alb_bare  ! season-selected snow / bare-ice albedo
   real(kind=WP) :: h_snowscale         ! local copy of namelist tanh scale
+  real(kind=WP) :: fmelt               ! 0 frozen .. 1 melting albedo weight
 
   albsn       => ice%thermo%albsn
   albi        => ice%thermo%albi
@@ -665,7 +668,13 @@ contains
 
   ! Calculate standard albedo first (without pond effects)
   if (h>0.0_WP) then
-     if (t<273.15_WP) then     ! freezing surface
+     if (ice%thermo%alb_tramp > 0.0_WP) then
+        ! Linear transition over alb_tramp K below the melting point
+        fmelt    = min(1.0_WP, max(0.0_WP, &
+                   (t - 273.15_WP + ice%thermo%alb_tramp) / ice%thermo%alb_tramp))
+        alb_snow = albsn + fmelt*(albsnm - albsn)
+        alb_bare = albi  + fmelt*(albim  - albi)
+     else if (t<273.15_WP) then     ! freezing surface
         alb_snow = albsn
         alb_bare = albi
      else                      ! melting surface


### PR DESCRIPTION
Two new `&ice_therm` switches for the coupled (`__oifs` / `__ifsinterface`) ice thermodynamics. The defaults reproduce the current behaviour.

- `snowmelt_tgate` (default `.true.`): in the coupled branch, snow on sea ice only melts when the surface temperature is above 273 K. Setting it to `.false.` removes that condition, so snow melts on the energy budget alone, as it already does in the uncoupled branch.
- `alb_tramp` (default `0`): the width in K of a linear transition from the frozen to the melting snow and ice albedo below 273.15 K. It replaces the step at 273.15 K.

Motivation: in AWI-ESM3 (OpenIFS 48r1) the temperature gate kept snow on the ice through the melt season, and the albedo step then made the summer ice too bright. A 10-year coupled test combined three things:
- `snowmelt_tgate = .false.` and `alb_tramp = 1.0`
- ECHAM6 albedo values
- an OpenIFS change that sends FESOM the heat leaving the IFS ice column

With all three, the co-located JJA sea-ice albedo is 0.645, against 0.627 from CERES.

With the default values the code paths are the same as before.