### PR TITLE
Add Fox-Kemper mixed-layer eddy restratification (default off)

### DIFF
--- a/config/namelist.oce
+++ b/config/namelist.oce
@@ -47,6 +47,16 @@ scaling_GMzexp     = .true.  ! do downscaling of GM & Redi over depth by exp(-z/
 GMzexp_zref        = 500.0   ! reference for vertical exp GM scaling 
 GMzexp_smin        = 0.6     ! minimum scaling factor
 
+! --- Mixed Layer Eddy Restratification (Fox-Kemper et al. 2008, 2011) ---
+use_mle            = .false. ! enable MLE restratification (GM is tapered out of the mixed layer by ODM95)
+mle_Ce             = 0.06    ! efficiency coefficient
+mle_Lf_min         = 1000.0  ! floor on the frontal width (m), Lf = max(N*H/f, Lf_min)
+mle_tau            = 86400.0 ! frontal lifetime (s), regularises f towards the equator
+mle_hmax           = 500.0   ! max. mixed layer depth used (m), Psi scales with H^2
+mle_resscale_max   = 20.0    ! max. resolution factor ds/Lf
+mle_ustar_max      = 0.05    ! max. induced bolus velocity (m/s), column scaled to satisfy it
+mle_mld_decay_time = 0.0     ! running-mean decay time for H (s), 0 = use instantaneous MLD
+
 scaling_GINsea     = .false. ! Increase K_GM resolution scaling only in the GIN sea by factor 
 GINsea_fac         = 2.0     ! GIN sea K_GM upscaling factor 
 

--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -597,6 +597,7 @@ subroutine ini_mean_io(ice, dynamics, tracers, partit, mesh)
           "benC                ", "benCalc             ", "benN                ", &
           "benSi               ", "beta                ", "bolus_u             ", &
           "bolus_v             ", "bolus_w             ", "calcdiss            ", &
+          "mle_psi             ", &
           "calcif              ", "cfl_z               ", "Chldegc             ", &
           "Chldegd             ", "Chldegn             ", "CO2_aq              ", "CO2f                ", "CO3                 ", &
           "curl_surf           ", "dens_flux           ", "d_eta               ", &
@@ -1908,6 +1909,8 @@ CASE ('slope_y   ')
 CASE ('slope_z   ')
     call def_stream((/nl-1,  nod2D/), (/nl-1, myDim_nod2D/),  'slope_z',   'neutral slope Z',    'none', neutral_slope(3,:,:), io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
 
+CASE ('mle_psi   ')
+    call def_stream((/nl,    nod2D/), (/nl,   myDim_nod2D/),  'mle_psi',   'Fox-Kemper MLE streamfunction', 'm2/s', mle_psi(:,:), io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
 CASE ('N2        ')
     call def_stream((/nl,    nod2D/), (/nl,   myDim_nod2D/),  'N2',        'brunt väisälä',      '1/s2', bvfreq(:,:),          io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
 CASE ('Kv        ')

--- a/src/io_meandata.F90
+++ b/src/io_meandata.F90
@@ -1910,7 +1910,9 @@ CASE ('slope_z   ')
     call def_stream((/nl-1,  nod2D/), (/nl-1, myDim_nod2D/),  'slope_z',   'neutral slope Z',    'none', neutral_slope(3,:,:), io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
 
 CASE ('mle_psi   ')
+    if (use_mle) then
     call def_stream((/nl,    nod2D/), (/nl,   myDim_nod2D/),  'mle_psi',   'Fox-Kemper MLE streamfunction', 'm2/s', mle_psi(:,:), io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
+    end if
 CASE ('N2        ')
     call def_stream((/nl,    nod2D/), (/nl,   myDim_nod2D/),  'N2',        'brunt väisälä',      '1/s2', bvfreq(:,:),          io_list(i)%freq, io_list(i)%unit, io_list(i)%precision, partit, mesh)
 CASE ('Kv        ')

--- a/src/oce_ale.F90
+++ b/src/oce_ale.F90
@@ -3447,6 +3447,7 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
     use check_blowup_interface
     use ieee_arithmetic
     use fer_solve_interface
+    use mle_interface
     use impl_vert_visc_ale_vtransp_interface
 #if defined (FESOM_PROFILING)
     use fesom_profiler
@@ -3866,9 +3867,18 @@ subroutine oce_timestep_ale(n, ice, dynamics, tracers, partit, mesh)
     
     ! Implementation of Gent & McWiliams parameterization after R. Ferrari et al., 2010
     ! does not belong directly to ALE formalism
-    if (Fer_GM) then
-        if (flag_debug .and. mype==0)  print *, achar(27)//'[36m'//'     --> call fer_solve_Gamma'//achar(27)//'[0m'
-        call fer_solve_Gamma(partit, mesh)
+    if (Fer_GM .or. use_mle) then
+        if (Fer_GM) then
+            if (flag_debug .and. mype==0)  print *, achar(27)//'[36m'//'     --> call fer_solve_Gamma'//achar(27)//'[0m'
+            call fer_solve_Gamma(partit, mesh)
+        end if
+        ! Fox-Kemper mixed-layer eddies add to the same streamfunction, so the bolus
+        ! velocity, the vertical velocity from continuity, tracer advection and the
+        ! diagnostics all pick them up unchanged. Resets fer_gamma itself when GM is off.
+        if (use_mle) then
+            if (flag_debug .and. mype==0)  print *, achar(27)//'[36m'//'     --> call mle_add_gamma'//achar(27)//'[0m'
+            call mle_add_gamma(partit, mesh)
+        end if
         call fer_gamma2vel(dynamics, partit, mesh)
     end if
     t7=MPI_Wtime()

--- a/src/oce_mle.F90
+++ b/src/oce_mle.F90
@@ -1,0 +1,190 @@
+!---------------------------------------------------------------------------
+!Implementation of mixed layer eddy restratification after Fox-Kemper et al., 2008, 2011
+!Contains:
+!  mle_add_gamma
+!===========================================================================
+module mle_interface
+    interface
+        subroutine mle_add_gamma(partit, mesh)
+            use mod_mesh
+            USE MOD_PARTIT
+            USE MOD_PARSUP
+            type(t_partit), intent(inout), target :: partit
+            type(t_mesh),   intent(in),    target :: mesh
+        end subroutine mle_add_gamma
+    end interface
+end module mle_interface
+!
+!===============================================================================
+!
+subroutine mle_add_gamma(partit, mesh)
+    !  Adds the mixed layer eddy streamfunction to the GM one, before
+    !  fer_gamma2vel converts both to a bolus velocity.
+    !
+    !  Gamma_mle = Ce * (ds/Lf) * H**2 * mu(z) * grad_h(b) / sqrt(f**2 + tau**-2)
+    !  mu(z)     = (1-xi**2) * (1 + 5/21*xi**2),  xi = 2*(z-ztop)/H - 1
+    !
+    !  H       is the mixed layer depth, limited by mle_hmax
+    !  grad_h(b) is the buoyancy gradient averaged over the mixed layer
+    !  ds/Lf   is the grid scale over the frontal width, limited by mle_resscale_max.
+    !          The grid-scale buoyancy gradient underestimates the frontal one by
+    !          about Lf/ds, so this is a field on a variable resolution mesh and
+    !          mesh_resolution(n) is used per node.
+    !  Lf      = max(N*H/sqrt(f**2+tau**-2), mle_Lf_min), the mixed layer
+    !          deformation radius with a floor. Using the regularised f makes the
+    !          factor vanish towards the equator rather than diverge.
+    !  H       is optionally passed through a one-sided running mean
+    !          (mle_mld_decay_time): it deepens at once but decays slowly, so
+    !          restratification continues after a convective event. Not carried
+    !          in the restart; it respins within a few decay times.
+    !  Ce, Lf, tau and the limits are namelist-tunable (oce_dyn)
+    !
+    !  GM and MLE do not double count: the ODM95 taper drives GM to zero wherever
+    !  the neutral slope exceeds ODM95_Scr, which is the whole mixed layer front.
+    !
+    !  Gamma is parallel to grad_h(b), as in fer_solve_Gamma, whose interior limit
+    !  is Gamma = K*grad_h(b)/N**2. mu vanishes at both ends of the range, so the
+    !  boundary conditions match those of the GM Gamma.
+    !
+    !  Levels are restricted to ulevels_nod2D_max..nlevels_nod2D_min as in
+    !  fer_solve_Gamma. This is required, not cosmetic: fer_gamma2vel forms
+    !  u* = [Gamma(nz)-Gamma(nz+1)]/h, so the column integral of the bolus
+    !  transport telescopes to Gamma(top)-Gamma(bottom) and vanishes only if
+    !  Gamma is zero at both ends of the range the ELEMENT has. Where a node is
+    !  deeper than its surrounding elements the residual forces the barotropic mode.
+    !
+    !  The column is then scaled so that max|d(Gamma)/dz| <= mle_ustar_max. Psi
+    !  grows as H**2 and as 1/f, so without this it is unbounded at the equator.
+    !
+    ! Output: fer_gamma(1:2,:,:) incremented, mle_psi(:,:) diagnostic
+    USE MOD_MESH
+    USE MOD_PARTIT
+    USE MOD_PARSUP
+    USE o_PARAM
+    USE o_ARRAYS, ONLY: sigma_xy, fer_gamma, MLD2, bvfreq, mle_psi, mle_hbar
+    USE g_CONFIG
+    use g_comm_auto
+    IMPLICIT NONE
+
+    type(t_partit), intent(inout), target  :: partit
+    type(t_mesh),   intent(in),    target  :: mesh
+
+    integer       :: n, nz, nzmin, nzmax, nzmin_s, nzmax_s, nlev_ml
+    real(kind=WP) :: hml, dxlf, fdenom, prefac, r, xi, mu, zlev, wsum, thick, umax
+    real(kind=WP) :: n2bar, nml, lfront
+    real(kind=WP) :: ztop, zspan
+    real(kind=WP) :: sigbar(2)
+    real(kind=WP) :: zbar_n(mesh%nl), gcol(2, mesh%nl)
+
+#include "associate_part_def.h"
+#include "associate_mesh_def.h"
+#include "associate_part_ass.h"
+#include "associate_mesh_ass.h"
+
+    if (.not. use_mle) return
+    ! With GM off nothing else fills fer_gamma, so it has to start clean each step.
+    if (.not. Fer_GM) fer_gamma = 0.0_WP
+    ! Diagnostic: the MLE streamfunction on its own, since fer_uv holds the sum of
+    ! the MLE and GM bolus velocities.
+    mle_psi = 0.0_WP
+    r = g / density_0
+
+!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(n, nz, nzmin, nzmax, nlev_ml, hml, dxlf, &
+!$OMP                                     fdenom, prefac, xi, mu, zlev, wsum, thick, &
+!$OMP                                     umax, ztop, zspan, nzmin_s, nzmax_s, &
+!$OMP                                     n2bar, nml, lfront, &
+!$OMP                                     sigbar, zbar_n, gcol)
+    DO n=1, myDim_nod2D
+        nzmin = ulevels_nod2D(n)
+        nzmax = nlevels_nod2D(n)
+        if (nzmax - nzmin < 3) cycle
+
+        !_______________________________________________________________________
+        ! level depths below the local surface, positive downward, rebuilt from
+        ! hnode_new exactly as fer_solve_Gamma does so the two stay consistent
+        zbar_n(nzmin) = 0.0_WP
+        do nz = nzmin, nzmax-1
+            zbar_n(nz+1) = zbar_n(nz) + hnode_new(nz,n)
+        end do
+
+        !_______________________________________________________________________
+        ! Level range every element containing this node has, as in fer_solve_Gamma.
+        ! Required for the bolus transport to integrate to zero; see the header.
+        nzmin_s = ulevels_nod2D_max(n)
+        nzmax_s = nlevels_nod2D_min(n)
+        if (nzmax_s - nzmin_s < 3) cycle
+
+        !_______________________________________________________________________
+        ! mixed layer depth, limited by mle_hmax: Psi grows as H**2 and a column
+        ! convecting to the bottom is outside the regime this was derived for
+        ztop = zbar_n(nzmin_s)
+        hml  = min(abs(MLD2(n)), mle_hmax)
+        hml  = min(hml, zbar_n(nzmax_s))
+        if (mle_mld_decay_time > 0.0_WP) then
+            mle_hbar(n) = max(hml, (dt*hml + mle_mld_decay_time*mle_hbar(n)) &
+                                   / (dt + mle_mld_decay_time))
+            hml = min(mle_hbar(n), zbar_n(nzmax_s))
+        end if
+        zspan = hml - ztop
+        if (zspan <= zbar_n(nzmin_s+1) - ztop) cycle   ! thinner than one layer
+
+        !_______________________________________________________________________
+        ! mixed-layer average of the horizontal density gradient
+        sigbar = 0.0_WP
+        n2bar  = 0.0_WP
+        wsum   = 0.0_WP
+        nlev_ml = nzmin_s
+        do nz = nzmin_s, nzmax_s-1
+            if (zbar_n(nz) >= hml) exit
+            thick    = min(zbar_n(nz+1), hml) - zbar_n(nz)
+            sigbar   = sigbar + sigma_xy(1:2,nz,n) * thick
+            n2bar    = n2bar + max(bvfreq(nz,n), 0.0_WP) * thick
+            wsum     = wsum + thick
+            nlev_ml  = nz+1
+        end do
+        if (wsum <= 0.0_WP) cycle
+        sigbar = sigbar / wsum
+        n2bar  = n2bar / wsum
+
+        !_______________________________________________________________________
+        ! resolution factor and the equatorial regularisation
+        fdenom = sqrt(mesh%coriolis_node(n)**2 + 1.0_WP/(mle_tau*mle_tau))
+        nml    = sqrt(max(n2bar, 0.0_WP))
+        lfront = max(nml*zspan/fdenom, mle_Lf_min)
+        dxlf   = min(mesh_resolution(n)/lfront, mle_resscale_max)
+        prefac = mle_Ce * dxlf * zspan*zspan / fdenom
+
+        !_______________________________________________________________________
+        ! vertical structure, and add to the GM streamfunction.  Gamma is parallel
+        ! to grad_h(b) = -(g/rho0)*sigma_xy, matching the GM sign (see header).
+        gcol = 0.0_WP
+        do nz = nzmin_s, min(nlev_ml, nzmax_s)
+            zlev = zbar_n(nz)
+            if (zlev > hml) exit
+            ! xi runs -1 at the top of the range to +1 at the mixed layer base
+            xi = 2.0_WP*(zlev - ztop)/zspan - 1.0_WP
+            mu = (1.0_WP - xi*xi) * (1.0_WP + (5.0_WP/21.0_WP)*xi*xi)
+            if (mu <= 0.0_WP) cycle
+            gcol(1:2,nz) = prefac * mu * ( -r * sigbar(1:2) )
+        end do
+
+        !_______________________________________________________________________
+        ! Limit the induced bolus velocity u* = d(Gamma)/dz. One factor for the
+        ! whole column, so mu(z) is not distorted.
+        umax = 0.0_WP
+        do nz = nzmin_s, nzmax_s-1
+            thick = max(hnode_new(nz,n), 1.0_WP)
+            umax  = max(umax, sqrt( (gcol(1,nz)-gcol(1,nz+1))**2 &
+                                  + (gcol(2,nz)-gcol(2,nz+1))**2 ) / thick)
+        end do
+        if (umax > mle_ustar_max) gcol = gcol * (mle_ustar_max/umax)
+
+        do nz = nzmin_s, nzmax_s
+            fer_gamma(1:2,nz,n) = fer_gamma(1:2,nz,n) + gcol(1:2,nz)
+            mle_psi(nz,n) = sqrt(gcol(1,nz)*gcol(1,nz) + gcol(2,nz)*gcol(2,nz))
+        end do
+    END DO
+!$OMP END PARALLEL DO
+
+    call exchange_nod(fer_gamma, partit)
+end subroutine mle_add_gamma

--- a/src/oce_modules.F90
+++ b/src/oce_modules.F90
@@ -93,6 +93,15 @@ logical                       :: Redi_Ktaper = .false.
 real(kind=WP)                 :: Redi_Kmax   = 3000.0_WP
 real(kind=WP)                 :: Redi_Kmin   = 2.0_WP
 
+!___mixed layer eddy restratification (Fox-Kemper et al. 2008, 2011, see oce_mle.F90)___
+logical                       :: use_mle = .false.        ! enable MLE restratification
+real(kind=WP)                 :: mle_Ce  = 0.06_WP        ! efficiency coefficient
+real(kind=WP)                 :: mle_Lf_min = 1000.0_WP   ! floor on the frontal width Lf = max(N*H/f, Lf_min)
+real(kind=WP)                 :: mle_tau = 86400.0_WP     ! frontal lifetime, regularises f towards the equator
+real(kind=WP)                 :: mle_hmax = 500.0_WP      ! max. mixed layer depth used, Psi scales with H^2
+real(kind=WP)                 :: mle_resscale_max = 20.0_WP ! max. resolution factor ds/Lf
+real(kind=WP)                 :: mle_ustar_max = 0.05_WP  ! max. induced bolus velocity
+real(kind=WP)                 :: mle_mld_decay_time = 0.0_WP ! running-mean decay time for H, 0 = off
 logical                       :: scaling_ODM95 =.true.    ! tapering based on critical slope
 real(kind=WP)                 :: ODM95_Scr = 1.0e-2_WP   ! Critical slope for tapering
 real(kind=WP)                 :: ODM95_Sd = 1.0e-3_WP   ! slope width of tapering smoothing zone
@@ -230,6 +239,8 @@ character(20)                  :: which_pgf='shchepetkin'
                     scaling_LDD97, LDD97_c, LDD97_rmin, LDD97_rmax, &
                     scaling_GINsea, GINsea_fac, GMzexp_smin, &
                     scaling_GMzexp, GMzexp_zref, &
+                    use_mle, mle_Ce, mle_Lf_min, mle_tau, mle_hmax, mle_resscale_max, &
+                    mle_ustar_max, mle_mld_decay_time, &
                     use_salt_anomaly
 
  NAMELIST /tracer_phys/ diff_sh_limit, Kv0_const, double_diffusion, K_ver, K_hor, surf_relax_T, surf_relax_S, &
@@ -273,6 +284,8 @@ real(kind=WP), allocatable    :: heat_flux_t(:,:), heat_rel_t(:,:), heat_rel(:)
 !!PS real(kind=WP), allocatable    :: coriolis(:), coriolis_node(:)
 real(kind=WP), allocatable    :: relax2clim(:)
 real(kind=WP), allocatable    :: MLD1(:), MLD2(:), MLD3(:)
+real(kind=WP), allocatable    :: mle_psi(:,:)   ! Fox-Kemper MLE streamfunction magnitude [m2/s]
+real(kind=WP), allocatable    :: mle_hbar(:)    ! running-mean mixed layer depth used by MLE [m]
 integer,       allocatable    :: MLD1_ind(:), MLD2_ind(:), MLD3_ind(:)
 real(kind=WP), allocatable    :: ssh_gp(:)
 !Tracer gradients&RHS

--- a/src/oce_setup_step.F90
+++ b/src/oce_setup_step.F90
@@ -756,7 +756,7 @@ nl => mesh%nl
     dynamics%uv_rhs          = 0.0_WP
     dynamics%uv_rhsAB        = 0.0_WP
     dynamics%uvnode          = 0.0_WP
-    if (Fer_GM) then
+    if (Fer_GM .or. use_mle) then
         allocate(dynamics%fer_uv(2, nl-1, elem_size))
         dynamics%fer_uv      = 0.0_WP
     end if 
@@ -774,7 +774,7 @@ nl => mesh%nl
     dynamics%w_e             = 0.0_WP
     dynamics%w_i             = 0.0_WP
     dynamics%cfl_z           = 0.0_WP
-    if (Fer_GM) then
+    if (Fer_GM .or. use_mle) then
         allocate(dynamics%fer_w(      nl, node_size))
         dynamics%fer_w       = 0.0_WP
     end if 
@@ -964,6 +964,12 @@ nl              => mesh%nl
     ! ================
     allocate( hpressure(nl,node_size))
     allocate(bvfreq(nl,node_size),mixlay_dep(node_size),bv_ref(node_size))
+    ! MLE streamfunction diagnostic, so the MLE bolus can be told apart from the GM one
+    if (use_mle) then
+        allocate(mle_psi(nl, node_size), mle_hbar(node_size))
+        mle_psi  = 0.0_WP
+        mle_hbar = 0.0_WP
+    end if
     ! ================
     ! Ocean forcing arrays
     ! ================
@@ -1056,7 +1062,9 @@ nl              => mesh%nl
     sw_alpha =0.0_WP
     dens_flux=0.0_WP
 
-    if (Fer_GM) then
+    ! MLE writes into fer_gamma and rides the GM plumbing, so these are needed
+    ! whenever either scheme is on.
+    if (Fer_GM .or. use_mle) then
     allocate(fer_c(node_size),fer_scal(node_size), fer_gamma(2, nl, node_size), fer_K(nl, node_size), fer_tapfac(nl, node_size))
     fer_gamma = 0.0_WP
     fer_K     = 500._WP


### PR DESCRIPTION
This adds `use_mle` to `&oce_dyn`, the mixed-layer eddy streamfunction of Fox-Kemper et al. (2008, 2011). It is added to `fer_gamma` before `fer_gamma2vel`, so the bolus velocity, the vertical velocity, tracer advection and the GM diagnostics all pick it up unchanged. It works with or without `Fer_GM`. It is off by default. With `use_mle = .false.` the only change is that the GM work arrays are allocated when either scheme is on.

- **Frontal width.** `Lf = max(N*H/f, mle_Lf_min)`, where `f` is regularised towards the equator with `mle_tau`. The resolution factor `ds/Lf` uses `mesh_resolution` per node and is capped by `mle_resscale_max`.
- **Mixed-layer depth.** `H = min(MLD2, mle_hmax)`. It can optionally be passed through a one-sided running mean (`mle_mld_decay_time`), which is not carried in the restart.
- **Level range.** The streamfunction is limited to `ulevels_nod2D_max..nlevels_nod2D_min`, as in `fer_solve_Gamma`, so the column bolus transport integrates to zero.
- **Velocity bound.** Each column is scaled so that the induced bolus velocity stays below `mle_ustar_max`.
- **Output.** `mle_psi` is a new output field. It is registered through `def_stream`, so it is not written when output goes through XIOS.

**Testing** used AWI-ESM3 (OpenIFS 48r1, CORE3 mesh, linfs, single precision): one year each from the same restart, with `use_mle` on and off. The mixed-layer depth uses the WOA18 density criterion.

- The mixed layer shoals in every latitude band on the annual mean, by 1.9 to 17.5 m. It shoals most in winter: 62 m at 45–60N in March, and 48 m at 30–45S in October.
- Two further one-year runs completed without instability: one without the `mle_hmax` cap, and one with the frontal width as a field.

**This is a draft for three reasons:**

- The added bolus streamfunction at the mixed-layer base, diagnosed from monthly-mean bolus output, is 0.00–0.03 m2/s. An offline estimate predicted 0.9–2.0 m2/s at the outcrops. I do not understand this discrepancy yet.
- The test runs predate #1054.
- The commit was tested on an older base. It cherry-picks cleanly onto current main but has not been compiled there.