### PR TITLE
Keep the FCT low-order tendency in flux form in both precisions

### DIFF
--- a/src/MOD_TRACER.F90
+++ b/src/MOD_TRACER.F90
@@ -54,6 +54,7 @@ real(kind=WP), allocatable                    :: tra_recom_sms(:,:,:)
 
 ! The fct part
 real(kind=WP),allocatable,dimension(:,:)      :: fct_LO          ! Low-order solution
+real(kind=WP),allocatable,dimension(:,:)      :: fct_LO_tend     ! Low-order tendency in flux form (tracer*thickness per step)
 real(kind=WP),allocatable,dimension(:,:)      :: adv_flux_hor    ! Antidif. horiz. contrib. from edges / backup for iterafive fct scheme
 real(kind=WP),allocatable,dimension(:,:)      :: adv_flux_ver    ! Antidif. vert. fluxes from nodes    / backup for iterafive fct scheme
 

--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -853,7 +853,7 @@ contains
     !$ACC ENTER DATA CREATE (f%tracers%data(tr_num)%tra_adv_ph, f%tracers%data(tr_num)%tra_adv_pv)
     end do
     !$ACC ENTER DATA CREATE (f%tracers%work%fct_ttf_min, f%tracers%work%fct_ttf_max, f%tracers%work%fct_plus, f%tracers%work%fct_minus)
-    !$ACC ENTER DATA CREATE (f%tracers%work%adv_flux_hor, f%tracers%work%adv_flux_ver, f%tracers%work%fct_LO)
+    !$ACC ENTER DATA CREATE (f%tracers%work%adv_flux_hor, f%tracers%work%adv_flux_ver, f%tracers%work%fct_LO, f%tracers%work%fct_LO_tend)
     !$ACC ENTER DATA CREATE (f%tracers%work%del_ttf_advvert, f%tracers%work%del_ttf_advhoriz, f%tracers%work%edge_up_dn_grad)
     !$ACC ENTER DATA CREATE (tr_xy, tr_z, relax2clim, Sclim, Tclim)
   end subroutine fesom_init
@@ -1429,7 +1429,7 @@ contains
     !$ACC EXIT DATA DELETE (f%tracers%data(tr_num)%valuesold)
     end do
     !$ACC EXIT DATA DELETE (f%tracers%work%fct_ttf_min, f%tracers%work%fct_ttf_max, f%tracers%work%fct_plus, f%tracers%work%fct_minus)
-    !$ACC EXIT DATA DELETE (f%tracers%work%adv_flux_hor, f%tracers%work%adv_flux_ver, f%tracers%work%fct_LO)
+    !$ACC EXIT DATA DELETE (f%tracers%work%adv_flux_hor, f%tracers%work%adv_flux_ver, f%tracers%work%fct_LO, f%tracers%work%fct_LO_tend)
     !$ACC EXIT DATA DELETE (f%tracers%work%del_ttf_advvert, f%tracers%work%del_ttf_advhoriz, f%tracers%work%edge_up_dn_grad)
     !$ACC EXIT DATA DELETE (f%tracers%work%del_ttf)
     !$ACC EXIT DATA DELETE (tr_xy, tr_z, relax2clim, Sclim, Tclim)

--- a/src/oce_adv_tra_driver.F90
+++ b/src/oce_adv_tra_driver.F90
@@ -1,13 +1,3 @@
-! Single precision cannot resolve the per-step change of the FCT low-order solution
-! LO, so LO*hnode_new - ttf*hnode loses it. The low-order tendency is kept in flux
-! form here instead.
-module adv_lo_tend_mod
-  use o_PARAM, only: WP
-  implicit none
-  real(kind=WP), allocatable, save :: lo_tend(:,:)
-  logical,                    save :: lo_flux_form = .false.
-end module adv_lo_tend_mod
-
 module oce_adv_tra_driver_interfaces
   interface
    subroutine do_oce_adv_tra(dt, vel, w, wi, we, tr_num, dynamics, tracers, partit, mesh)
@@ -32,7 +22,7 @@ end module oce_adv_tra_driver_interfaces
 
 module oce_tra_adv_flux2dtracer_interface
   interface
-    subroutine oce_tra_adv_flux2dtracer(dt, dttf_h, dttf_v, flux_h, flux_v, partit, mesh, use_lo, ttf, lo)
+    subroutine oce_tra_adv_flux2dtracer(dt, dttf_h, dttf_v, flux_h, flux_v, partit, mesh, lo_tend)
       !update the solution for vertical and horizontal flux contributions
       use MOD_MESH
       USE MOD_PARTIT
@@ -44,9 +34,7 @@ module oce_tra_adv_flux2dtracer_interface
       real(kind=WP), intent(inout)      :: dttf_v(mesh%nl-1, partit%myDim_nod2D+partit%eDim_nod2D)
       real(kind=WP), intent(inout)      :: flux_h(mesh%nl-1, partit%myDim_edge2D)
       real(kind=WP), intent(inout)      :: flux_v(mesh%nl,   partit%myDim_nod2D)
-      logical,       optional           :: use_lo
-      real(kind=WP), optional           :: ttf(mesh%nl-1, partit%myDim_nod2D+partit%eDim_nod2D)
-      real(kind=WP), optional           :: lo (mesh%nl-1, partit%myDim_nod2D+partit%eDim_nod2D)
+      real(kind=WP), intent(in), optional :: lo_tend(mesh%nl-1, partit%myDim_nod2D+partit%eDim_nod2D)
     end subroutine oce_tra_adv_flux2dtracer
   end interface
 end module oce_tra_adv_flux2dtracer_interface
@@ -54,7 +42,6 @@ end module oce_tra_adv_flux2dtracer_interface
 !
 !===============================================================================
 subroutine do_oce_adv_tra(dt, vel, w, wi, we, tr_num, dynamics, tracers, partit, mesh)
-    use adv_lo_tend_mod
     use MOD_MESH
     use MOD_TRACER
     USE MOD_PARTIT
@@ -79,7 +66,7 @@ subroutine do_oce_adv_tra(dt, vel, w, wi, we, tr_num, dynamics, tracers, partit,
     real(kind=WP),  intent(in), target    :: WE(mesh%nl,   partit%myDim_nod2D+partit%eDim_nod2D)
 
     real(kind=WP),  pointer, dimension (:,:)   :: pwvel
-    real(kind=WP),  pointer, dimension (:,:)   :: ttf, ttfAB, fct_LO
+    real(kind=WP),  pointer, dimension (:,:)   :: ttf, ttfAB, fct_LO, fct_LO_tend
     real(kind=WP),  pointer, dimension (:,:)   :: adv_flux_hor, adv_flux_ver, dttf_h, dttf_v
     real(kind=WP),  pointer, dimension (:,:)   :: fct_ttf_min, fct_ttf_max
     real(kind=WP),  pointer, dimension (:,:)   :: fct_plus, fct_minus
@@ -105,10 +92,7 @@ subroutine do_oce_adv_tra(dt, vel, w, wi, we, tr_num, dynamics, tracers, partit,
     opth            =  tracers%data(tr_num)%tra_adv_ph
     optv            =  tracers%data(tr_num)%tra_adv_pv
     fct_LO          => tracers%work%fct_LO
-#if defined(USE_SINGLE_PRECISION)
-    if (.not. allocated(lo_tend)) allocate(lo_tend(size(fct_LO,1), size(fct_LO,2)))
-#endif
-    lo_flux_form = .false.
+    fct_LO_tend     => tracers%work%fct_LO_tend
     adv_flux_ver    => tracers%work%adv_flux_ver
     adv_flux_hor    => tracers%work%adv_flux_hor
     edge_up_dn_grad => tracers%work%edge_up_dn_grad
@@ -257,7 +241,7 @@ subroutine do_oce_adv_tra(dt, vel, w, wi, we, tr_num, dynamics, tracers, partit,
 #ifndef ENABLE_OPENACC
 !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(n, nu1, nl1, nz)
 #else
-        !$ACC PARALLEL LOOP GANG PRESENT(fct_LO) DEFAULT(PRESENT) VECTOR_LENGTH(acc_vl)
+        !$ACC PARALLEL LOOP GANG PRESENT(fct_LO, fct_LO_tend) DEFAULT(PRESENT) VECTOR_LENGTH(acc_vl)
 #endif
         do n=1, myDim_nod2D
             nu1 = ulevels_nod2D(n)
@@ -265,12 +249,9 @@ subroutine do_oce_adv_tra(dt, vel, w, wi, we, tr_num, dynamics, tracers, partit,
             !!PS do  nz=1, nlevels_nod2D(n)-1
             !$ACC LOOP VECTOR
             do  nz= nu1, nl1-1
-#if defined(USE_SINGLE_PRECISION)
-                lo_tend(nz,n)=(fct_LO(nz,n)+(adv_flux_ver(nz, n)-adv_flux_ver(nz+1, n)))*dt/areasvol(nz,n)
-                fct_LO(nz,n)=(ttf(nz,n)*hnode(nz,n)+lo_tend(nz,n))/hnode_new(nz,n)
-#else
-                fct_LO(nz,n)=(ttf(nz,n)*hnode(nz,n)+(fct_LO(nz,n)+(adv_flux_ver(nz, n)-adv_flux_ver(nz+1, n)))*dt/areasvol(nz,n))/hnode_new(nz,n)
-#endif
+                ! kept in flux form: LO*hnode_new-ttf*hnode is not precise enough in single precision
+                fct_LO_tend(nz,n)=(fct_LO(nz,n)+(adv_flux_ver(nz, n)-adv_flux_ver(nz+1, n)))*dt/areasvol(nz,n)
+                fct_LO(nz,n)=(ttf(nz,n)*hnode(nz,n)+fct_LO_tend(nz,n))/hnode_new(nz,n)
             end do
             !$ACC END LOOP
         end do
@@ -278,9 +259,6 @@ subroutine do_oce_adv_tra(dt, vel, w, wi, we, tr_num, dynamics, tracers, partit,
 !$OMP END PARALLEL DO
 #else
         !$ACC END PARALLEL LOOP
-#endif
-#if defined(USE_SINGLE_PRECISION)
-        lo_flux_form = .true.
 #endif
 
 
@@ -350,10 +328,9 @@ subroutine do_oce_adv_tra(dt, vel, w, wi, we, tr_num, dynamics, tracers, partit,
         if (dynamics%use_wsplit) then !wvel/=wvel_e
             ! update for implicit contribution (w_split option)
 !when adv_tra_vert_impl is ported to ACC the UPDATEs below wont be needed!
-!$ACC UPDATE HOST(fct_LO)
-            call adv_tra_vert_impl(dt, wi, fct_LO, partit, mesh)
-            lo_flux_form = .false.   ! the implicit split updates LO itself
-!$ACC UPDATE DEVICE(fct_LO)
+!$ACC UPDATE HOST(fct_LO, fct_LO_tend)
+            call adv_tra_vert_impl(dt, wi, fct_LO, partit, mesh, fct_LO_tend)
+!$ACC UPDATE DEVICE(fct_LO, fct_LO_tend)
             ! compute the low order upwind vertical flux (full vertical velocity)
             ! zero the input/output flux before computation
             ! --> compute here low order part of vertical anti diffusive fluxes,
@@ -410,7 +387,7 @@ subroutine do_oce_adv_tra(dt, vel, w, wi, we, tr_num, dynamics, tracers, partit,
     if (trim(tracers%data(tr_num)%tra_adv_lim)=='FCT') then
        !edge_up_dn_grad will be used as an auxuary array here
        call oce_tra_adv_fct(dt, ttf, fct_LO, adv_flux_hor, adv_flux_ver, fct_ttf_min, fct_ttf_max, fct_plus, fct_minus, edge_up_dn_grad, partit, mesh)
-       call oce_tra_adv_flux2dtracer(dt, dttf_h, dttf_v, adv_flux_hor, adv_flux_ver, partit, mesh, use_lo=.TRUE., ttf=ttf, lo=fct_LO)
+       call oce_tra_adv_flux2dtracer(dt, dttf_h, dttf_v, adv_flux_hor, adv_flux_ver, partit, mesh, lo_tend=fct_LO_tend)
     else
        call oce_tra_adv_flux2dtracer(dt, dttf_h, dttf_v, adv_flux_hor, adv_flux_ver, partit, mesh)
     end if
@@ -519,8 +496,7 @@ end subroutine do_oce_adv_tra
 !
 !
 !===============================================================================
-subroutine oce_tra_adv_flux2dtracer(dt, dttf_h, dttf_v, flux_h, flux_v, partit, mesh, use_lo, ttf, lo)
-    use adv_lo_tend_mod
+subroutine oce_tra_adv_flux2dtracer(dt, dttf_h, dttf_v, flux_h, flux_v, partit, mesh, lo_tend)
     use MOD_MESH
     use o_ARRAYS
     USE MOD_PARTIT
@@ -534,9 +510,7 @@ subroutine oce_tra_adv_flux2dtracer(dt, dttf_h, dttf_v, flux_h, flux_v, partit, 
     real(kind=WP), intent(inout)      :: dttf_v(mesh%nl-1, partit%myDim_nod2D+partit%eDim_nod2D)
     real(kind=WP), intent(inout)      :: flux_h(mesh%nl-1, partit%myDim_edge2D)
     real(kind=WP), intent(inout)      :: flux_v(mesh%nl,   partit%myDim_nod2D)
-    logical,       optional           :: use_lo
-    real(kind=WP), optional           :: lo (mesh%nl-1, partit%myDim_nod2D+partit%eDim_nod2D)
-    real(kind=WP), optional           :: ttf(mesh%nl-1, partit%myDim_nod2D+partit%eDim_nod2D)
+    real(kind=WP), intent(in), optional :: lo_tend(mesh%nl-1, partit%myDim_nod2D+partit%eDim_nod2D)
     integer                           :: n, nz, k, elem, enodes(3), num, el(2), nu12, nl12, nu1, nu2, nl1, nl2, edge
 #include "associate_part_def.h"
 #include "associate_mesh_def.h"
@@ -548,8 +522,7 @@ subroutine oce_tra_adv_flux2dtracer(dt, dttf_h, dttf_v, flux_h, flux_v, partit, 
 #ifndef ENABLE_OPENACC
 !$OMP PARALLEL DEFAULT(SHARED) PRIVATE(n, nz, k, elem, enodes, num, el, nu12, nl12, nu1, nu2, nl1, nl2, edge)
 #endif
-    if (present(use_lo)) then
-       if (use_lo) then
+    if (present(lo_tend)) then
 #ifndef ENABLE_OPENACC
 !$OMP DO
 #else
@@ -561,11 +534,7 @@ subroutine oce_tra_adv_flux2dtracer(dt, dttf_h, dttf_v, flux_h, flux_v, partit, 
              !!PS do nz=1,nlevels_nod2D(n)-1
              !$ACC LOOP VECTOR
              do nz=nu1, nl1-1
-                if (lo_flux_form) then
-                    dttf_v(nz,n)=dttf_v(nz,n)+lo_tend(nz,n)
-                else
-                    dttf_v(nz,n)=dttf_v(nz,n)-ttf(nz,n)*hnode(nz,n)+LO(nz,n)*hnode_new(nz,n)
-                end if
+                dttf_v(nz,n)=dttf_v(nz,n)+lo_tend(nz,n)
              end do
              !$ACC END LOOP
           end do
@@ -574,7 +543,6 @@ subroutine oce_tra_adv_flux2dtracer(dt, dttf_h, dttf_v, flux_h, flux_v, partit, 
 #else
          !$ACC END PARALLEL LOOP
 #endif
-       end if
     end if
 #ifndef ENABLE_OPENACC
 !$OMP DO

--- a/src/oce_adv_tra_fct.F90
+++ b/src/oce_adv_tra_fct.F90
@@ -49,6 +49,7 @@ subroutine oce_adv_tra_fct_init(twork, partit, mesh)
 
     my_size=myDim_nod2D+eDim_nod2D
     allocate(twork%fct_LO(nl-1, my_size))        ! Low-order solution
+    allocate(twork%fct_LO_tend(nl-1, my_size))   ! Low-order tendency in flux form
     allocate(twork%adv_flux_hor(nl-1,partit%myDim_edge2D)) ! antidiffusive hor. contributions / from edges
     allocate(twork%adv_flux_ver(nl, partit%myDim_nod2D))   ! antidiffusive ver. fluxes / from nodes
 
@@ -56,6 +57,7 @@ subroutine oce_adv_tra_fct_init(twork, partit, mesh)
     allocate(twork%fct_plus(nl-1, my_size),   twork%fct_minus(nl-1, my_size))
     ! Initialize with zeros:
     twork%fct_LO=0.0_WP
+    twork%fct_LO_tend=0.0_WP
     twork%adv_flux_hor=0.0_WP
     twork%adv_flux_ver=0.0_WP
     twork%fct_ttf_max=0.0_WP

--- a/src/oce_adv_tra_ver.F90
+++ b/src/oce_adv_tra_ver.F90
@@ -1,17 +1,18 @@
 module oce_adv_tra_ver_interfaces
   interface
 ! implicit 1st order upwind vertical advection with to solve for fct_LO
-! updates the input tracer ttf
-    subroutine adv_tra_ver_impl(dt, w, ttf, partit, mesh)
+! updates the input tracer ttf and adds the change of ttf*hnode_new to tend
+    subroutine adv_tra_vert_impl(dt, w, ttf, partit, mesh, tend)
       use mod_mesh
       USE MOD_PARTIT
       USE MOD_PARSUP
       real(kind=WP), intent(in), target  :: dt
       type(t_partit),intent(in), target  :: partit
       type(t_mesh),  intent(in), target  :: mesh
-      real(kind=WP), intent(inout)       :: ttf(mesh%nl-1, partit%myDim_nod2D+partit%eDim_nod2D)
-      real(kind=WP), intent(in)          :: W  (mesh%nl,   partit%myDim_nod2D+partit%eDim_nod2D)
-    end subroutine adv_tra_ver_impl
+      real(kind=WP), intent(inout)       :: ttf (mesh%nl-1, partit%myDim_nod2D+partit%eDim_nod2D)
+      real(kind=WP), intent(in)          :: W   (mesh%nl,   partit%myDim_nod2D+partit%eDim_nod2D)
+      real(kind=WP), intent(inout)       :: tend(mesh%nl-1, partit%myDim_nod2D+partit%eDim_nod2D)
+    end subroutine adv_tra_vert_impl
 !===============================================================================
 ! 1st order upwind (explicit)
 ! returns flux given at vertical interfaces of scalar volumes
@@ -106,7 +107,7 @@ module oce_adv_tra_ver_interfaces
   end interface
 end module oce_adv_tra_ver_interfaces
 !===============================================================================
-subroutine adv_tra_vert_impl(dt, w, ttf, partit, mesh)
+subroutine adv_tra_vert_impl(dt, w, ttf, partit, mesh, tend)
     use MOD_MESH
     use MOD_TRACER
     USE MOD_PARTIT
@@ -117,8 +118,9 @@ subroutine adv_tra_vert_impl(dt, w, ttf, partit, mesh)
     real(kind=WP), intent(in) , target :: dt
     type(t_partit),intent(in), target  :: partit
     type(t_mesh),  intent(in) , target :: mesh
-    real(kind=WP), intent(inout)       :: ttf(mesh%nl-1, partit%myDim_nod2D+partit%eDim_nod2D)
-    real(kind=WP), intent(in)          :: W  (mesh%nl,   partit%myDim_nod2D+partit%eDim_nod2D)
+    real(kind=WP), intent(inout)       :: ttf (mesh%nl-1, partit%myDim_nod2D+partit%eDim_nod2D)
+    real(kind=WP), intent(in)          :: W   (mesh%nl,   partit%myDim_nod2D+partit%eDim_nod2D)
+    real(kind=WP), intent(inout)       :: tend(mesh%nl-1, partit%myDim_nod2D+partit%eDim_nod2D)
     real(kind=WP)                      :: a(mesh%nl), b(mesh%nl), c(mesh%nl), tr(mesh%nl)
     real(kind=WP)                      :: cp(mesh%nl), tp(mesh%nl)
     real(kind=WP)                      :: zbar_n(mesh%nl), z_n(mesh%nl-1)
@@ -251,6 +253,7 @@ subroutine adv_tra_vert_impl(dt, w, ttf, partit, mesh)
         ! update tracer
         do nz=nzmin,nzmax-1
             ttf(nz,n)=ttf(nz,n)+tr(nz)
+            tend(nz,n)=tend(nz,n)+tr(nz)*hnode_new(nz,n)
         end do
     end do ! --> do n=1,myDim_nod2D
 !$OMP END DO


### PR DESCRIPTION
This follows up #1054, which added the flux-form low-order tendency for single precision only. This PR makes it unconditional.

- The low-order tendency `fct_LO_tend` is always accumulated in flux form and added to `del_ttf_advvert` directly. `LO*hnode_new - ttf*hnode` is no longer reconstructed. The `#if defined(USE_SINGLE_PRECISION)` blocks and the `lo_flux_form` switch are removed.
- The implicit part of the w-split (`adv_tra_vert_impl`) now adds its increment `tr*hnode_new` to the tendency too. `use_wsplit = .true.` is therefore covered in both precisions; #1054 fell back to the old reconstruction there.
- `fct_LO_tend` lives in `tracers%work` next to `fct_LO`. It is created and deleted on the device together with the other FCT work arrays, and updated around the host-side implicit solve in the same way as `fct_LO`.
- `oce_tra_adv_flux2dtracer` now takes `lo_tend` in place of `use_lo, ttf, lo`.
- The interface block in `oce_adv_tra_ver_interfaces` declared `adv_tra_ver_impl`, but the routine is called `adv_tra_vert_impl`, so the call was never checked against it. The name is corrected.

Tests used AWI-ESM3 on CORE3 with linfs: 5-day coupled runs with a double-precision global heat-budget diagnostic. The residual is the heat-content change minus the surface input minus the intended explicit tendency, as a 5-day mean in W/m2.

- **Single precision:** bit-identical to #1054; the residual is +0.0116 in both.
- **Single precision with `use_wsplit = .true.` and `wsplit_maxcfl = 0.5`:** +0.0109.
- **Double precision:** +0.00075, against +0.00063 before. The result is not bit-identical, because the arithmetic is reordered. In the coupled model the global surface flux differs by 0.2% after the first day.

The OpenACC build is not tested.