### PR TITLE
Describe all remaining namelists, identical to the defaults where values match

### DIFF
--- a/config/bin_2p1z1d/namelist.config
+++ b/config/bin_2p1z1d/namelist.config
@@ -1,76 +1,133 @@
-! This is the namelist file for model general configuration
+! ============================================================================
+! ============ Namelist file for FESOM2 general configuration ================
+! ============================================================================
+! This file contains the main configuration parameters for FESOM2, including:
+! - Model identification and run settings
+! - Time stepping and simulation duration
+! - Initial time/date settings
+! - File paths for mesh, forcing, and output
+! - Restart and logging configuration
+! - Vertical coordinate system (ALE)
+! - Grid geometry and rotation
+! - Calendar settings
+! - Model components (ice, cavities, etc.)
+! - Parallel decomposition
+! - Iceberg settings
+! ============================================================================
 
+! ============================================================================
+! RUN IDENTIFICATION
+! ============================================================================
 &modelname
-runid='fesom'
+runid = 'fesom'        ! run identifier (used in output filenames)
 /
 
+! ============================================================================
+! TIME STEPPING AND RUN LENGTH
+! ============================================================================
 &timestep
-step_per_day=32 !96 !96 !72 !72 !45 !72 !96
-run_length= 1 !62 !62 !62 !28
-run_length_unit='y' ! y, m, d, s
+step_per_day      = 32         ! number of time steps per day (determines dt = 86400/step_per_day seconds)
+                                ! common values: 32 (45min), 48 (30min), 72 (20min), 96 (15min), 192 (7min 30sec), 
+                                ! 216 (6min 40sec), 240 (6min), 288 (5min), 360 (4min), 720 (2min), 1440 (1min), 2880 (30sec)
+run_length        = 1          ! total length of simulation run
+run_length_unit   = 'y'        ! unit for run_length: 'y' (years), 'm' (months), 'd' (days), 's' (steps)
 /
 
-&clockinit              ! the model starts at
-timenew=0.0
-daynew=1
-yearnew=1958
+! ============================================================================
+! INITIAL TIME/DATE SETTINGS
+! ============================================================================
+&clockinit
+timenew = 0.0                  ! initial time within the day [seconds] (0.0 = midnight)
+daynew  = 1                    ! initial day of the month (1-31)
+yearnew = 1958                 ! initial year
 /
 
+! ============================================================================
+! MESH, INITIALIZATION & OUTPUT PATHS
+! ============================================================================
 &paths
-MeshPath='/albedo/work/projects/p_recompdaf/frbunsen/FESOM2/meshes/core2/'
-ClimateDataPath='/albedo/work/projects/MarESys/ogurses/input/corrected_input/'
-ResultPath='/albedo/work/user/...'
+MeshPath         = '/albedo/work/projects/p_recompdaf/frbunsen/FESOM2/meshes/core2/' ! path to mesh files (nod2d.out, elem2d.out, etc.)
+ClimateDataPath  = '/albedo/work/projects/MarESys/ogurses/input/corrected_input/' ! path to initial conditions (temperature, salinity)
+ResultPath       = '/albedo/work/user/...'  ! path for output files and fesom.clock file
 /
 
+! ============================================================================
+! RESTART AND LOGGING CONFIGURATION
+! ============================================================================
 &restart_log
-restart_length=1            ! --> do netcdf restart ( only required for d,h,s cases, y, m take 1)
-restart_length_unit='y'     !output period: y, d, h, s, off
-raw_restart_length=1        ! --> do core dump restart
-raw_restart_length_unit='off' ! e.g. y, d, h, s, off
-bin_restart_length=1        ! --> do derived type binary restart 
-bin_restart_length_unit='off' ! e.g. y, d, h, s, off
-logfile_outfreq=960         !in logfile info. output frequency, # steps
+restart_length          = 1        ! frequency for netCDF restart files (required for d,h,s; y,m use 1)
+restart_length_unit     = 'y'      ! unit: 'y' (years), 'm' (months), 'd' (days), 'h' (hours), 's' (steps), 'off' (disabled)
+raw_restart_length      = 1        ! frequency for raw core dump restart files
+raw_restart_length_unit = 'off'    ! unit: 'y', 'm', 'd', 'h', 's', 'off'
+bin_restart_length      = 1        ! frequency for binary derived type restart files
+bin_restart_length_unit = 'off'    ! unit: 'y', 'm', 'd', 'h', 's', 'off'
+logfile_outfreq         = 960      ! log file output frequency [number of time steps]
 /
 
+! ============================================================================
+! VERTICAL COORDINATE SYSTEM (ALE - Arbitrary Lagrangian-Eulerian)
+! ============================================================================
 &ale_def
-which_ALE='zstar'       ! 'linfs','zlevel', 'zstar'
-use_partial_cell=.true.
+which_ALE          = 'zstar'     ! vertical coordinate type:
+                                  !   'linfs'  = linear free surface
+                                  !   'zlevel' = z-level (fixed depth levels)
+                                  !   'zstar'  = z-star (terrain-following with SSH scaling)
+use_partial_cell   = .true.      ! use partial bottom cells for better topography representation (not recommended)
 /
 
+! ============================================================================
+! GRID GEOMETRY AND ROTATION
+! ============================================================================
 &geometry
-cartesian=.false.
-fplane=.false.
-cyclic_length=360       ![degree]
-rotated_grid=.true.     !option only valid for coupled model case now
-force_rotation=.true.
-alphaEuler=50.          ![degree] Euler angles, convention:
-betaEuler=15.           ![degree] first around z, then around new x,
-gammaEuler=-90.         ![degree] then around new z.
+cartesian       = .false.        ! use Cartesian coordinates (false = spherical Earth)
+fplane          = .false.        ! use f-plane approximation (constant Coriolis parameter)
+cyclic_length   = 360            ! length of cyclic domain [degrees] (360 = global)
+rotated_grid    = .true.         ! use rotated grid (typically for coupled models to avoid pole singularity)
+force_rotation  = .true.         ! force grid rotation even if not coupled
+alphaEuler      = 50.            ! first Euler angle (rotation around z-axis) [degrees]
+betaEuler       = 15.            ! second Euler angle (rotation around new x-axis) [degrees]
+gammaEuler      = -90.           ! third Euler angle (rotation around new z-axis) [degrees]
+                                  ! Euler angle convention: rotate first around z, then around new x, then around new z
 /
 
+! ============================================================================
+! CALENDAR SETTINGS
+! ============================================================================
 &calendar
-include_fleapyear=.false.
+include_fleapyear = .false.      ! include leap years in calendar (false = 365-day year, true = 365/366-day year)
 /
 
+! ============================================================================
+! MODEL COMPONENTS AND FEATURES
+! ============================================================================
 &run_config
-use_ice=.true.                  ! ocean+ice
-use_cavity=.false.              !
-use_cavity_partial_cell=.false. 
-use_floatice = .false.
-use_sw_pene=.true.
-flag_debug=.false.
-use_transit=.false.
+use_ice                  = .true.        ! enable sea ice model
+use_cavity               = .false.       ! enable ice shelf cavities
+use_cavity_partial_cell  = .false.       ! use partial cells in ice shelf cavities (not recommended)
+use_floatice             = .false.       ! enable floating ice (icebergs)
+use_sw_pene              = .true.        ! enable shortwave radiation penetration into ocean
+flag_debug               = .false.       ! enable debug output (verbose logging)
+use_transit              = .false.       ! enable transient tracer module (CFCs, SF6, etc.)
 /
 
+! ============================================================================
+! PARALLEL DECOMPOSITION (DOMAIN PARTITIONING)
+! ============================================================================
 &machine
-n_levels=2
-n_part= 12, 36          ! 432 number of partitions on each hierarchy level
+n_levels = 2             ! number of hierarchy levels for domain decomposition
+n_part   = 12, 36        ! number of partitions at each level (total CPUs = product of n_part)
+                         ! example: 2 x 128 = 256 MPI tasks
+                         ! adjust based on mesh size and available compute resources
+                         ! maximum scaling reached at ~300 FESOM2 2D nodes per CPU (see first line in nod2d.out for number of 2D nodes)
 /
 
+! ============================================================================
+! ICEBERG SETTINGS
+! ============================================================================
 &icebergs
-use_icesheet_coupling=.false.
-ib_num=1
-use_icebergs=.false.
-steps_per_ib_step=8
-ib_async_mode=0
+use_icesheet_coupling = .false.  ! enable ice sheet model
+ib_num                = 1        ! number of iceberg classes
+use_icebergs          = .false.  ! enable iceberg module
+steps_per_ib_step     = 8        ! ocean time steps per iceberg time step (iceberg subcycling)
+ib_async_mode         = 0        ! iceberg asynchronous mode (0=synchronous, 1=asynchronous)
 /

--- a/config/bin_2p1z1d/namelist.dyn
+++ b/config/bin_2p1z1d/namelist.dyn
@@ -1,24 +1,56 @@
+! ============================================================================
+! ========== Namelist file for FESOM2 momentum dynamics ======================
+! ============================================================================
+! This file contains configuration for momentum equations and dynamics:
+! - Horizontal viscosity schemes and parameters
+! - Momentum advection options
+! - Free-slip vs no-slip boundary conditions
+! - Vertical velocity splitting
+! - Split-explicit barotropic subcycling
+! - Energy diagnostics
+! ============================================================================
+
+! ============================================================================
+! HORIZONTAL VISCOSITY
+! ============================================================================
 &dynamics_visc
-visc_gamma0  = 0.003 ! [m/s],   backgroung viscosity= gamma0*len, it should be as small a s possible (keep it < 0.01 m/s).
-visc_gamma1  = 0.1   ! [nodim], for computation of the flow aware viscosity
-visc_gamma2  = 0.285 ! [s/m],   is only used in easy backscatter option
-visc_easybsreturn= 1.5
+! --- Biharmonic Viscosity Coefficients ---
+visc_gamma0        = 0.003       ! background viscosity coefficient [m/s]
+                                 ! viscosity = gamma0 × element_length
+                                 ! keep < 0.01 m/s for numerical stability
+visc_gamma1        = 0.1         ! flow-aware viscosity coefficient [dimensionless]
+visc_gamma2        = 0.285       ! additional viscosity coefficient [s/m]
+                                 ! only used for easy backscatter (opt_visc=5) and dynamic backscatter (opt_visc=8)
+visc_easybsreturn  = 1.5         ! energy return parameter for easy backscatter [dimensionless]
 
-opt_visc     = 5          
-! 5=Kinematic (easy) Backscatter
-! 6=Biharmonic flow aware (viscosity depends on velocity Laplacian)
-! 7=Biharmonic flow aware (viscosity depends on velocity differences)
-! 8=Dynamic Backscatter
+! --- Viscosity Scheme Selection ---
+opt_visc           = 5           ! horizontal viscosity scheme:
+                                 !   5 = Kinematic (easy) Backscatter
+                                 !   6 = Biharmonic flow-aware (depends on velocity Laplacian)
+                                 !   7 = Biharmonic flow-aware (depends on velocity differences)
+                                 !       + optional Laplacian when visc_gamma0_h or visc_gamma1_h > 0
+                                 !   8 = Dynamic Backscatter
 
-use_ivertvisc= .true.  
+! --- Vertical Viscosity ---
+use_ivertvisc      = .true.      ! use implicit vertical viscosity (recommended for stability)
 /
 
+! ============================================================================
+! GENERAL DYNAMICS SETTINGS
+! ============================================================================
 &dynamics_general
-momadv_opt   = 2       ! option for momentum advection in moment only =2
-use_freeslip = .false. ! Switch on free slip
-use_wsplit   = .false. ! Switch for implicite/explicte splitting of vert. velocity
-wsplit_maxcfl= 1.0     ! maximum allowed CFL criteria in vertical (0.5 < w_max_cfl < 1.) 
-                       ! in older FESOM it used to be w_exp_max=1.e-3
-ldiag_KE=.false.       ! activates energy diagnostics
+! --- Momentum Advection ---
+momadv_opt         = 2           ! momentum advection option (only 2 is currently supported)
+
+! --- Boundary Conditions ---
+use_freeslip       = .false.     ! enable free-slip lateral boundary conditions (false = no-slip)
+
+! --- Vertical Velocity Splitting ---
+use_wsplit         = .false.     ! enable implicit/explicit splitting of vertical velocity
+wsplit_maxcfl      = 1.0         ! maximum allowed vertical CFL criterion (range: 0.5-1.0)
+                                 ! in older FESOM versions this was w_exp_max=1.e-3
+
+! --- Energy Diagnostics ---
+ldiag_KE           = .false.     ! enable kinetic energy diagnostics (requires additional computation)
 /
 

--- a/config/bin_2p1z1d/namelist.forcing
+++ b/config/bin_2p1z1d/namelist.forcing
@@ -1,80 +1,154 @@
-! This is the namelist file for forcing
+! ============================================================================
+! ============= Namelist file for FESOM2 atmospheric forcing ================
+! ============================================================================
+! This file contains configuration for atmospheric forcing and surface boundary
+! conditions, including:
+! - Bulk formulae exchange coefficients (heat, momentum, moisture)
+! - Bulk formulae options and reference heights
+! - Land ice freshwater forcing
+! - Age tracer configuration
+! - Surface forcing data files and variables
+! - Runoff and salinity restoring
+! - Chlorophyll data for shortwave penetration
+! ============================================================================
+! ----------------------------------------------------------------------------
+! File names below are relative to ForcingDataPath in namelist.config. A name
+! starting with '/' is used as given, which is how files outside the forcing
+! tree (for example the Sweeney chlorophyll climatology) are pointed at.
+! ----------------------------------------------------------------------------
 
+! ============================================================================
+! BULK FORMULAE EXCHANGE COEFFICIENTS
+! ============================================================================
+! These coefficients control the turbulent exchange of heat, moisture, and
+! momentum between the atmosphere and ocean/ice surfaces.
+! ============================================================================
 &forcing_exchange_coeff
-Ce_atm_oce=0.00175 ! exchange coeff. of latent heat over open water
-Ch_atm_oce=0.00175 ! exchange coeff. of sensible heat over open water
-Cd_atm_oce=0.001  ! drag coefficient between atmosphere and water
-Ce_atm_ice=0.00175 ! exchange coeff. of latent heat over ice
-Ch_atm_ice=0.00175 ! exchange coeff. of sensible heat over ice
-Cd_atm_ice=0.0012  ! drag coefficient between atmosphere and ice 
-Swind     =0.0     ! parameterization for coupled current feedback
+Ce_atm_oce = 0.00175    ! exchange coefficient of latent heat over open water (dimensionless)
+Ch_atm_oce = 0.00175    ! exchange coefficient of sensible heat over open water (dimensionless)
+Cd_atm_oce = 0.001      ! drag coefficient between atmosphere and water (dimensionless)
+Ce_atm_ice = 0.00175    ! exchange coefficient of latent heat over ice (dimensionless)
+Ch_atm_ice = 0.00175    ! exchange coefficient of sensible heat over ice (dimensionless)
+Cd_atm_ice = 0.0012     ! drag coefficient between atmosphere and ice (dimensionless)
+Swind       = 0.0       ! parameterization for coupled current feedback (0.0 = disabled)
+                        ! non-zero values reduce wind stress based on ocean surface currents
 /
 
+! ============================================================================
+! BULK FORMULAE OPTIONS
+! ============================================================================
+! Configuration for bulk formulae calculations (turbulent fluxes).
+! Reference heights must match the forcing data specifications.
+! ============================================================================
 &forcing_bulk
-AOMIP_drag_coeff=.false.
-ncar_bulk_formulae=.true.
-ncar_bulk_z_wind=10.0 ! height at which wind forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-ncar_bulk_z_tair=10.0 ! height at which temp forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-ncar_bulk_z_shum=10.0 ! height at which humi forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-
+AOMIP_drag_coeff  = .false.  ! use AOMIP drag coefficient formulation (false = use standard)
+ncar_bulk_formulae = .true.  ! use NCAR bulk formulae (Large & Yeager 2004, 2009)
+ncar_bulk_z_wind   = 10.0    ! reference height for wind forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_tair   = 10.0    ! reference height for air temperature forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_shum   = 10.0    ! reference height for specific humidity forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
 /
 
+! ============================================================================
+! LAND ICE FRESHWATER FORCING
+! ============================================================================
+! Configuration for freshwater input from land ice (glaciers, ice sheets).
+! Requires use_landice_water=.true. in namelist.config to enable output.
+! ============================================================================
 &land_ice
-use_landice_water=.false.
-landice_start_mon=5
-landice_end_mon=10
-fwf_path='./mesh/'
-
+use_landice_water = .false.  ! enable land ice freshwater forcing
+landice_start_mon = 5        ! start month for land ice forcing (1-12)
+landice_end_mon   = 10       ! end month for land ice forcing (1-12)
+fwf_path          = './mesh/'    ! path to land ice freshwater flux data files
 /
 
+! ============================================================================
+! AGE TRACER CONFIGURATION
+! ============================================================================
+! Configuration for passive age tracer (tracks water mass age).
+! Requires use_age_tracer=.true. in namelist.config to enable output.
+! ============================================================================
 &age_tracer
-use_age_tracer=.false.
-use_age_mask=.false.
-age_tracer_path='./mesh/'
-age_start_year=2000
-
+use_age_tracer    = .false.  ! enable age tracer computation
+use_age_mask      = .false.  ! use spatial mask for age tracer initialization
+age_tracer_path   = './mesh/'    ! path to age tracer mask file (if use_age_mask=.true.)
+age_start_year    = 2000     ! year to start age tracer (tracer age = 0 at this year)
 /
 
+! ============================================================================
+! SURFACE BOUNDARY CONDITION (FORCING DATA)
+! ============================================================================
+! Specification of atmospheric forcing data files and variables.
+! File paths are relative to the run directory.
+! ============================================================================
 &nam_sbc
-   nm_xwind_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/uas.clim61'        ! name of file with winds, if nm_sbc=2
-   nm_ywind_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/vas.clim61'        ! name of file with winds, if nm_sbc=2
-   nm_xstre_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/uas.clim61'        ! name of file with winds, if nm_sbc=2
-   nm_ystre_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/vas.clim61'        ! name of file with winds, if nm_sbc=2
-   nm_humi_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/huss.clim61'        ! name of file with humidity
-   nm_qsr_file   = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/rsds.clim61'    ! name of file with solar heat
-   nm_qlw_file   = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/rlds.clim61'    ! name of file with Long wave
-   nm_tair_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/tas.clim61'        ! name of file with 2m air temperature
+   ! --- Forcing file paths ---
+   nm_xwind_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/uas.clim61' ! name of file with zonal wind speeds
+   nm_ywind_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/vas.clim61' ! name of file with meridional wind speeds
+   nm_xstre_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/uas.clim61' ! name of file with zonal wind stress
+   nm_ystre_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/vas.clim61' ! name of file with meridional wind stress
+   nm_humi_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/huss.clim61' ! name of file with air humidity
+   nm_qsr_file   = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/rsds.clim61' ! name of file with short wave radiation
+   nm_qlw_file   = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/rlds.clim61' ! name of file with long wave radiation
+   nm_tair_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/tas.clim61' ! name of file with 2m air temperature
    nm_prec_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/prra.clim61' ! name of file with total precipitation
-   nm_snow_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/prsn.clim61' ! name of file with snow  precipitation
+   nm_snow_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/prsn.clim61' ! name of file with snow precipitation
    nm_mslp_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/psl.clim61'         ! air_pressure_at_sea_level
-   nm_xwind_var  = 'uas'   ! name of variable in file with wind
-   nm_ywind_var  = 'vas'   ! name of variable in file with wind
-   nm_xstre_var  = 'uas'   ! name of variable in file with wind
-   nm_ystre_var  = 'vas'   ! name of variable in file with wind
-   nm_humi_var   = 'huss'  ! name of variable in file with humidity
-   nm_qsr_var    = 'rsds'  ! name of variable in file with solar heat
-   nm_qlw_var    = 'rlds'  ! name of variable in file with Long wave
-   nm_tair_var   = 'tas'   ! name of variable in file with 2m air temperature
-   nm_prec_var   = 'prra'  ! name of variable in file with total precipitation
-   nm_snow_var   = 'prsn'  ! name of variable in file with total precipitation
-   nm_mslp_var   = 'psl'   ! name of variable in file with air_pressure_at_sea_level
-   nm_nc_iyear   = 1900
-   nm_nc_imm     = 1            ! initial month of time axis in netCDF 
-   nm_nc_idd     = 1            ! initial day of time axis in netCDF
-   nm_nc_freq    = 1            ! data points per day (i.e. 86400 if the time axis is in seconds)
-   nm_nc_tmid    = 0            ! 1 if the time stamps are given at the mid points of the netcdf file, 0 otherwise (i.e. 1 in CORE1, CORE2; 0 in JRA55)
-   y_perpetual=.true.
-   l_xwind=.true. l_ywind=.true. l_xstre=.false. l_ystre=.false. l_humi=.true. l_qsr=.true. l_qlw=.true. l_tair=.true. l_prec=.true. l_mslp=.true. l_cloud=.false. l_snow=.true.
-   nm_runoff_file      ='/albedo/pool/FESOM/forcing/CORE2/runoff.nc'
-   runoff_data_source ='CORE2'	!Dai09, CORE2
-   !runoff_data_source ='Dai09'  !Dai09, CORE2, JRA55
-   !runoff_climatology =.true.
-   sss_data_source    ='CORE2'
-   nm_sss_data_file   ='/albedo/pool/FESOM/forcing/CORE2/PHC2_salx.nc'
-   chl_data_source    ='None' !'Sweeney' monthly chlorophyll climatology or 'NONE' for constant chl_const (below). Make use_sw_pene=.TRUE. in namelist.config!
-   nm_chl_data_file   ='/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/Sweeney/Sweeney_2005.nc'
-   chl_const          = 0.1
-   use_runoff_mapper  = .FALSE.
-   runoff_basins_file = 'runoff_maps_regular.nc'
-   runoff_radius      = 500000.
+
+   ! --- Variable names in netCDF forcing files ---
+   nm_xwind_var  = 'uas'      ! name of variable in file with zonal wind
+   nm_ywind_var  = 'vas'      ! name of variable in file with meridional wind
+   nm_xstre_var  = 'uas'      ! name of variable in file with zonal wind stress
+   nm_ystre_var  = 'vas'      ! name of variable in file with meridional wind stress
+   nm_humi_var   = 'huss'     ! name of variable in file with humidity
+   nm_qsr_var    = 'rsds'     ! name of variable in file with solar heat
+   nm_qlw_var    = 'rlds'     ! name of variable in file with long wave
+   nm_tair_var   = 'tas'      ! name of variable in file with 2m air temperature
+   nm_prec_var   = 'prra'     ! name of variable in file with total precipitation
+   nm_snow_var   = 'prsn'     ! name of variable in file with snow precipitation
+   nm_mslp_var   = 'psl'      ! name of variable in file with air_pressure_at_sea_level
+
+   ! --- Time axis configuration in forcing files ---
+   nm_nc_iyear   = 1900       ! initial year of forcing data time axis (note, not the first year in the file!)
+   nm_nc_imm     = 1          ! initial month of forcing data time axis (1-12)
+   nm_nc_idd     = 1          ! initial day of forcing data time axis (1-31)
+   nm_nc_freq    = 1          ! divisor converting the time axis of the forcing files to days (1 = days, 24 = hours, 86400 = seconds)
+   nm_nc_tmid    = 0          ! time stamp position: 1=mid-point, 0=start of interval
+   y_perpetual   = .true.     ! use perpetual year forcing (repeat single year)
+
+   ! --- Enable/disable individual forcing fields ---
+   l_xwind       = .true.     ! use zonal wind forcing
+   l_ystre=.false.
+   l_ywind       = .true.     ! use meridional wind forcing
+   l_humi        = .true.     ! use specific humidity forcing
+   l_qsr         = .true.     ! use shortwave radiation forcing
+   l_qlw         = .true.     ! use longwave radiation forcing
+   l_tair        = .true.     ! use air temperature forcing
+   l_xstre=.false.
+   l_prec        = .true.     ! use precipitation forcing
+   l_mslp        = .true.     ! use mean sea level pressure forcing
+   l_cloud       = .false.    ! use cloud cover forcing
+   l_snow        = .true.     ! use snow precipitation forcing
+
+   ! --- Runoff configuration ---
+   runoff_data_source = 'CORE2'       ! runoff data source: 'Dai09', 'JRA55', 'CORE1', 'CORE2' or 'NONE'
+   nm_runoff_file     = '/albedo/pool/FESOM/forcing/CORE2/runoff.nc' ! CORE2 monthly climatology with runoff_climatology=.true.
+   !nm_runoff_file     = 'friver.'  ! Dai09/JRA55 with runoff_climatology=.false.: prefix, year and '.nc' are appended (friver.1958.nc).
+
+   ! --- Sea surface salinity restoring ---
+   sss_data_source  = 'CORE2'  ! SSS restoring data source: 'CORE2', 'WOA', or 'NONE'
+   nm_sss_data_file = '/albedo/pool/FESOM/forcing/CORE2/PHC2_salx.nc' ! path to SSS restoring data file, e.g. PHC2_salx.nc
+
+   ! --- Chlorophyll data for shortwave penetration ---
+   chl_data_source  = 'None'      ! chlorophyll data source: 'Sweeney' (monthly climatology) or 'None' (constant)
+                               ! requires use_sw_pene=.true. in namelist.config
+   nm_chl_data_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/Sweeney/Sweeney_2005.nc' ! chlorophyll data file (if Sweeney)
+   chl_const        = 0.1      ! constant chlorophyll concentration [mg/m³] (if chl_data_source='None')
+
+   ! --- Runoff mapper (distributes runoff over coastal area) ---
+   use_runoff_mapper  = .false.  ! enable runoff mapper (spreads runoff spatially)
+   runoff_basins_file = 'runoff_maps_regular.nc' ! runoff basin mapping file
+   runoff_radius      = 500000.  ! radius for runoff spreading [m] (if use_runoff_mapper=.true.)
 /

--- a/config/bin_2p1z1d/namelist.ice
+++ b/config/bin_2p1z1d/namelist.ice
@@ -1,31 +1,76 @@
-! Ice namelist
+! ============================================================================
+! ============== Namelist file for FESOM2 sea ice model =====================
+! ============================================================================
+! This file contains configuration for sea ice dynamics and thermodynamics:
+! - EVP (Elastic-Viscous-Plastic) rheology options
+! - Ice strength and deformation parameters
+! - Ocean-ice drag
+! - Ice thermodynamics and thickness distribution
+! - Albedo parameterizations
+! ============================================================================
+
+! ============================================================================
+! SEA ICE DYNAMICS
+! ============================================================================
 &ice_dyn
-whichEVP=0             ! 0=standart; 1=mEVP; 2=aEVP
-Pstar=30000.0          ! [N/m^2]
-ellipse=2.0
-c_pressure=20.0        ! ice concentration parameter used in ice strength computation
-delta_min=1.0e-11      ! [s^(-1)]
-evp_rheol_steps=120    ! number of EVP subcycles
-alpha_evp=250          ! constant that control numerical stability of mEVP. Adjust with resolution. 
-beta_evp=250           ! constant that control numerical stability of mEVP. Adjust with resolution.
-c_aevp=0.15            ! a tuning constant in aEVP. Adjust with resolution.
-Cd_oce_ice=0.0055      ! drag coef. oce - ice 
-ice_gamma_fct=0.5      ! smoothing parameter
-ice_diff=0.0           ! diffusion to stabilize
-theta_io=0.0           ! rotation angle
-ice_ave_steps=1        ! ice step=ice_ave_steps*oce_step
+! --- EVP Rheology Options ---
+whichEVP       = 0              ! EVP solver type:
+                                !   0 = standard EVP
+                                !   1 = modified EVP (mEVP)
+                                !   2 = adaptive EVP (aEVP)
+
+! --- Ice Strength Parameters ---
+Pstar          = 30000.0        ! ice strength parameter [N/m²] (typical: 20000-30000)
+ellipse        = 2.0            ! aspect ratio of yield curve ellipse (dimensionless)
+c_pressure     = 20.0           ! ice concentration parameter for strength computation (dimensionless)
+
+! --- Ice Deformation ---
+delta_min      = 1.0e-11        ! minimum strain rate for viscosity regularization [s⁻¹]
+
+! --- EVP Subcycling ---
+evp_rheol_steps = 120           ! number of EVP subcycles per ice time step
+
+! --- mEVP Stability Parameters (for whichEVP=1) ---
+alpha_evp      = 250            ! mEVP stability constant (adjust with resolution)
+beta_evp       = 250            ! mEVP stability constant (adjust with resolution)
+
+! --- aEVP Tuning (for whichEVP=2) ---
+c_aevp         = 0.15           ! aEVP tuning constant (adjust with resolution)
+
+! --- Ocean-Ice Coupling ---
+Cd_oce_ice     = 0.0055         ! drag coefficient between ocean and ice (dimensionless, typical: 0.0055)
+
+! --- Numerical Stabilization ---
+ice_gamma_fct  = 0.5            ! smoothing parameter for ice dynamics (0.0-1.0)
+ice_diff       = 0.0            ! artificial diffusion for numerical stability [m²/s]
+theta_io       = 0.0            ! rotation angle for ice-ocean stress [degrees]
+
+! --- Time Stepping ---
+ice_ave_steps  = 1              ! ice time step = ice_ave_steps × ocean time step
 /
 
+! ============================================================================
+! SEA ICE THERMODYNAMICS
+! ============================================================================
 &ice_therm
-Sice=4.0               ! Ice salinity 3.2--5.0 ppt.
-h0=.5                  ! Lead closing parameter [m] 
-emiss_ice=0.97         ! Emissivity of Snow/Ice,
-emiss_wat=0.97         ! Emissivity of open water
-albsn=0.81             ! Albedo: frozen snow
-albsnm=0.77            !         melting snow
-albi=0.7               !         frozen ice
-albim=0.68             !         melting ice
-albw=0.1               !         open water
-con=2.1656             ! Thermal conductivities: ice; W/m/K
-consn=0.31             !                         snow
+! --- Ice Properties ---
+Sice           = 4.0            ! bulk ice salinity [ppt] (typical range: 3.2-5.0)
+
+! --- Lead Closing Parameters ---
+h0             = 0.5            ! lead closing parameter for Northern Hemisphere [m]
+
+! --- Emissivity (Longwave Radiation) ---
+emiss_ice      = 0.97           ! emissivity of snow/ice surface (dimensionless, 0-1)
+emiss_wat      = 0.97           ! emissivity of open water (dimensionless, 0-1)
+
+! --- Albedo (Shortwave Radiation) ---
+albsn             = 0.81           ! albedo of frozen snow (dimensionless, 0-1)
+albsnm            = 0.77           ! albedo of melting snow (dimensionless, 0-1)
+albi              = 0.7            ! albedo of frozen ice (dimensionless, 0-1)
+albim             = 0.68           ! albedo of melting ice (dimensionless, 0-1)
+albw              = 0.1            ! albedo of open water (dimensionless, 0-1)
+
+! --- Thermal Conductivity ---
+con            = 2.1656         ! thermal conductivity of ice [W/m/K]
+consn          = 0.31           ! thermal conductivity of snow [W/m/K]
 /

--- a/config/bin_2p1z1d/namelist.icepack
+++ b/config/bin_2p1z1d/namelist.icepack
@@ -1,4 +1,23 @@
-&env_nml                    ! In the original release these variables are defined in the icepack.settings
+! ============================================================================
+! =============== Namelist file for FESOM2 Icepack sea ice ===================
+! ============================================================================
+! This file contains configuration for the Icepack column physics package,
+! used when FESOM2 is built with Icepack (see docs/icepack_in_fesom.rst):
+! - Tracer array sizes and switches
+! - Ice thickness distribution and thermodynamics
+! - Shortwave radiation and albedo
+! - Melt ponds
+! - Surface forcing options
+! - Ridging and ice strength
+! - Icepack output variables
+! ============================================================================
+
+! ============================================================================
+! ENVIRONMENT (ARRAY SIZES)
+! ============================================================================
+! In the original Icepack release these are set in icepack.settings.
+! ============================================================================
+&env_nml
     nicecat   = 5           ! number of ice thickness categories
     nfsdcat   = 1           ! number of floe size categories
     nicelyr   = 4           ! number of vertical layers in the ice
@@ -6,110 +25,160 @@
     ntraero   = 0           ! number of aerosol tracers (up to max_aero in ice_domain_size.F90)
     trzaero   = 0           ! number of z aerosol tracers (up to max_aero = 6)
     tralg     = 0           ! number of algal tracers (up to max_algae = 3)
-    trdoc     = 0           ! number of dissolve organic carbon (up to max_doc = 3)
-    trdic     = 0           ! number of dissolve inorganic carbon (up to max_dic = 1)
-    trdon     = 0           ! number of dissolve organic nitrogen (up to max_don = 1)
-    trfed     = 0           ! number of dissolved iron tracers (up to max_fe  = 2)
-    trfep     = 0           ! number of particulate iron tracers (up to max_fe  = 2)
+    trdoc     = 0           ! number of dissolved organic carbon tracers (up to max_doc = 3)
+    trdic     = 0           ! number of dissolved inorganic carbon tracers (up to max_dic = 1)
+    trdon     = 0           ! number of dissolved organic nitrogen tracers (up to max_don = 1)
+    trfed     = 0           ! number of dissolved iron tracers (up to max_fe = 2)
+    trfep     = 0           ! number of particulate iron tracers (up to max_fe = 2)
     nbgclyr   = 0           ! number of zbgc layers
-    trbgcz    = 0           ! set to 1 for zbgc tracers (needs TRBGCS = 0 and TRBRI = 1)
-    trzs      = 0           ! set to 1 for zsalinity tracer (needs TRBRI = 1)
+    trbgcz    = 0           ! set to 1 for zbgc tracers (needs trbgcs = 0 and trbri = 1)
+    trzs      = 0           ! set to 1 for zsalinity tracer (needs trbri = 1)
     trbri     = 0           ! set to 1 for brine height tracer
     trage     = 0           ! set to 1 for ice age tracer
     trfy      = 0           ! set to 1 for first-year ice area tracer
     trlvl     = 0           ! set to 1 for level and deformed ice tracers
     trpnd     = 0           ! set to 1 for melt pond tracers
-    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs TRBGCZ = 0)
+    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs trbgcz = 0)
     ndtd      = 1           ! dynamic time steps per thermodynamic time step
 /
 
+! ============================================================================
+! ICE THICKNESS CATEGORIES
+! ============================================================================
 &grid_nml
-    kcatbound    = 1
+    kcatbound    = 1        ! category boundary formula:
+                            !   -1 = single category (column configurations, nicecat = 1)
+                            !    0 = old formula, 1 = new formula with round numbers
+                            !    2 = WMO standard categories (nicecat = 5, 6 or 7 only)
+                            !    3 = asymptotic scheme
 /
 
+! ============================================================================
+! TRACER SWITCHES
+! ============================================================================
+! Any melt pond scheme with calc_Tsfc = .true. needs shortwave = 'dEdd'.
+! ============================================================================
 &tracer_nml
-    tr_iage      = .false.
-    tr_FY        = .false.
-    tr_lvl       = .false.
-    tr_pond_cesm = .false.
-    tr_pond_topo = .false.
-    tr_pond_lvl  = .false.
-    tr_aero      = .false.
-    tr_fsd       = .false.
+    tr_iage      = .false.  ! ice age tracer
+    tr_FY        = .false.  ! first-year ice area tracer
+    tr_lvl       = .false.  ! level (undeformed) ice area and volume tracers
+    tr_pond_cesm = .false.  ! CESM melt pond scheme
+    tr_pond_topo = .false.  ! topographic melt pond scheme
+    tr_pond_lvl  = .false.  ! level-ice melt pond scheme (needs tr_lvl, forces hs0 = 0)
+    tr_aero      = .false.  ! aerosol tracers (needs shortwave = 'dEdd')
+    tr_fsd       = .false.  ! floe size distribution
 /
 
+! ============================================================================
+! THERMODYNAMICS
+! ============================================================================
 &thermo_nml
-    kitd              = 1
-    ktherm            = 1
-    conduct           = 'bubbly'
-    a_rapid_mode      =  0.5e-3
-    Rac_rapid_mode    =    10.0
-    aspect_rapid_mode =     1.0
-    dSdt_slow_mode    = -5.0e-8
-    phi_c_slow_mode   =    0.05
-    phi_i_mushy       =    0.85
-    ksno              = 0.3
+! --- Thickness Distribution and Thermodynamics Scheme ---
+    kitd              = 1           ! ice thickness distribution: 0 = delta function, 1 = linear remapping
+    ktherm            = 1           ! thermodynamics: 1 = Bitz & Lipscomb (1999), 2 = mushy layer
+                                    ! ktherm = 1 expects tfrz_option = 'linear_salt',
+                                    ! ktherm = 2 expects tfrz_option = 'mushy' and calc_Tsfc = .true.
+    conduct           = 'bubbly'    ! ice thermal conductivity (ktherm = 1):
+                                    !   'MU71' = Maykut & Untersteiner (1971), 'bubbly' = Pringle et al. (2007)
+
+! --- Mushy Layer Brine Drainage (ktherm = 2) ---
+    a_rapid_mode      =  0.5e-3     ! brine channel diameter [m]
+    Rac_rapid_mode    =    10.0     ! critical Rayleigh number for rapid drainage
+    aspect_rapid_mode =     1.0     ! brine convection aspect ratio
+    dSdt_slow_mode    = -5.0e-8     ! slow drainage strength parameter [m/(s K)]
+    phi_c_slow_mode   =    0.05     ! critical liquid fraction for slow drainage
+    phi_i_mushy       =    0.85     ! solid fraction at the lower ice boundary
+
+! --- Snow ---
+    ksno              = 0.3         ! thermal conductivity of snow [W/(m K)]
 /
 
+! ============================================================================
+! SHORTWAVE RADIATION AND ALBEDO
+! ============================================================================
 &shortwave_nml
-    shortwave       = 'ccsm3'
-    albedo_type     = 'ccsm3'
-    albicev         = 0.78
-    albicei         = 0.36
-    albsnowv        = 0.98
-    albsnowi        = 0.70
-    albocn          = 0.1
-    ahmax           = 0.3
-    R_ice           = 0.
-    R_pnd           = 0.
-    R_snw           = 1.5
-    dT_mlt          = 1.5
-    rsnw_mlt        = 1500.
-    kalg            = 0.6
+! --- Scheme Selection ---
+    shortwave       = 'ccsm3'   ! shortwave scheme: 'ccsm3' (bulk albedo) or 'dEdd' (Delta-Eddington)
+    albedo_type     = 'ccsm3'   ! albedo parameterization with shortwave = 'ccsm3': 'ccsm3' or 'constant'
+
+! --- Bulk Albedos (shortwave = 'ccsm3') ---
+    albicev         = 0.78      ! visible albedo of thick bare ice
+    albicei         = 0.36      ! near-infrared albedo of thick bare ice
+    albsnowv        = 0.98      ! visible albedo of cold snow
+    albsnowi        = 0.70      ! near-infrared albedo of cold snow
+    albocn          = 0.1       ! ocean albedo
+    ahmax           = 0.3       ! ice thickness above which the albedo is constant [m]
+
+! --- Delta-Eddington Tuning (shortwave = 'dEdd') ---
+    R_ice           = 0.        ! sea ice albedo tuning [standard deviations]
+    R_pnd           = 0.        ! melt pond albedo tuning [standard deviations]
+    R_snw           = 1.5       ! snow grain radius tuning [standard deviations]
+    dT_mlt          = 1.5       ! temperature change that gives rsnw_mlt [deg C]
+    rsnw_mlt        = 1500.     ! maximum melting snow grain radius [micrometres]
+    kalg            = 0.6       ! absorption coefficient for algae
 /
 
+! ============================================================================
+! MELT PONDS
+! ============================================================================
 &ponds_nml
-    hp1             = 0.01
-    hs0             = 0.
-    hs1             = 0.03
-    dpscale         = 1.e-3
-    frzpnd          = 'hlid'
-    rfracmin        = 0.15
-    rfracmax        = 1.
-    pndaspect       = 0.8
+    hp1             = 0.01      ! critical parameter for pond ice thickness [m]
+    hs0             = 0.        ! snow depth for transition to bare sea ice [m]
+    hs1             = 0.03      ! snow depth for transition to pond ice [m] (tr_pond_lvl)
+    dpscale         = 1.e-3     ! time scale for flushing in permeable ice (not used with tr_pond_cesm)
+    frzpnd          = 'hlid'    ! pond refreezing: 'cesm' or 'hlid' (Stefan refreezing with a pond ice lid)
+    rfracmin        = 0.15      ! minimum fraction of melt water added to ponds
+    rfracmax        = 1.        ! maximum fraction of melt water added to ponds
+    pndaspect       = 0.8       ! aspect ratio of pond changes (depth:area)
 /
 
+! ============================================================================
+! SURFACE FORCING OPTIONS
+! ============================================================================
 &forcing_nml
-    formdrag        = .false.
-    atmbndy         = 'default'
-    calc_strair     = .true.
-    calc_Tsfc       = .true.
-    highfreq        = .false.
-    natmiter        = 5
-    ustar_min       = 0.0005
-    emissivity      = 0.95
-    fbot_xfer_type  = 'constant'
-    update_ocn_f    = .false.
-    l_mpond_fresh   = .false.
-    tfrz_option     = 'linear_salt'
-    oceanmixed_ice  = .true.
-    wave_spec_type  = 'none'
+! --- Atmosphere-Ice Exchange ---
+    formdrag        = .false.       ! calculate form drag (needs calc_strair and tr_lvl, not atmbndy = 'constant')
+    atmbndy         = 'default'     ! atmospheric boundary layer: 'default' (stability dependent) or 'constant'
+    calc_strair     = .true.        ! calculate the wind stress in Icepack instead of reading it
+    calc_Tsfc       = .true.        ! calculate the surface temperature in Icepack instead of reading it
+    highfreq        = .false.       ! high-frequency atmosphere-ice coupling (Roberts et al. 2015)
+    natmiter        = 5             ! number of iterations for the atmospheric boundary layer fluxes
+    emissivity      = 0.95          ! emissivity of snow and ice
+
+! --- Ice-Ocean Exchange ---
+    ustar_min       = 0.0005        ! minimum friction velocity for the ice-ocean heat flux [m/s]
+    fbot_xfer_type  = 'constant'    ! ice-ocean heat transfer coefficient: 'constant' or 'Cdn_ocn' (needs formdrag)
+    update_ocn_f    = .false.       ! include frazil ice fluxes in the ocean flux fields
+    l_mpond_fresh   = .false.       ! retain (topo) pond water until the ponds drain
+    tfrz_option     = 'linear_salt' ! seawater freezing temperature: 'minus1p8', 'linear_salt' or 'mushy'
+    oceanmixed_ice  = .true.        ! active ocean mixed layer calculation in Icepack
+
+! --- Waves ---
+    wave_spec_type  = 'none'        ! wave spectrum for the floe size distribution: 'none', 'constant' or 'random'
 /
 
+! ============================================================================
+! RIDGING AND ICE STRENGTH
+! ============================================================================
 &dynamics_nml
-    kstrength       = 1
-    krdg_partic     = 1
-    krdg_redist     = 1
-    mu_rdg          = 3
-    Cf              = 17.
-    P_star          = 27000.
-    C_star          = 20.
+    kstrength       = 1         ! ice strength formulation: 0 = Hibler (1979), 1 = Rothrock (1975)
+    krdg_partic     = 1         ! ridging participation function: 0 = Thorndike et al. (1975), 1 = exponential
+    krdg_redist     = 1         ! ridging redistribution function: 0 = Hibler (1980), 1 = exponential
+    mu_rdg          = 3         ! e-folding scale of ridged ice [m^0.5] (krdg_redist = 1)
+    Cf              = 17.       ! ratio of ridging work to change in potential energy (kstrength = 1)
+    P_star          = 27000.    ! ice strength parameter [N/m²] (kstrength = 0)
+    C_star          = 20.       ! ice strength decay constant [dimensionless] (kstrength = 0)
 /
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!!!!!!!!!                Icepack output namelist                    !!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
+! ============================================================================
+! ICEPACK OUTPUT VARIABLES
+! ============================================================================
+! Format: 'variable_id', frequency, unit, precision
+!   frequency  = output frequency (integer)
+!   unit       = 'y' (yearly), 'm' (monthly), 'd' (daily), 'h' (hourly), 's' (steps)
+!   precision  = 4 (single precision) or 8 (double precision)
+! Remove the leading '!' to enable a variable.
+! ============================================================================
 &nml_list_icepack
 io_list_icepack =  'aicen     ',1, 'm', 4, ! Sea ice concentration
                    'vicen     ',1, 'm', 4, ! Volume per unit area of ice

--- a/config/bin_2p1z1d/namelist.icepack.cesm.ponds
+++ b/config/bin_2p1z1d/namelist.icepack.cesm.ponds
@@ -1,4 +1,23 @@
-&env_nml                    ! In the original release these variables are defined in the icepack.settings
+! ============================================================================
+! =============== Namelist file for FESOM2 Icepack sea ice ===================
+! ============================================================================
+! This file contains configuration for the Icepack column physics package,
+! used when FESOM2 is built with Icepack (see docs/icepack_in_fesom.rst):
+! - Tracer array sizes and switches
+! - Ice thickness distribution and thermodynamics
+! - Shortwave radiation and albedo
+! - Melt ponds
+! - Surface forcing options
+! - Ridging and ice strength
+! - Icepack output variables
+! ============================================================================
+
+! ============================================================================
+! ENVIRONMENT (ARRAY SIZES)
+! ============================================================================
+! In the original Icepack release these are set in icepack.settings.
+! ============================================================================
+&env_nml
     nicecat   = 5           ! number of ice thickness categories
     nfsdcat   = 1           ! number of floe size categories
     nicelyr   = 4           ! number of vertical layers in the ice
@@ -6,108 +25,156 @@
     ntraero   = 0           ! number of aerosol tracers (up to max_aero in ice_domain_size.F90)
     trzaero   = 0           ! number of z aerosol tracers (up to max_aero = 6)
     tralg     = 0           ! number of algal tracers (up to max_algae = 3)
-    trdoc     = 0           ! number of dissolve organic carbon (up to max_doc = 3)
-    trdic     = 0           ! number of dissolve inorganic carbon (up to max_dic = 1)
-    trdon     = 0           ! number of dissolve organic nitrogen (up to max_don = 1)
-    trfed     = 0           ! number of dissolved iron tracers (up to max_fe  = 2)
-    trfep     = 0           ! number of particulate iron tracers (up to max_fe  = 2)
+    trdoc     = 0           ! number of dissolved organic carbon tracers (up to max_doc = 3)
+    trdic     = 0           ! number of dissolved inorganic carbon tracers (up to max_dic = 1)
+    trdon     = 0           ! number of dissolved organic nitrogen tracers (up to max_don = 1)
+    trfed     = 0           ! number of dissolved iron tracers (up to max_fe = 2)
+    trfep     = 0           ! number of particulate iron tracers (up to max_fe = 2)
     nbgclyr   = 0           ! number of zbgc layers
-    trbgcz    = 0           ! set to 1 for zbgc tracers (needs TRBGCS = 0 and TRBRI = 1)
-    trzs      = 0           ! set to 1 for zsalinity tracer (needs TRBRI = 1)
+    trbgcz    = 0           ! set to 1 for zbgc tracers (needs trbgcs = 0 and trbri = 1)
+    trzs      = 0           ! set to 1 for zsalinity tracer (needs trbri = 1)
     trbri     = 0           ! set to 1 for brine height tracer
     trage     = 0           ! set to 1 for ice age tracer
     trfy      = 0           ! set to 1 for first-year ice area tracer
     trlvl     = 0           ! set to 1 for level and deformed ice tracers
     trpnd     = 1           ! set to 1 for melt pond tracers
-    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs TRBGCZ = 0)
+    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs trbgcz = 0)
     ndtd      = 1           ! dynamic time steps per thermodynamic time step
 /
 
+! ============================================================================
+! ICE THICKNESS CATEGORIES
+! ============================================================================
 &grid_nml
-    kcatbound    = 1
+    kcatbound    = 1        ! category boundary formula:
+                            !   -1 = single category (column configurations, nicecat = 1)
+                            !    0 = old formula, 1 = new formula with round numbers
+                            !    2 = WMO standard categories (nicecat = 5, 6 or 7 only)
+                            !    3 = asymptotic scheme
 /
 
+! ============================================================================
+! TRACER SWITCHES
+! ============================================================================
+! Any melt pond scheme with calc_Tsfc = .true. needs shortwave = 'dEdd'.
+! ============================================================================
 &tracer_nml
-    tr_iage      = .false.
-    tr_FY        = .false.
-    tr_lvl       = .false.
-    tr_pond_cesm = .true.
-    tr_pond_topo = .false.
-    tr_pond_lvl  = .false.
-    tr_aero      = .false.
-    tr_fsd       = .false.
+    tr_iage      = .false.  ! ice age tracer
+    tr_FY        = .false.  ! first-year ice area tracer
+    tr_lvl       = .false.  ! level (undeformed) ice area and volume tracers
+    tr_pond_cesm = .true.   ! CESM melt pond scheme
+    tr_pond_topo = .false.  ! topographic melt pond scheme
+    tr_pond_lvl  = .false.  ! level-ice melt pond scheme (needs tr_lvl, forces hs0 = 0)
+    tr_aero      = .false.  ! aerosol tracers (needs shortwave = 'dEdd')
+    tr_fsd       = .false.  ! floe size distribution
 /
 
+! ============================================================================
+! THERMODYNAMICS
+! ============================================================================
 &thermo_nml
-    kitd              = 1
-    ktherm            = 1
-    conduct           = 'bubbly'
-    a_rapid_mode      =  0.5e-3
-    Rac_rapid_mode    =    10.0
-    aspect_rapid_mode =     1.0
-    dSdt_slow_mode    = -5.0e-8
-    phi_c_slow_mode   =    0.05
-    phi_i_mushy       =    0.85
+! --- Thickness Distribution and Thermodynamics Scheme ---
+    kitd              = 1           ! ice thickness distribution: 0 = delta function, 1 = linear remapping
+    ktherm            = 1           ! thermodynamics: 1 = Bitz & Lipscomb (1999), 2 = mushy layer
+                                    ! ktherm = 1 expects tfrz_option = 'linear_salt',
+                                    ! ktherm = 2 expects tfrz_option = 'mushy' and calc_Tsfc = .true.
+    conduct           = 'bubbly'    ! ice thermal conductivity (ktherm = 1):
+                                    !   'MU71' = Maykut & Untersteiner (1971), 'bubbly' = Pringle et al. (2007)
+
+! --- Mushy Layer Brine Drainage (ktherm = 2) ---
+    a_rapid_mode      =  0.5e-3     ! brine channel diameter [m]
+    Rac_rapid_mode    =    10.0     ! critical Rayleigh number for rapid drainage
+    aspect_rapid_mode =     1.0     ! brine convection aspect ratio
+    dSdt_slow_mode    = -5.0e-8     ! slow drainage strength parameter [m/(s K)]
+    phi_c_slow_mode   =    0.05     ! critical liquid fraction for slow drainage
+    phi_i_mushy       =    0.85     ! solid fraction at the lower ice boundary
 /
 
+! ============================================================================
+! SHORTWAVE RADIATION AND ALBEDO
+! ============================================================================
 &shortwave_nml
-    shortwave       = 'dEdd'
-    albedo_type     = 'ccsm3'
-    albicev         = 0.78
-    albicei         = 0.36
-    albsnowv        = 0.98
-    albsnowi        = 0.70
-    ahmax           = 0.3
-    R_ice           = 0.
-    R_pnd           = 0.
-    R_snw           = 1.5
-    dT_mlt          = 1.5
-    rsnw_mlt        = 1500.
-    kalg            = 0.6
+! --- Scheme Selection ---
+    shortwave       = 'dEdd'    ! shortwave scheme: 'ccsm3' (bulk albedo) or 'dEdd' (Delta-Eddington)
+    albedo_type     = 'ccsm3'   ! albedo parameterization with shortwave = 'ccsm3': 'ccsm3' or 'constant'
+
+! --- Bulk Albedos (shortwave = 'ccsm3') ---
+    albicev         = 0.78      ! visible albedo of thick bare ice
+    albicei         = 0.36      ! near-infrared albedo of thick bare ice
+    albsnowv        = 0.98      ! visible albedo of cold snow
+    albsnowi        = 0.70      ! near-infrared albedo of cold snow
+    ahmax           = 0.3       ! ice thickness above which the albedo is constant [m]
+
+! --- Delta-Eddington Tuning (shortwave = 'dEdd') ---
+    R_ice           = 0.        ! sea ice albedo tuning [standard deviations]
+    R_pnd           = 0.        ! melt pond albedo tuning [standard deviations]
+    R_snw           = 1.5       ! snow grain radius tuning [standard deviations]
+    dT_mlt          = 1.5       ! temperature change that gives rsnw_mlt [deg C]
+    rsnw_mlt        = 1500.     ! maximum melting snow grain radius [micrometres]
+    kalg            = 0.6       ! absorption coefficient for algae
 /
 
+! ============================================================================
+! MELT PONDS
+! ============================================================================
 &ponds_nml
-    hp1             = 0.01
-    hs0             = 0.
-    hs1             = 0.03
-    dpscale         = 1.e-3
-    frzpnd          = 'hlid'
-    rfracmin        = 0.15
-    rfracmax        = 1.
-    pndaspect       = 0.8
+    hp1             = 0.01      ! critical parameter for pond ice thickness [m]
+    hs0             = 0.        ! snow depth for transition to bare sea ice [m]
+    hs1             = 0.03      ! snow depth for transition to pond ice [m] (tr_pond_lvl)
+    dpscale         = 1.e-3     ! time scale for flushing in permeable ice (not used with tr_pond_cesm)
+    frzpnd          = 'hlid'    ! pond refreezing: 'cesm' or 'hlid' (Stefan refreezing with a pond ice lid)
+    rfracmin        = 0.15      ! minimum fraction of melt water added to ponds
+    rfracmax        = 1.        ! maximum fraction of melt water added to ponds
+    pndaspect       = 0.8       ! aspect ratio of pond changes (depth:area)
 /
 
+! ============================================================================
+! SURFACE FORCING OPTIONS
+! ============================================================================
 &forcing_nml
-    formdrag        = .false.
-    atmbndy         = 'default'
-    calc_strair     = .true.
-    calc_Tsfc       = .true.
-    highfreq        = .false.
-    natmiter        = 5
-    ustar_min       = 0.0005
-    emissivity      = 0.95
-    fbot_xfer_type  = 'constant'
-    update_ocn_f    = .false.
-    l_mpond_fresh   = .false.
-    tfrz_option     = 'linear_salt'
-    oceanmixed_ice  = .true.
-    wave_spec_type  = 'none'
+! --- Atmosphere-Ice Exchange ---
+    formdrag        = .false.       ! calculate form drag (needs calc_strair and tr_lvl, not atmbndy = 'constant')
+    atmbndy         = 'default'     ! atmospheric boundary layer: 'default' (stability dependent) or 'constant'
+    calc_strair     = .true.        ! calculate the wind stress in Icepack instead of reading it
+    calc_Tsfc       = .true.        ! calculate the surface temperature in Icepack instead of reading it
+    highfreq        = .false.       ! high-frequency atmosphere-ice coupling (Roberts et al. 2015)
+    natmiter        = 5             ! number of iterations for the atmospheric boundary layer fluxes
+    emissivity      = 0.95          ! emissivity of snow and ice
+
+! --- Ice-Ocean Exchange ---
+    ustar_min       = 0.0005        ! minimum friction velocity for the ice-ocean heat flux [m/s]
+    fbot_xfer_type  = 'constant'    ! ice-ocean heat transfer coefficient: 'constant' or 'Cdn_ocn' (needs formdrag)
+    update_ocn_f    = .false.       ! include frazil ice fluxes in the ocean flux fields
+    l_mpond_fresh   = .false.       ! retain (topo) pond water until the ponds drain
+    tfrz_option     = 'linear_salt' ! seawater freezing temperature: 'minus1p8', 'linear_salt' or 'mushy'
+    oceanmixed_ice  = .true.        ! active ocean mixed layer calculation in Icepack
+
+! --- Waves ---
+    wave_spec_type  = 'none'        ! wave spectrum for the floe size distribution: 'none', 'constant' or 'random'
 /
 
+! ============================================================================
+! RIDGING AND ICE STRENGTH
+! ============================================================================
 &dynamics_nml
-    kstrength       = 1
-    krdg_partic     = 1
-    krdg_redist     = 1
-    mu_rdg          = 3
-    Cf              = 17.
-    P_star          = 27000.
-    C_star          = 20.
+    kstrength       = 1         ! ice strength formulation: 0 = Hibler (1979), 1 = Rothrock (1975)
+    krdg_partic     = 1         ! ridging participation function: 0 = Thorndike et al. (1975), 1 = exponential
+    krdg_redist     = 1         ! ridging redistribution function: 0 = Hibler (1980), 1 = exponential
+    mu_rdg          = 3         ! e-folding scale of ridged ice [m^0.5] (krdg_redist = 1)
+    Cf              = 17.       ! ratio of ridging work to change in potential energy (kstrength = 1)
+    P_star          = 27000.    ! ice strength parameter [N/m²] (kstrength = 0)
+    C_star          = 20.       ! ice strength decay constant [dimensionless] (kstrength = 0)
 /
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!!!!!!!!!                Icepack output namelist                    !!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
+! ============================================================================
+! ICEPACK OUTPUT VARIABLES
+! ============================================================================
+! Format: 'variable_id', frequency, unit, precision
+!   frequency  = output frequency (integer)
+!   unit       = 'y' (yearly), 'm' (monthly), 'd' (daily), 'h' (hourly), 's' (steps)
+!   precision  = 4 (single precision) or 8 (double precision)
+! Remove the leading '!' to enable a variable.
+! ============================================================================
 &nml_list_icepack
 io_list_icepack =  'aicen     ',1, 'm', 4, ! Sea ice concentration
                    'vicen     ',1, 'm', 4, ! Volume per unit area of ice

--- a/config/bin_2p1z1d/namelist.io
+++ b/config/bin_2p1z1d/namelist.io
@@ -1,26 +1,55 @@
+! ============================================================================
+! ============ Namelist file for FESOM2 output configuration =================
+! ============================================================================
+! This file contains configuration for model output and diagnostics:
+! - Diagnostic flags for optional output fields
+! - General output settings (compression, rotation)
+! - Output variable list with frequency and precision
+! - Complete catalog of all available output fields
+!
+! See the output catalog at the end of this file for all possible variables.
+! Some outputs require specific flags in &diag_list or other namelists.
+! ============================================================================
+
+! ============================================================================
+! DIAGNOSTIC FLAGS
+! ============================================================================
+! Enable/disable optional diagnostic computations and outputs.
+! Setting these to .true. enables additional output fields (see catalog below).
+! ============================================================================
 &diag_list
-ldiag_solver     =.false.
-lcurt_stress_surf=.false.
-ldiag_curl_vel3  =.false.
-ldiag_Ri         =.false.
-ldiag_turbflux   =.false.
-ldiag_salt3D     =.false.
-ldiag_dMOC       =.false.
-ldiag_DVD        =.false.
-ldiag_forc       =.false.
-ldiag_extflds    =.false.
+ldiag_solver      = .false.  ! enables solver diagnostics (convergence, iterations)
+lcurt_stress_surf = .false.  ! enables 'curl_surf' output (vorticity of surface stress)
+ldiag_curl_vel3   = .false.  ! enables 'curl_u' output (relative vorticity from 3D velocity)
+ldiag_Ri          = .false.  ! enables Richardson number diagnostics ('shear', 'Ri')
+ldiag_turbflux    = .false.  ! enables turbulent flux diagnostics ('KvdTdz', 'KvdSdz')
+ldiag_salt3D      = .false.  ! enables 3D salinity diagnostics
+ldiag_dMOC        = .false.  ! enables 'dMOC' output (density MOC diagnostics)
+ldiag_DVD         = .false.  ! enables 'DVD' output (Discrete Variance Decay diagnostics)
+ldiag_forc        = .false.  ! enables 'FORC' output (comprehensive forcing diagnostics)
+ldiag_extflds     = .false.  ! enables extended field diagnostics
 /
 
+! ============================================================================
+! GENERAL OUTPUT SETTINGS
+! ============================================================================
 &nml_general
-io_listsize    =150 !number of streams to allocate. shallbe large or equal to the number of streams in &nml_list
-vec_autorotate =.false.
+io_listsize       = 150      ! total number of streams to allocate. Shall be larger or equal to the number of streams in &nml_list (max. 150)
+vec_autorotate    = .false.  ! unrotate vector fields (velocities, winds) before writing to output files
 /
 
-! for sea ice related variables use_ice should be true, otherewise there will be no output
-! for 'curl_surf' to work lcurt_stress_surf must be .true. otherwise no output
-! for 'fer_C', 'bolus_u', 'bolus_v', 'bolus_w', 'fer_K' to work Fer_GM must be .true. otherwise no output
-! 'otracers' - all other tracers if applicable
-! for 'dMOC' to work ldiag_dMOC must be .true. otherwise no output
+! ============================================================================
+! OUTPUT VARIABLE LIST
+! ============================================================================
+! Format: 'variable_id', frequency, unit, precision
+!   frequency  = output frequency (integer)
+!   unit       = 'y' (yearly), 'm' (monthly), 'd' (daily), 'h' (hourly), 's' (steps)
+!   precision  = 4 (single precision) or 8 (double precision)
+!   Note: in a single-precision build (WP=4) a field requesting precision 8 is
+!   still honoured (written as NF_DOUBLE; means accumulated in real64), but its
+!   samples are single-precision-sourced. FESOM prints one summary line at
+!   startup listing such fields.
+! ============================================================================
 &nml_list
 io_list =  'sst       ',1, 'm', 4,
            'sss       ',1, 'm', 4,
@@ -79,3 +108,277 @@ io_list =  'sst       ',1, 'm', 4,
            'respn',1, 'm', 4,
            'respd',1, 'm', 4,
 /
+
+! ============================================================================
+! COMPLETE CATALOG OF ALL POSSIBLE OUTPUT FIELDS
+! ============================================================================
+! Below is a comprehensive list of all valid io_list IDs available in FESOM2.
+! To enable any field, copy the line to the &nml_list section above.
+! NOTE: Some fields require specific flags to be enabled (see comments).
+! ============================================================================
+
+! --- 2D OCEAN SURFACE FIELDS ---
+! 'sst       ',1, 'm', 4,  ! sea surface temperature [C]
+! 'sss       ',1, 'm', 4,  ! sea surface salinity [psu]
+! 'ssh       ',1, 'm', 4,  ! sea surface elevation [m]
+! 'vve_5     ',1, 'm', 4,  ! vertical velocity at 5th level [m/s]
+! 't_star    ',1, 'm', 4,  ! air temperature [C]
+! 'qsr       ',1, 'm', 4,  ! solar radiation [W/s^2]
+
+! --- 3D OCEAN FIELDS ---
+! 'temp      ',1, 'm', 4,  ! temperature [C]
+! 'salt      ',1, 'm', 8,  ! salinity [psu]
+! 'sigma0    ',1, 'm', 4,  ! potential density [kg/m3]
+! 'u         ',1, 'm', 4,  ! zonal velocity [m/s]
+! 'v         ',1, 'm', 4,  ! meridional velocity [m/s]
+! 'unod      ',1, 'm', 4,  ! zonal velocity at nodes [m/s]
+! 'vnod      ',1, 'm', 4,  ! meridional velocity at nodes [m/s]
+! 'w         ',1, 'm', 4,  ! vertical velocity [m/s]
+! 'otracers  ',1, 'm', 4,  ! all other tracers if applicable
+! 'age       ',1, 'm', 4,  ! water age tracer [year] (require use_age_tracer=.true.)
+
+! --- 2D SSH DIAGNOSTIC VARIABLES ---
+! 'ssh_rhs   ',1, 'm', 4,  ! ssh rhs [m/s]
+! 'ssh_rhs_old',1, 'm', 4, ! ssh rhs old [m/s]
+! 'd_eta     ',1, 'm', 4,  ! dssh from solver [m]
+! 'hbar      ',1, 'm', 4,  ! ssh n+0.5 tstep [m]
+! 'hbar_old  ',1, 'm', 4,  ! ssh n-0.5 tstep [m]
+! 'dhe       ',1, 'm', 4,  ! dhbar @ elem [m]
+
+! --- SEA ICE FIELDS (require use_ice=.true.) ---
+! 'uice      ',1, 'm', 4,  ! ice velocity x [m/s]
+! 'vice      ',1, 'm', 4,  ! ice velocity y [m/s]
+! 'a_ice     ',1, 'm', 4,  ! ice concentration [%]
+! 'm_ice     ',1, 'm', 4,  ! ice height per unit area [m]
+! 'thdgrice  ',1, 'm', 4,  ! thermodynamic growth rate ice [m/s]
+! 'thdgrarea ',1, 'm', 4,  ! thermodynamic growth rate ice concentration [frac/s]
+! 'dyngrarea' ,1, 'm', 4,  ! dynamic growth rate ice concentration [frac/s]
+! 'dyngrice  ',1, 'm', 4,  ! dynamic growth rate ice [m/s]
+! 'thdgrsn   ',1, 'm', 4,  ! thermodynamic growth rate snow [m/s]
+! 'dyngrsnw  ',1, 'm', 4,  ! dynamic growth rate snow [m/s] 
+! 'flice     ',1, 'm', 4,  ! flooding growth rate ice [m/s]
+! 'm_snow    ',1, 'm', 4,  ! snow height per unit area [m]
+! 'h_ice     ',1, 'm', 4,  ! ice thickness over ice-covered fraction [m]
+! 'h_snow    ',1, 'm', 4,  ! snow thickness over ice-covered fraction [m]
+! 'fw_ice    ',1, 'm', 4,  ! fresh water flux from ice ['m/s']
+! 'fw_snw    ',1, 'm', 4,  ! fresh water flux from snow ['m/s']
+
+! --- SEA ICE DEBUG VARIABLES (require use_ice=.true.) ---
+! 'strength_ice',1, 'm', 4,  ! ice strength [?]
+! 'inv_areamass',1, 'm', 4,  ! inv_areamass [?]
+! 'rhs_a     ',1, 'm', 4,  ! rhs_a [?]
+! 'rhs_m     ',1, 'm', 4,  ! rhs_m [?]
+! 'sgm11     ',1, 'm', 4,  ! sgm11 [?]
+! 'sgm12     ',1, 'm', 4,  ! sgm12 [?]
+! 'sgm22     ',1, 'm', 4,  ! sgm22 [?]
+! 'eps11     ',1, 'm', 4,  ! eps11 [?]
+! 'eps12     ',1, 'm', 4,  ! eps12 [?]
+! 'eps22     ',1, 'm', 4,  ! eps22 [?]
+! 'u_rhs_ice ',1, 'm', 4,  ! u_rhs_ice [?]
+! 'v_rhs_ice ',1, 'm', 4,  ! v_rhs_ice [?]
+! 'metric_fac',1, 'm', 4,  ! metric_fac [?]
+! 'elevat_ice',1, 'm', 4,  ! elevat_ice [?]
+! 'uwice     ',1, 'm', 4,  ! uwice [?]
+! 'vwice     ',1, 'm', 4,  ! vwice [?]
+! 'twice     ',1, 'm', 4,  ! twice [?]
+! 'swice     ',1, 'm', 4,  ! swice [?]
+
+! --- MIXED LAYER DEPTH ---
+! 'MLD1      ',1, 'm', 4,  ! Mixed Layer Depth [m] Large et al. 1997, bvfreq(nz, node) > db_max
+! 'MLD2      ',1, 'm', 4,  ! Mixed Layer Depth [m] Levitus treshold, rhopot(nz)-rhopot(1) > 0.125_WP kg/m
+! 'MLD3      ',1, 'm', 4,  ! Mixed Layer Depth [m] Griffies 2016 , rhopot(nz)-rhopot(1) > 0.03_WP kg/m
+
+! --- HEAT CONTENT (require ldiag_destine=.true.) ---
+! 'hc300m    ',1, 'm', 4,  ! Vertically integrated heat content upper 300m [J m**-2]
+! 'hc700m    ',1, 'm', 4,  ! Vertically integrated heat content upper 700m [J m**-2]
+! 'hc        ',1, 'm', 4,  ! Vertically integrated heat content total column [J m**-2]
+
+! --- WATER ISOTOPES IN SEA ICE (require lwiso=.true.) ---
+! 'h2o18_ice ',1, 'm', 4,  ! h2o18 concentration in sea ice [kmol/m**3]
+! 'hDo16_ice ',1, 'm', 4,  ! hDo16 concentration in sea ice [kmol/m**3]
+! 'h2o16_ice ',1, 'm', 4,  ! h2o16 concentration in sea ice [kmol/m**3]
+
+! --- FRESHWATER FLUX (require use_landice_water=.true.) ---
+! 'landice   ',1, 'm', 4,  ! freshwater flux [m/s]
+
+! --- SURFACE FORCING ---
+! 'tx_sur    ',1, 'm', 4,  ! zonal wind str. to ocean [N/m2]
+! 'ty_sur    ',1, 'm', 4,  ! meridional wind str. to ocean [N/m2]
+! 'curl_surf ',1, 'm', 4,  ! vorticity of the surface stress [none] (require lcurt_stress_surf=.true.)
+! 'fh        ',1, 'm', 4,  ! heat flux [W/m2]
+! 'fw        ',1, 'm', 4,  ! fresh water flux [m/s]
+! 'atmice_x  ',1, 'm', 4,  ! stress atmice x [N/m2]
+! 'atmice_y  ',1, 'm', 4,  ! stress atmice y [N/m2]
+! 'atmoce_x  ',1, 'm', 4,  ! stress atmoce x [N/m2]
+! 'atmoce_y  ',1, 'm', 4,  ! stress atmoce y [N/m2]
+! 'iceoce_x  ',1, 'm', 4,  ! stress iceoce x [N/m2]
+! 'iceoce_y  ',1, 'm', 4,  ! stress iceoce y [N/m2]
+! 'alpha     ',1, 'm', 4,  ! thermal expansion [none]
+! 'beta      ',1, 'm', 4,  ! saline contraction [none]
+! 'dens_flux ',1, 'm', 4,  ! density flux [kg/(m3*s)]
+! 'runoff    ',1, 'm', 4,  ! river runoff [m/s]
+! 'evap      ',1, 'm', 4,  ! evaporation [m/s]
+! 'prec      ',1, 'm', 4,  ! precipitation rain [m/s]
+! 'snow      ',1, 'm', 4,  ! precipitation snow [m/s]
+! 'tair      ',1, 'm', 4,  ! surface air temperature [°C]
+! 'shum      ',1, 'm', 4,  ! specific humidity []
+! 'swr       ',1, 'm', 4,  ! short wave radiation [W/m^2]
+! 'lwr       ',1, 'm', 4,  ! long wave radiation [W/m^2]
+! 'uwind     ',1, 'm', 4,  ! 10m zonal surface wind velocity [m/s]
+! 'vwind     ',1, 'm', 4,  ! 10m merid. surface wind velocity [m/s]
+! 'virtsalt  ',1, 'm', 4,  ! virtual salt flux [m/s*psu]
+! 'relaxsalt ',1, 'm', 4,  ! relaxation salt flux [m/s*psu]
+! 'realsalt  ',1, 'm', 4,  ! real salt flux from sea ice [m/s*psu]
+
+! --- KPP VERTICAL MIXING (require mix_scheme_nmb==1,17,3,37) ---
+! 'kpp_obldepth',1, 'm', 4, ! KPP ocean boundary layer depth [m]
+! 'kpp_sbuoyflx',1, 'm', 4, ! surface buoyancy flux [m2/s3]
+
+! --- RECOM 2D BIOGEOCHEMISTRY (require use_REcoM=.true. and __recom) ---
+! 'dpCO2s    ',1, 'm', 4,  ! Difference of oceanic pCO2 minus atmospheric pCO2 [uatm]
+! 'pCO2s     ',1, 'm', 4,  ! Partial pressure of oceanic CO2 [uatm]
+! 'CO2f      ',1, 'm', 4,  ! CO2-flux into the surface water [mmolC/m2/d]
+! 'O2f       ',1, 'm', 4,  ! O2-flux into the surface water [mmolO/m2/d]
+! 'Hp        ',1, 'm', 4,  ! Mean of H-plus ions in the surface water [mol/kg]
+! 'aFe       ',1, 'm', 4,  ! Atmospheric iron input [umolFe/m2/s]
+! 'aN        ',1, 'm', 4,  ! Atmospheric DIN input [mmolN/m2/s]
+! 'benN      ',1, 'm', 4,  ! Benthos Nitrogen [mmol]
+! 'benC      ',1, 'm', 4,  ! Benthos Carbon [mmol]
+! 'benSi     ',1, 'm', 4,  ! Benthos silicon [mmol]
+! 'benCalc   ',1, 'm', 4,  ! Benthos calcite [mmol]
+! 'NPPn      ',1, 'm', 4,  ! Mean NPP nanophytoplankton [mmolC/m2/d]
+! 'NPPd      ',1, 'm', 4,  ! Mean NPP diatoms [mmolC/m2/d]
+! 'GPPn      ',1, 'm', 4,  ! Mean GPP nanophytoplankton [mmolC/m2/d]
+! 'GPPd      ',1, 'm', 4,  ! Mean GPP diatoms [mmolC/m2/d]
+! 'NNAn      ',1, 'm', 4,  ! Net N-assimilation nanophytoplankton [mmolN/m2/d]
+! 'NNAd      ',1, 'm', 4,  ! Net N-assimilation diatoms [mmolN/m2/d]
+! 'Chldegn   ',1, 'm', 4,  ! Chlorophyll degradation nanophytoplankton [1/d]
+! 'Chldegd   ',1, 'm', 4,  ! Chlorophyll degradation diatoms [1/d]
+! 'NPPc      ',1, 'm', 4,  ! Mean NPP coccolithophores [mmolC/(m2*d)]
+! 'GPPc      ',1, 'm', 4,  ! Mean GPP coccolithophores [mmolC/m2/d]
+! 'NNAc      ',1, 'm', 4,  ! Net N-assimilation coccolithophores [mmolN/(m2*d)]
+! 'Chldegc   ',1, 'm', 4,  ! Chlorophyll degradation coccolithophores [1/d]
+
+! --- RECOM 3D BIOGEOCHEMISTRY (require use_REcoM=.true. and __recom) ---
+! 'PAR       ',1, 'm', 4,  ! PAR [W/m2]
+! 'respmeso  ',1, 'm', 4,  ! Respiration rate of mesozooplankton [mmolC/m2/d]
+! 'respmacro ',1, 'm', 4,  ! Respiration rate of macrozooplankton [mmolC/m2/d]
+! 'respmicro ',1, 'm', 4,  ! Respiration rate of microzooplankton [mmolC/m2/d]
+! 'calcdiss  ',1, 'm', 4,  ! Calcite dissolution [mmolC/m2/d]
+! 'calcif    ',1, 'm', 4,  ! Calcification [mmolC/m2/d]
+! 'aggn      ',1, 'm', 4,  ! Aggregation of small phytoplankton [mmolC/m2/d]
+! 'aggd      ',1, 'm', 4,  ! Aggregation of diatoms [mmolC/m2/d]
+! 'aggc      ',1, 'm', 4,  ! Aggregation of coccolithophores [mmolC/m2/d]
+! 'docexn    ',1, 'm', 4,  ! DOC excretion by small phytoplankton [mmolC/m2/d]
+! 'docexd    ',1, 'm', 4,  ! DOC excretion by diatoms [mmolC/m2/d]
+! 'docexc    ',1, 'm', 4,  ! DOC excretion by coccolithophores [mmolC/m2/d]
+! 'respn     ',1, 'm', 4,  ! Respiration by small phytoplankton [mmolC/m2/d]
+! 'respd     ',1, 'm', 4,  ! Respiration by diatoms [mmolC/m2/d]
+! 'respc     ',1, 'm', 4,  ! Respiration by coccolithophores [mmolC/(m2*d)]
+! 'NPPn3D    ',1, 'm', 4,  ! Net primary production of small phytoplankton [mmolC/(m3*d)]
+! 'NPPd3D    ',1, 'm', 4,  ! Net primary production of diatoms [mmolC/(m3*d)]
+! 'NPPc3D    ',1, 'm', 4,  ! Net primary production of coccolithophores [mmolC/(m3*d)]
+
+! --- WATER ISOTOPES IN OCEAN (require lwiso=.true.) ---
+! 'h2o18     ',1, 'm', 4,  ! h2o18 concentration [kmol/m**3]
+! 'hDo16     ',1, 'm', 4,  ! hDo16 concentration [kmol/m**3]
+! 'h2o16     ',1, 'm', 4,  ! h2o16 concentration [kmol/m**3]
+
+! --- NEUTRAL SLOPES ---
+! 'slopetap_x',1, 'm', 4,  ! neutral slope tapered X [none]
+! 'slopetap_y',1, 'm', 4,  ! neutral slope tapered Y [none]
+! 'slopetap_z',1, 'm', 4,  ! neutral slope tapered Z [none]
+! 'slope_x   ',1, 'm', 4,  ! neutral slope X [none]
+! 'slope_y   ',1, 'm', 4,  ! neutral slope Y [none]
+! 'slope_z   ',1, 'm', 4,  ! neutral slope Z [none]
+
+! --- MIXING AND DYNAMICS ---
+! 'N2        ',1, 'm', 4,  ! brunt väisälä [1/s2]
+! 'Kv        ',1, 'm', 4,  ! vertical diffusivity Kv [m2/s]
+! 'Av        ',1, 'm', 4,  ! vertical viscosity Av [m2/s]
+
+! --- VISCOSITY TENDENCIES (require dynamics%opt_visc==8) ---
+! 'u_dis_tend',1, 'm', 4,  ! horizontal velocity viscosity tendency [m/s]
+! 'v_dis_tend',1, 'm', 4,  ! meridional velocity viscosity tendency [m/s]
+! 'u_back_tend',1, 'm', 4, ! horizontal velocity backscatter tendency [m2/s2]
+! 'v_back_tend',1, 'm', 4, ! meridional velocity backscatter tendency [m2/s2]
+! 'u_total_tend',1, 'm', 4,! horizontal velocity total viscosity tendency [m/s]
+! 'v_total_tend',1, 'm', 4,! meridional velocity total viscosity tendency [m/s]
+
+! --- FERRARI/GM PARAMETERISATION (require Fer_GM=.true.) ---
+! 'bolus_u   ',1, 'm', 4,  ! GM bolus velocity U [m/s]
+! 'bolus_v   ',1, 'm', 4,  ! GM bolus velocity V [m/s]
+! 'bolus_w   ',1, 'm', 4,  ! GM bolus velocity W [m/s]
+! 'fer_K     ',1, 'm', 4,  ! GM, stirring diff. [m2/s]
+! 'fer_scal  ',1, 'm', 4,  ! GM surface scaling []
+! 'fer_C     ',1, 'm', 4,  ! GM, depth independent speed [m/s]
+! 'cfl_z     ',1, 'm', 4,  ! vertical CFL criteria [?]
+
+! --- DENSITY MOC DIAGNOSTICS (require ldiag_dMOC=.true.) ---
+! 'dMOC      ',1, 'm', 4,  ! fluxes for density MOC (multiple variables)
+
+! --- PRESSURE GRADIENT FORCE ---
+! 'pgf_x     ',1, 'm', 4,  ! zonal pressure gradient force [m/s^2]
+! 'pgf_y     ',1, 'm', 4,  ! meridional pressure gradient force [m/s^2]
+
+! --- ALE LAYER THICKNESS ---
+! 'hnode     ',1, 'm', 4,  ! vertice layer thickness [m]
+! 'hnode_new ',1, 'm', 4,  ! hnode_new [m]
+! 'helem     ',1, 'm', 4,  ! elemental layer thickness [m]
+
+! --- OIFS/IFS INTERFACE (require __oifs or __ifsinterface) ---
+! 'alb       ',1, 'm', 4,  ! ice albedo [none]
+! 'ist       ',1, 'm', 4,  ! ice surface temperature [K]
+! 'qsi       ',1, 'm', 4,  ! ice heat flux [W/m^2]
+! 'qso       ',1, 'm', 4,  ! oce heat flux [W/m^2]
+! 'enthalpy  ',1, 'm', 4,  ! enthalpy of fusion [W/m^2]
+! 'qcon      ',1, 'm', 4,  ! conductive heat flux [W/m^2]
+! 'qres      ',1, 'm', 4,  ! residual heat flux [W/m^2]
+! 'runoff_liquid',1, 'm', 4, ! liquid water runoff [m/s]
+! 'runoff_solid',1, 'm', 4, ! solid water runoff [m/s]
+
+! --- ICEBERG OUTPUTS (require use_icebergs=.true.) ---
+! 'icb       ',1, 'm', 4,  ! iceberg outputs (multiple variables)
+
+! --- TKE MIXING DIAGNOSTICS (require mix_scheme_nmb==5 or 56) ---
+! 'TKE       ',1, 'm', 4,  ! TKE diagnostics (multiple variables)
+
+! --- IDEMIX MIXING DIAGNOSTICS (require mod(mix_scheme_nmb,10)==6) ---
+! 'IDEMIX    ',1, 'm', 4,  ! IDEMIX diagnostics (multiple variables)
+
+! --- TIDAL MIXING DIAGNOSTICS (require mod(mix_scheme_nmb,10)==7) ---
+! 'TIDAL     ',1, 'm', 4,  ! TIDAL diagnostics (multiple variables)
+
+! --- FORCING DIAGNOSTICS (require ldiag_forc=.true.) ---
+! 'FORC      ',1, 'm', 4,  ! forcing diagnostics (multiple variables)
+
+! --- DISCRETE VARIANCE DECAY (require ldiag_DVD=.true.) ---
+! 'DVD       ',1, 'm', 4,  ! DVD diagnostics (multiple variables)
+
+! --- SPLIT-EXPLICIT SUBCYCLING (require dynamics%use_ssh_se_subcycl=.true.) ---
+! 'SPLIT-EXPL',1, 'm', 4,  ! split-explicit diagnostics (multiple variables)
+
+! --- SQUARED VELOCITIES (require ldiag_uvw_sqr=.true.) ---
+! 'UVW_SQR   ',1, 'm', 4,  ! squared velocities (u2, v2, w2)
+
+! --- TRACER GRADIENTS (require ldiag_trgrd_xyz=.true.) ---
+! 'TRGRD_XYZ ',1, 'm', 4,  ! horizontal and vertical tracer gradients
+
+! --- CMOR DIAGNOSTICS FOR CMIP6/CMIP7 (require ldiag_cmor=.true.) ---
+! 'tos       ',1, 'm', 8,  ! sea surface temperature [degC] (CMOR standard)
+! 'sos       ',1, 'm', 8,  ! sea surface salinity [psu] (CMOR standard)
+! 'pbo       ',1, 'm', 8,  ! sea water pressure at sea floor [Pa]
+! 'opottemptend',1, 'm', 8,! ocean potential temperature tendency [W/m^2]
+! 'volo      ',1, 'm', 8,  ! ocean volume [m^3] (global scalar)
+! 'soga      ',1, 'm', 8,  ! global mean sea water salinity [psu] (global scalar)
+! 'thetaoga  ',1, 'm', 8,  ! global mean sea water potential temperature [degC] (global scalar)
+! 'siarean   ',1, 'm', 8,  ! sea ice area Northern hemisphere [10^12 m^2] (global scalar)
+! 'siareas   ',1, 'm', 8,  ! sea ice area Southern hemisphere [10^12 m^2] (global scalar)
+! 'siextentn ',1, 'm', 8,  ! sea ice extent Northern hemisphere [10^12 m^2] (global scalar)
+! 'siextents ',1, 'm', 8,  ! sea ice extent Southern hemisphere [10^12 m^2] (global scalar)
+! 'sivoln    ',1, 'm', 8,  ! sea ice volume Northern hemisphere [10^9 m^3] (global scalar)
+! 'sivols    ',1, 'm', 8,  ! sea ice volume Southern hemisphere [10^9 m^3] (global scalar)
+
+! ============================================================================
+! END OF CATALOG
+! ============================================================================

--- a/config/bin_2p1z1d/namelist.oce
+++ b/config/bin_2p1z1d/namelist.oce
@@ -1,26 +1,105 @@
-! The namelist file for the finite-volume ocean model
+! ============================================================================
+! ============ Namelist file for FESOM2 ocean dynamics ======================
+! ============================================================================
+! This file contains configuration for ocean dynamics and parameterizations:
+! - Bottom drag and vertical viscosity
+! - Gent-McWilliams (GM) eddy parameterization
+! - Redi isopycnal diffusion
+! - Vertical mixing schemes (KPP, PP)
+! - Convection parameters
+! - Tidal forcing
+! ============================================================================
 
+! ============================================================================
+! OCEAN DYNAMICS AND PARAMETERIZATIONS
+! ============================================================================
 &oce_dyn
-C_d=0.0025             ! Bottom drag, nondimensional
-A_ver= 1.e-4	       ! Vertical viscosity, m^2/s
-scale_area=5.8e9       ! Visc. and diffus. are for an element with scale_area
-SPP=.false.                 ! Salt Plume Parameterization
-Fer_GM=.true.               ! to swith on/off GM after Ferrari et al. 2010
-K_GM_max     = 2000.0       ! max. GM thickness diffusivity (m2/s)
-K_GM_min     = 2.0          ! max. GM thickness diffusivity (m2/s)
-K_GM_bvref   = 2            ! def of bvref in ferreira scaling 0=srf,1=bot mld,2=mean over mld,3=weighted mean over mld
-K_GM_rampmax = -1.0         ! Resol >K_GM_rampmax[km] GM on
-K_GM_rampmin = -1.0         ! Resol <K_GM_rampmin[km] GM off, in between linear scaled down
-K_GM_resscalorder = 1
+! --- Basic ocean dynamics parameters ---
+C_d                = 0.0025  ! bottom drag coefficient (dimensionless, typical: 0.0025)
+A_ver              = 1.e-4   ! background vertical viscosity [m²/s]
+scale_area         = 5.8e9   ! reference element area for viscosity/diffusivity scaling [m²]
 
-scaling_Ferreira   =.false.  ! GM vertical scaling after Ferreira et al.(2005) (as also implemented by Qiang in FESOM 1.4)
-scaling_Rossby     =.false. ! GM is smoothly switched off according to Rossby radius (from 1. in coarse areas to 0. where resolution reaches 2 points/Rossby radius)
-scaling_resolution =.true.  ! GM is spatially scaled with resolution; A value of K_GM corresponds then to a resolution of 100km
-scaling_FESOM14    =.false.  ! special treatment of GM in the NH (as also implemented by Qiang in FESOM 1.4; it is zero within the boundary layer)
+! --- Salt Plume Parameterization ---
+SPP                = .false. ! enable Salt Plume Parameterization (for brine rejection under sea ice)
 
-Redi  =.true.
-visc_sh_limit=5.0e-3       ! for KPP, max visc due to shear instability
-mix_scheme='KPP'           ! vertical mixing scheme: KPP, PP 
-Ricr   = 0.3               ! critical bulk Richardson Number
-concv  = 1.6               ! constant for pure convection (eqn. 23) (Large 1.5-1.6; MOM default 1.8)
+! --- Gent-McWilliams (GM) Eddy Parameterization ---
+Fer_GM             = .true.  ! to swith on/off GM after Ferrari et al. 2010
+K_GM_max           = 2000.0  ! max. GM thickness diffusivity (m2/s)
+K_GM_min           = 2.0     ! min. GM thickness diffusivity (m2/s)
+K_GM_bvref         = 2       ! def of bvref in ferreira scaling 0=srf,1=bot mld,2=mean over mld,3=weighted mean over mld
+K_GM_rampmax       = -1.0    ! Resol >K_GM_rampmax[km] GM on
+K_GM_rampmin       = -1.0    ! Resol <K_GM_rampmin[km] GM off, in between linear scaled down
+K_GM_resscalorder  = 1       ! scaling order 1: resol scaling, 2: area scaling 
+
+! --- GM Scaling Options ---
+scaling_Ferreira   = .false. ! enable GM vertical scaling (Ferreira et al. 2005, as in FESOM 1.4)
+scaling_Rossby     = .false. ! scale GM with Rossby radius (1.0 in coarse regions, 0.0 at 2 points/Rossby radius)
+scaling_resolution = .true.  ! scale GM with horizontal resolution (K_GM corresponds to 100km resolution)
+scaling_FESOM14    = .false. ! use FESOM 1.4 GM treatment in Northern Hemisphere (zero within boundary layer)
+
+! --- Redi Isopycnal Diffusion ---
+Redi               = .true.  ! enable Redi isopycnal diffusion
+
+! --- Vertical Mixing Scheme ---
+visc_sh_limit      = 5.0e-3  ! maximum viscosity due to shear instability [m²/s] (for KPP)
+mix_scheme         = 'KPP'   ! vertical mixing scheme: 'KPP' (K-Profile Parameterization), 'PP' (Pacanowski-Philander), or 'cvmix_TKE' (Turbulent Kinetic Energy). For complete list of available shemes look at the oce_setup_step.F90. 
+
+! --- Convection Parameters ---
+Ricr               = 0.3     ! critical bulk Richardson number (for convection onset)
+concv              = 1.6     ! constant for pure convection (eq. 23 in Large et al.)
+                             ! typical values: Large 1.5-1.6, MOM default 1.8
 /
+
+! ===================================================================
+! Initial condition perturbation settings
+! ===================================================================
+! This section controls random perturbation of initial temperature
+! and salinity fields. Useful for ensemble modeling and uncertainty
+! quantification.
+!
+! lperturb       : Enable/disable perturbation (.true./.false.)
+! perturb_mode   : When to apply perturbations
+!                  'initial_only' - Apply only during initial runs (not restarts)
+!                  'first_step'   - Apply during first time step (initial or restart)
+! perturb_method : Type of random distribution
+!                  'uniform'   - Uniform distribution between [min_val, max_val]
+!                  'gaussian'  - Gaussian distribution with mean=min_val, std_dev=max_val
+! perturb_seed   : Random seed for reproducible perturbations
+!                  -1 = use system time (different each run)
+!                  >0 = use specified seed (reproducible)
+! temp_perturb   : Temperature perturbation parameters
+!                  For uniform: [min_val, max_val] in Kelvin
+!                  For gaussian: [mean(=0.0), std_dev] in Kelvin
+! salt_perturb   : Salinity perturbation parameters
+!                  For uniform: [min_val, max_val] in PSU
+!                  For gaussian: [mean(=0.0), std_dev] in PSU
+!
+! Example for ensemble forecasting with Gaussian perturbations:
+!&oce_perturb
+!lperturb       = .true.
+!perturb_mode   = 'first_step'
+!perturb_method = 'gaussian'
+!perturb_seed   = 12345
+!temp_perturb   = 0.0, 1.D-13
+!salt_perturb   = 0.0, 2.D-13
+!/
+!
+! Example for sensitivity study with uniform perturbations:
+!&oce_perturb
+!lperturb       = .true.
+!perturb_mode   = 'initial_only'
+!perturb_method = 'uniform'
+!perturb_seed   = -1
+!temp_perturb   = -1.D-12, 1.D-12
+!salt_perturb   = -2.D-12, 2.D-12
+!/
+
+! Default behavior (no perturbations):
+!&oce_perturb
+!lperturb       = .false.
+!perturb_mode   = 'initial_only'
+!perturb_method = 'uniform'
+!perturb_seed   = -1
+!temp_perturb   = 0.0, 0.0
+!salt_perturb   = 0.0, 0.0
+!/

--- a/config/bin_2p1z1d/namelist.recom
+++ b/config/bin_2p1z1d/namelist.recom
@@ -1,361 +1,511 @@
-! This is the namelist file for recom
+! ============================================================================
+! ============ Namelist file for FESOM2 REcoM biogeochemistry ================
+! ============================================================================
+! This file contains configuration for the REcoM biogeochemical model:
+! - Surface boundary condition input files
+! - Model switches, tracer counts and sinking
+! - Phytoplankton, zooplankton and detritus parameters
+! - Carbonate chemistry, iron, calcite and benthos
+! - Ballasting and carbon isotopes
+!
+! Phytoplankton parameters come in sets: no suffix = small phytoplankton,
+! _d = diatoms, _c = coccolithophores, _p = Phaeocystis (where present).
+! Zooplankton: first = mesozooplankton, second (suffix 2) = macrozooplankton,
+! third (suffix 3) = microzooplankton.
+! ============================================================================
 
+! ============================================================================
+! SURFACE BOUNDARY CONDITION FILES
+! ============================================================================
+! Relative names of the dust, aeolian nitrogen and CO2 files are taken from
+! ClimateDataPath; the river and erosion files are used as given.
+! ============================================================================
 &nam_rsbc
-fe_data_source        ='Albani'
-nm_fe_data_file       ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/DustClimMonthlyAlbani.nc'
-nm_aen_data_file      ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/AeolianNitrogenDep.nc'
-nm_river_data_file    ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/RiverineInput.nc'
-nm_erosion_data_file  ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/ErosionInput.nc'
-nm_co2_data_file      ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/MonthlyAtmCO2_gcb2023.nc'
+fe_data_source        = 'Albani'    ! 'Albani' reads nm_fe_data_file; any other value switches the Albani dust input off
+nm_fe_data_file       = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/DustClimMonthlyAlbani.nc'
+                                    ! monthly dust deposition climatology (Albani)
+nm_aen_data_file      = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/AeolianNitrogenDep.nc'
+                                    ! aeolian nitrogen deposition (useAeolianN)
+nm_river_data_file    = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/RiverineInput.nc'
+                                    ! riverine nutrient input (useRivers)
+nm_erosion_data_file  = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/ErosionInput.nc'
+                                    ! input from erosion (useErosion)
+nm_co2_data_file      = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/MonthlyAtmCO2_gcb2023.nc'
+                                    ! atmospheric CO2 time series, read when constant_CO2 = .false.
 /
 
+! ============================================================================
+! TRACER SET
+! ============================================================================
+! bgc_num in &pavariables is checked against these switches at startup.
+! ============================================================================
 &parecomsetup
-enable_3zoo2det = .true.
-enable_coccos = .false.
+enable_3zoo2det       = .true.      ! three zooplankton groups and two detritus classes instead of one each
+enable_coccos         = .false.     ! coccolithophore and Phaeocystis tracers
 /
 
+! ============================================================================
+! MODEL SWITCHES, TRACER COUNTS AND SINKING
+! ============================================================================
 &pavariables
-use_REcoM             =.true.
-REcoM_restart         =.true.
+! --- Main Switches ---
+use_REcoM             = .true.      ! switch REcoM on
+REcoM_restart         = .true.      ! read the REcoM tracers from the restart (false = initialize from climatology)
+recom_debug           = .false.     ! extra REcoM debug output
+Diags                 = .true.      ! compute REcoM diagnostics
 
-bgc_num               = 22 !24 !38 !22
-diags3d_num           = 28          ! Number of diagnostic 3d tracers to be saved
-bgc_base_num          = 22          ! standard tracers
-VDet                  = 20.d0       ! Sinking velocity, constant through the water column and positive downwards
-VDet_zoo2             = 200.d0      ! Sinking velocity, constant through the water column
-VPhy                  = 0.d0        !!! If the number of sinking velocities are different from 3, code needs to be changed !!!
-VDia                  = 0.d0
-VCocco	       	      = 0.d0       
-allow_var_sinking     = .true.   
-biostep               = 1           ! Number of times biology should be stepped forward for each time step		 
-REcoM_Geider_limiter  = .false.     ! Decides what routine should be used to calculate limiters in sms
-REcoM_Grazing_Variable_Preference = .true. ! Decides if grazing should have preference for phyN or DiaN 
-Grazing_detritus      = .true.
-het_resp_noredfield   = .true.    ! Decides respiratation of copepod group
-diatom_mucus          = .true.    ! Decides nutrient limitation effect on aggregation
-O2dep_remin           = .true.    ! O2remin Add option for O2 dependency of organic matter remineralization
-use_ballasting        = .true.    
-use_density_scaling   = .true.   
-use_viscosity_scaling = .true.    
-OmegaC_diss           = .false.    ! Use OmegaC from Mocsy to compute calcite dissolution (after Aumont et al. 2015 and Gehlen et al. 2007) -> set calc_diss_guts to zero if this is false!!!!
-CO2lim                = .true.    ! CO2 dependence of growth and calcification
-Diags                 = .true.
-constant_CO2          = .true.
-UseFeDust             = .true.      ! Turns dust input of iron off when set to.false.
-UseDustClim           = .true.
-UseDustClimAlbani     = .true.     ! Use Albani dustclim field (If it is false Mahowald will be used)
-use_photodamage       = .true.      ! use Alvarez et al (2018) for chlorophyll degradation
-HetRespFlux_plus      = .true.      !MB More stable computation of zooplankton respiration fluxes adding a small number to HetN
+! --- Tracer Counts ---
+bgc_num               = 22          ! number of REcoM tracers, checked at startup against enable_3zoo2det and enable_coccos
+diags3d_num           = 28          ! number of 3D diagnostic tracers to be saved
+bgc_base_num          = 22          ! number of standard (base) BGC tracers
+benthos_num           = 4           ! number of benthic BGC tracers: 8 with ciso = .true., otherwise 4
+Nmocsy                = 1           ! length of the vector passed to mocsy (always 1 for REcoM)
+biostep               = 1           ! number of biology steps per ocean time step
+
+! --- Sinking ---
+VDet                  = 20.d0       ! sinking velocity of small detritus [m/day], positive downwards
+VDet_zoo2             = 200.d0      ! sinking velocity of large detritus [m/day]
+VPhy                  = 0.d0        ! sinking velocity of small phytoplankton [m/day]
+VDia                  = 0.d0        ! sinking velocity of diatoms [m/day]
+VCocco                = 0.d0        ! sinking velocity of coccolithophores [m/day]
+allow_var_sinking     = .true.      ! detritus sinking speed increases with depth (Vdet_a in &pasinking)
+
+! --- Process Options ---
+REcoM_Geider_limiter  = .false.     ! selects the routine that calculates the limiters in the sources-minus-sinks
+REcoM_Grazing_Variable_Preference = .true. ! grazing preferences weighted by prey abundance
+Grazing_detritus      = .true.      ! zooplankton also graze on detritus
+het_resp_noredfield   = .true.      ! respiration formulation of the first zooplankton (copepods)
+diatom_mucus          = .true.      ! nutrient limitation enhances diatom aggregation
+O2dep_remin           = .true.      ! oxygen-dependent remineralization of organic matter (k_o2_remin)
+use_photodamage       = .true.      ! light-dependent chlorophyll degradation after Alvarez et al. (2018)
+HetRespFlux_plus      = .true.      ! more stable zooplankton respiration flux (not used by the current code)
+CO2lim                = .true.      ! CO2 dependence of growth and calcification (&paco2lim)
+OmegaC_diss           = .false.     ! calcite dissolution from the mocsy saturation state OmegaC
+                                    ! (Aumont et al. 2015, Gehlen et al. 2007); set calc_diss_guts = 0 when .false.
+
+! --- Ballasting ---
+use_ballasting        = .true.      ! mineral ballasting of detritus sinking (&paballasting)
+use_density_scaling   = .true.      ! scale sinking with seawater density (ballasting)
+use_viscosity_scaling = .true.      ! scale sinking with seawater viscosity (ballasting)
+
+! --- External Sources ---
+UseFeDust             = .true.      ! iron input from dust (not used by the current code, see fe_data_source)
+UseDustClim           = .true.      ! dust deposition climatology (not used by the current code)
+UseDustClimAlbani     = .true.      ! Albani dust climatology, otherwise Mahowald (not used by the current code)
+useRivers             = .false.     ! riverine nutrient input (nm_river_data_file)
+useRivFe              = .false.     ! riverine iron source
+useErosion            = .false.     ! input from erosion (nm_erosion_data_file)
+NitrogenSS            = .false.     ! external nitrogen sources and sinks (riverine, aeolian and denitrification)
+useAeolianN           = .false.     ! aeolian nitrogen deposition (nm_aen_data_file)
 REcoMDataPath         = '/albedo/work/projects/MarESys/ogurses/input/mesh_CORE2_finaltopo_mean/'
-restore_alkalinity    = .true.
-useRivers             = .false.
-useRivFe              = .false.      ! When set to true, riverine Fe source is activated
-useErosion            = .false.
-NitrogenSS            = .false.     ! When set to true, external sources and sinks of nitrogen are activated (Riverine, aeolian and denitrification)
-useAeolianN           = .false.      ! When set to true, aeolian nitrogen deposition is activated
-firstyearoffesomcycle = 1958        ! The first year of the actual physical forcing (e.g. JRA-55) used
-lastyearoffesomcycle  = 2024        ! Last year of the actual physical forcing used
-numofCO2cycles        = 1           ! Number of cycles of the forcing planned 
-currentCO2cycle       = 1           ! Which CO2 cycle we are currently running
-DIC_PI                = .true.
-Nmocsy                = 1           ! Length of the vector that is passed to mocsy (always one for recom)
-recom_debug           =.false.
-ciso                  =.false.     ! Main switch to enable/disable carbon isotopes (13|14C)
-benthos_num           = 4          ! number of benthic BGC tracers -> 8 if (ciso == .true.) otherwise -> 4
-use_MEDUSA            = .false.      ! Main switch for the sediment model MEDUSA
-sedflx_num            = 0           ! if 0: no file from MEDUSA is read but default sediment
-bottflx_num           = 4           ! if ciso&ciso_14: =8; if .not.ciso_14: =6; no ciso: =4
-use_atbox             = .false.
-add_loopback          = .false.     ! add loopback fluxes through rivers to the surface
-lb_tscale             = 1.0         ! /year: fraction of loopback fluxes yearly added to the surface
+                                    ! REcoM input directory (not used by the current code)
+
+! --- Carbon Chemistry and Atmospheric CO2 ---
+constant_CO2          = .true.      ! use CO2_for_spinup instead of the time series in nm_co2_data_file
+DIC_PI                = .true.      ! initialize DIC with the preindustrial GLODAP field
+restore_alkalinity    = .true.      ! restore surface alkalinity (surf_relax_Alk)
+use_atbox             = .false.     ! atmospheric box model for CO2
+firstyearoffesomcycle = 1958        ! first year of the physical forcing used (e.g. JRA55)
+lastyearoffesomcycle  = 2024        ! last year of the physical forcing used
+numofCO2cycles        = 1           ! number of forcing cycles planned
+currentCO2cycle       = 1           ! forcing cycle currently running
+
+! --- Carbon Isotopes and Sediment ---
+ciso                  = .false.     ! main switch for carbon isotopes (13C, 14C), see &paciso
+use_MEDUSA            = .false.     ! main switch for the sediment model MEDUSA
+sedflx_num            = 0           ! number of sediment fluxes read from MEDUSA (0 = none, default sediment)
+bottflx_num           = 4           ! number of bottom fluxes: 8 with ciso and ciso_14, 6 with ciso only, 4 without ciso
+add_loopback          = .false.     ! return loopback fluxes to the surface through rivers
+lb_tscale             = 1.0         ! fraction of the loopback fluxes added to the surface per year [1/year]
 /
 
+! ============================================================================
+! DEPTH-DEPENDENT SINKING
+! ============================================================================
 &pasinking
-Vdet_a                = 0.0288      ! [1/day]
-Vcalc                 = 0.0144      ! [1/day]
+Vdet_a                = 0.0288      ! increase of detritus sinking speed with depth [1/day] (allow_var_sinking)
+Vcalc                 = 0.0144      ! depth dependence of calcite dissolution [1/day]
 /
 
+! ============================================================================
+! INITIALIZATION
+! ============================================================================
 &painitialization_N
-cPhyN                 = 0.2d0
-cHetN                 = 0.2d0
-cZoo2N                = 0.2d0
+cPhyN                 = 0.2d0       ! initial small phytoplankton N (not used by the current code)
+cHetN                 = 0.2d0       ! initial first zooplankton N (not used by the current code)
+cZoo2N                = 0.2d0       ! initial second zooplankton N (not used by the current code)
 /
 
+! ============================================================================
+! TEMPERATURE DEPENDENCE
+! ============================================================================
 &paArrhenius
-recom_Tref            = 288.15d0    ! [K]
-C2K                   = 273.15d0    ! Conversion from degrees C to K
-Ae                    = 4500.d0     ! [K] Slope of the linear part of the Arrhenius function
-reminSi               = 0.02d0
-k_o2_remin            = 15.d0       ! O2remin mmol m-3; Table 1 in Cram 2018 cites DeVries & Weber 2017 for a range of 0-30 mmol m-3
+recom_Tref            = 288.15d0    ! reference temperature of the Arrhenius function [K]
+C2K                   = 273.15d0    ! conversion from degrees C to K
+Ae                    = 4500.d0     ! slope of the linear part of the Arrhenius function [K]
+reminSi               = 0.02d0      ! lower bound of the silica remineralization rate [1/day]
+k_o2_remin            = 15.d0       ! half-saturation O2 for O2-dependent remineralization [mmol/m3] (O2dep_remin)
+                                    ! Cram et al. (2018), Table 1, cite 0-30 mmol/m3 (DeVries & Weber 2017)
 /
 
+! ============================================================================
+! LIMITATION FUNCTIONS
+! ============================================================================
 &palimiter_function
-NMinSlope             = 50.d0 
-SiMinSlope            = 1000.d0
-NCmin                 = 0.04d0
-NCmin_d               = 0.04d0
-NCmin_c		      = 0.04d0    
-SiCmin                = 0.04d0
-k_Fe                  = 0.04d0
-k_Fe_d                = 0.12d0
-k_Fe_c		      = 0.09d0    
-k_si                  = 4.d0
-P_cm                  = 3.0d0       ! [1/day]            Rate of C-specific photosynthesis 
-P_cm_d                = 3.5d0
-P_cm_c		      = 2.8d0	  
+! --- Limitation Function Slopes ---
+NMinSlope             = 50.d0       ! steepness of the nitrogen limitation function at the minimum quota
+SiMinSlope            = 1000.d0     ! steepness of the silicon limitation function at the minimum quota
+
+! --- Minimum Quotas ---
+NCmin                 = 0.04d0      ! minimum N:C quota, small phytoplankton [mmol N/mmol C]
+NCmin_d               = 0.04d0      ! minimum N:C quota, diatoms [mmol N/mmol C]
+NCmin_c               = 0.04d0      ! minimum N:C quota, coccolithophores [mmol N/mmol C]
+SiCmin                = 0.04d0      ! minimum Si:C quota, diatoms [mmol Si/mmol C]
+
+! --- Nutrient Half-Saturation ---
+k_Fe                  = 0.04d0      ! half-saturation constant for iron uptake, small phytoplankton [µmol Fe/m3]
+k_Fe_d                = 0.12d0      ! half-saturation constant for iron uptake, diatoms [µmol Fe/m3]
+k_Fe_c                = 0.09d0      ! half-saturation constant for iron uptake, coccolithophores [µmol Fe/m3]
+k_si                  = 4.d0        ! half-saturation constant for silicate uptake, diatoms [mmol Si/m3]
+
+! --- Maximum Photosynthesis ---
+P_cm                  = 3.0d0       ! maximum C-specific photosynthesis rate, small phytoplankton [1/day]
+P_cm_d                = 3.5d0       ! maximum C-specific photosynthesis rate, diatoms [1/day]
+P_cm_c                = 2.8d0       ! maximum C-specific photosynthesis rate, coccolithophores [1/day] (not used by the current code)
 /
 
+! ============================================================================
+! LIGHT
+! ============================================================================
 &palight_calculations
-k_w                   = 0.04d0      ! [1/m]              Light attenuation coefficient
-a_chl                 = 0.03d0      ! [1/m * 1/(mg Chl)] Chlorophyll specific attenuation coefficients
+k_w                   = 0.04d0      ! light attenuation coefficient of water [1/m]
+a_chl                 = 0.03d0      ! chlorophyll-specific attenuation coefficient [1/m * 1/(mg Chl)]
 /
 
+! ============================================================================
+! PHOTOSYNTHESIS
+! ============================================================================
 &paphotosynthesis
-alfa                  = 0.14d0	    ! [(mmol C*m2)/(mg Chl*W*day)] 
-alfa_d                = 0.19d0      ! An initial slope of the P-I curve
-alfa_c		      = 0.10d0     
-parFrac               = 0.43d0
+alfa                  = 0.14d0      ! initial slope of the P-I curve, small phytoplankton [(mmol C m²)/(mg Chl W day)]
+alfa_d                = 0.19d0      ! initial slope of the P-I curve, diatoms [(mmol C m²)/(mg Chl W day)]
+alfa_c                = 0.10d0      ! initial slope of the P-I curve, coccolithophores [(mmol C m²)/(mg Chl W day)]
+parFrac               = 0.43d0      ! photosynthetically active fraction of the shortwave radiation
 /
 
+! ============================================================================
+! NUTRIENT ASSIMILATION
+! ============================================================================
 &paassimilation
-V_cm_fact             = 0.7d0       ! scaling factor for temperature dependent maximum of C-specific N-uptake
-V_cm_fact_d           = 0.7d0  
-V_cm_fact_c	      = 0.7d0     
-NMaxSlope             = 1000.d0     ! Max slope for limiting function
-SiMaxSlope            = 1000.d0
-NCmax                 = 0.2d0       ! [mmol N/mmol C] Maximum cell quota of nitrogen (N:C)
-NCmax_d               = 0.2d0
-NCmax_c		      = 0.15d0     
-SiCmax                = 0.8d0
-NCuptakeRatio         = 0.2d0       ! [mmol N/mmol C] Maximum uptake ratio of N:C
-NCUptakeRatio_d       = 0.2d0
-NCUptakeRatio_c	      = 0.2d0     
-SiCUptakeRatio        = 0.2d0
-k_din                 = 0.55d0      ! [mmol N/m3] Half-saturation constant for nitrate uptake
-k_din_d               = 1.0d0
-k_din_c		      = 0.9d0     
-Chl2N_max             = 3.15d0      ! [mg CHL/mmol N] Maximum CHL a : N ratio = 0.3 gCHL gN^-1
-Chl2N_max_d           = 4.2d0
-Chl2N_max_c	      = 3.5d0     
-res_phy               = 0.01d0      ! [1/day] Maintenance respiration rate constant
-res_phy_d             = 0.01d0
-res_phy_c	      = 0.01d0    
-biosynth              = 2.33d0      ! [mmol C/mmol N] Cost of biosynthesis
-biosynthSi            = 0.d0
+! --- Nitrogen Uptake ---
+V_cm_fact             = 0.7d0       ! scaling of the temperature-dependent maximum C-specific N uptake, small phytoplankton
+V_cm_fact_d           = 0.7d0       ! scaling of the temperature-dependent maximum C-specific N uptake, diatoms
+V_cm_fact_c           = 0.7d0       ! scaling of the temperature-dependent maximum C-specific N uptake, coccolithophores
+NMaxSlope             = 1000.d0     ! steepness of the limitation function at the maximum N quota
+NCmax                 = 0.2d0       ! maximum N:C quota, small phytoplankton [mmol N/mmol C]
+NCmax_d               = 0.2d0       ! maximum N:C quota, diatoms [mmol N/mmol C]
+NCmax_c               = 0.15d0      ! maximum N:C quota, coccolithophores [mmol N/mmol C]
+NCuptakeRatio         = 0.2d0       ! maximum N:C uptake ratio, small phytoplankton [mmol N/mmol C]
+NCUptakeRatio_d       = 0.2d0       ! maximum N:C uptake ratio, diatoms [mmol N/mmol C]
+NCUptakeRatio_c       = 0.2d0       ! maximum N:C uptake ratio, coccolithophores [mmol N/mmol C]
+k_din                 = 0.55d0      ! half-saturation constant for nitrate uptake, small phytoplankton [mmol N/m3]
+k_din_d               = 1.0d0       ! half-saturation constant for nitrate uptake, diatoms [mmol N/m3]
+k_din_c               = 0.9d0       ! half-saturation constant for nitrate uptake, coccolithophores [mmol N/m3]
+
+! --- Silicon Uptake (Diatoms) ---
+SiMaxSlope            = 1000.d0     ! steepness of the limitation function at the maximum Si quota
+SiCmax                = 0.8d0       ! maximum Si:C quota [mmol Si/mmol C]
+SiCUptakeRatio        = 0.2d0       ! maximum Si:C uptake ratio [mmol Si/mmol C]
+
+! --- Chlorophyll ---
+Chl2N_max             = 3.15d0      ! maximum Chl:N ratio, small phytoplankton [mg Chl/mmol N]
+Chl2N_max_d           = 4.2d0       ! maximum Chl:N ratio, diatoms [mg Chl/mmol N]
+Chl2N_max_c           = 3.5d0       ! maximum Chl:N ratio, coccolithophores [mg Chl/mmol N]
+
+! --- Respiration ---
+res_phy               = 0.01d0      ! maintenance respiration rate, small phytoplankton [1/day]
+res_phy_d             = 0.01d0      ! maintenance respiration rate, diatoms [1/day]
+res_phy_c             = 0.01d0      ! maintenance respiration rate, coccolithophores [1/day]
+biosynth              = 2.33d0      ! cost of biosynthesis [mmol C/mmol N]
+biosynthSi            = 0.d0        ! cost of silica biosynthesis [mmol C/mmol Si]
 /
 
+! ============================================================================
+! IRON CHEMISTRY
+! ============================================================================
 &pairon_chem
-totalligand           = 1.d0        ! [mumol/m3] order 1. Total free ligand
-ligandStabConst       = 100.d0      ! [m3/mumol] order 100. Ligand-free iron stability constant
+totalligand           = 1.d0        ! total free ligand [µmol/m3] (order 1)
+ligandStabConst       = 100.d0      ! ligand-free iron stability constant [m3/µmol] (order 100)
 /
 
+! ============================================================================
+! FIRST ZOOPLANKTON (MESOZOOPLANKTON)
+! ============================================================================
 &pazooplankton
-graz_max              = 2.4d0       ! [mmol N/(m3 * day)] Maximum grazing loss parameter 
-epsilonr              = 0.35d0      ! [(mmol N)2 /m6] Half saturation constant for grazing loss 
-res_het               = 0.01d0     ! [1/day] Respiration by heterotrophs and mortality (loss to detritus)
-Redfield              = 6.625       ! [mmol C/mmol N] Redfield ratio of C:N = 106:16
-loss_het              = 0.05d0      ! [1/day] Temperature dependent N degradation of extracellular organic N (EON)
-pzDia                 = 0.5d0       ! Maximum diatom preference
-sDiaNsq               = 0.d0
-pzPhy                 = 1.0d0       ! Maximum small phytoplankton preference
-sPhyNsq               = 0.d0
-pzCocco		      = 0.4d0       ! Maximum coccolithophore preference   ! will not be used in the 2p1z1d version
-sCoccoNsq	      = 0.d0       
-pzMicZoo              = 1.0d0       ! Maximum microzooplankton preference  ! will not be used in the 2p1z1d version
-sMicZooNsq            = 0.d0      
-tiny_het              = 1.d-5       ! for more stable computation of HetRespFlux (_plus). Value can be > tiny because HetRespFlux ~ hetC**2.
+graz_max              = 2.4d0       ! maximum grazing rate [mmol N/(m3 day)]
+epsilonr              = 0.35d0      ! half-saturation constant for grazing [(mmol N)^2/m^6]
+res_het               = 0.01d0      ! respiration and mortality (loss to detritus) [1/day]
+Redfield              = 6.625       ! Redfield C:N ratio (106:16) [mmol C/mmol N]
+loss_het              = 0.05d0      ! temperature-dependent N degradation of extracellular organic N (EON) [1/day]
+tiny_het              = 1.d-5       ! small number for a more stable HetRespFlux; may exceed tiny since HetRespFlux ~ HetC^2
+
+! --- Prey Preferences ---
+pzDia                 = 0.5d0       ! maximum diatom preference
+sDiaNsq               = 0.d0        ! not used by the current code
+pzPhy                 = 1.0d0       ! maximum small phytoplankton preference
+sPhyNsq               = 0.d0        ! not used by the current code
+pzCocco               = 0.4d0       ! maximum coccolithophore preference
+sCoccoNsq             = 0.d0        ! not used by the current code
+pzMicZoo              = 1.0d0       ! maximum microzooplankton preference
+sMicZooNsq            = 0.d0        ! not used by the current code
 /
 
-&pasecondzooplankton ! will not be used in the 2p1z1d version
-graz_max2      = 0.1d0              ! [mmol N/(m3 * day)] Maximum grazing loss parameter                                                                                        
-epsilon2       = 0.0144d0           ! [(mmol N)2 /m6] Half saturation constant for grazing loss                                                                              
-res_zoo2       = 0.0107d0           ! [1/day] Respiration by heterotrophs and mortality (loss to detritus)                                                            
-loss_zoo2      = 0.003d0            ! [1/day] Temperature dependent N degradation of extracellular organic N (EON)
-fecal_rate_n      = 0.104d0         ! [1/day] Temperature dependent N degradation of \
-fecal_rate_c      = 0.236d0  
-fecal_rate_n_mes = 0.25d0           
-fecal_rate_c_mes = 0.32d0         
-pzDia2         = 1.0d0              ! Maximum diatom preference                                                                                                                 
-sDiaNsq2       = 0.d0
-pzPhy2         = 0.08d0             ! Maximum small phytoplankton preference                                                                                                                
-sPhyNsq2       = 0.d0
-pzCocco2       = 0.8d0              ! Maximum coccolithophore preference
-sCoccoNsq2     = 0.d0		 
-pzHet          = 1.5d0              ! Maximum mesozooplankton preference 
-sHetNsq        = 0.d0
-pzMicZoo2      = 1.0d0              ! Maximum microzooplankton preference
-sMicZooNsq2    = 0.d0   
-t1_zoo2        = 28145.d0           ! Krill temp. function constant1                                                                                                       
-t2_zoo2        = 272.5d0            ! Krill temp. function constant2                                                                                                         
-t3_zoo2        = 105234.d0          ! Krill temp. function constant3                                                                                                      
-t4_zoo2        = 274.15d0           ! Krill temp. function constant3
+! ============================================================================
+! SECOND ZOOPLANKTON (MACROZOOPLANKTON)
+! ============================================================================
+&pasecondzooplankton
+graz_max2             = 0.1d0       ! maximum grazing rate [mmol N/(m3 day)]
+epsilon2              = 0.0144d0    ! half-saturation constant for grazing [(mmol N)^2/m^6]
+res_zoo2              = 0.0107d0    ! respiration and mortality (loss to detritus) [1/day]
+loss_zoo2             = 0.003d0     ! temperature-dependent N degradation of extracellular organic N (EON) [1/day]
+
+! --- Fecal Pellets ---
+fecal_rate_n          = 0.104d0     ! fraction of the grazed nitrogen egested as fecal pellets
+fecal_rate_c          = 0.236d0     ! fraction of the grazed carbon egested as fecal pellets
+fecal_rate_n_mes      = 0.25d0      ! as fecal_rate_n, for the first zooplankton (mesozooplankton)
+fecal_rate_c_mes      = 0.32d0      ! as fecal_rate_c, for the first zooplankton (mesozooplankton)
+
+! --- Prey Preferences ---
+pzDia2                = 1.0d0       ! maximum diatom preference
+sDiaNsq2              = 0.d0        ! not used by the current code
+pzPhy2                = 0.08d0      ! maximum small phytoplankton preference
+sPhyNsq2              = 0.d0        ! not used by the current code
+pzCocco2              = 0.8d0       ! maximum coccolithophore preference
+sCoccoNsq2            = 0.d0        ! not used by the current code
+pzHet                 = 1.5d0       ! maximum preference for the first zooplankton
+sHetNsq               = 0.d0        ! not used by the current code
+pzMicZoo2             = 1.0d0       ! maximum microzooplankton preference
+sMicZooNsq2           = 0.d0        ! not used by the current code
+
+! --- Temperature Function (Krill) ---
+t1_zoo2               = 28145.d0    ! krill temperature function constant 1
+t2_zoo2               = 272.5d0     ! krill temperature function constant 2
+t3_zoo2               = 105234.d0   ! krill temperature function constant 3
+t4_zoo2               = 274.15d0    ! krill temperature function constant 4
 /
 
-&pathirdzooplankton ! will not be used in the 2p1z1d version
-graz_max3      = 0.46d0             ! [mmol N/(m3 * day)] Maximum grazing loss parameter
-epsilon3       = 0.64d0             ! [(mmol N)2 /m6] Half saturation constant for grazing loss
-loss_miczoo    = 0.01d0             ! [1/day] Temperature dependent N degradation of extracellular organic N (EON)
-res_miczoo     = 0.01d0             ! [1/day] Respiration by heterotrophs and mortality (loss to detritus)
-pzDia3         = 0.04d0             ! Maximum diatom preference
-sDiaNsq3       = 0.d0               
-pzPhy3         = 0.08d0             ! Maximum small phytoplankton preference
-sPhyNsq3       = 0.d0               
-pzCocco3       = 0.8d0              ! Maximum coccolithophore preference
-sCoccoNsq3     = 0.d0              
+! ============================================================================
+! THIRD ZOOPLANKTON (MICROZOOPLANKTON)
+! ============================================================================
+&pathirdzooplankton
+graz_max3             = 0.46d0      ! maximum grazing rate [mmol N/(m3 day)]
+epsilon3              = 0.64d0      ! half-saturation constant for grazing [(mmol N)^2/m^6]
+loss_miczoo           = 0.01d0      ! temperature-dependent N degradation of extracellular organic N (EON) [1/day]
+res_miczoo            = 0.01d0      ! respiration and mortality (loss to detritus) [1/day]
+
+! --- Prey Preferences ---
+pzDia3                = 0.04d0      ! maximum diatom preference
+sDiaNsq3              = 0.d0        ! not used by the current code
+pzPhy3                = 0.08d0      ! maximum small phytoplankton preference
+sPhyNsq3              = 0.d0        ! not used by the current code
+pzCocco3              = 0.8d0       ! maximum coccolithophore preference (still to be tuned)
+sCoccoNsq3            = 0.d0        ! not used by the current code
 /
 
+! ============================================================================
+! GRAZING ON DETRITUS
+! ============================================================================
 &pagrazingdetritus
-pzDet         = 0.5d0               ! Maximum small detritus prefence by first zooplankton
-sDetNsq       = 0.d0
-pzDetZ2       = 0.5d0               ! Maximum large detritus preference by first zooplankton                                 
-sDetZ2Nsq     = 0.d0
-pzDet2        = 0.5d0               ! Maximum small detritus prefence by second zooplankton                               
-sDetNsq2      = 0.d0
-pzDetZ22      = 0.5d0               ! Maximum large detritus preference by second zooplankton
-sDetZ2Nsq2    = 0.d0
+pzDet                 = 0.5d0       ! maximum small detritus preference, first zooplankton
+sDetNsq               = 0.d0        ! not used by the current code
+pzDetZ2               = 0.5d0       ! maximum large detritus preference, first zooplankton
+sDetZ2Nsq             = 0.d0        ! not used by the current code
+pzDet2                = 0.5d0       ! maximum small detritus preference, second zooplankton
+sDetNsq2              = 0.d0        ! not used by the current code
+pzDetZ22              = 0.5d0       ! maximum large detritus preference, second zooplankton
+sDetZ2Nsq2            = 0.d0        ! not used by the current code
 /
 
+! ============================================================================
+! AGGREGATION
+! ============================================================================
 &paaggregation
-agg_PD                = 0.165d0     ! [m3/(mmol N * day)] Maximum aggregation loss parameter for DetN
-agg_PP                = 0.015d0     ! [m3/(mmol N * day)] Maximum aggregation loss parameter for PhyN and DiaN (plankton)
+agg_PD                = 0.165d0     ! maximum aggregation loss parameter for detritus [m3/(mmol N day)]
+agg_PP                = 0.015d0     ! maximum aggregation loss parameter for phytoplankton [m3/(mmol N day)]
 /
 
+! ============================================================================
+! DISSOLVED ORGANIC MATTER
+! ============================================================================
 &padin_rho_N
-rho_N                 = 0.11d0      ! [1/day] Temperature dependent N degradation of extracellular organic N (EON) (Remineralization of DON)
+rho_N                 = 0.11d0      ! temperature-dependent remineralization of DON (degradation of EON) [1/day]
 /
 
 &padic_rho_C1
-rho_C1                = 0.1d0       ! [1/day] Temperature dependent C degradation of extracellular organic C (EOC)
+rho_C1                = 0.1d0       ! temperature-dependent degradation of extracellular organic C (EOC) [1/day]
 /
 
+! ============================================================================
+! PHYTOPLANKTON LOSSES
+! ============================================================================
 &paphytoplankton_N
-lossN                 = 0.05d0      ! [1/day] Phytoplankton loss of organic N compounds
-lossN_d               = 0.05d0
-lossN_c		      = 0.05d0    
+lossN                 = 0.05d0      ! loss of organic N compounds, small phytoplankton [1/day]
+lossN_d               = 0.05d0      ! loss of organic N compounds, diatoms [1/day]
+lossN_c               = 0.05d0      ! loss of organic N compounds, coccolithophores [1/day]
 /
 
 &paphytoplankton_C
-lossC                 = 0.10d0      ! [1/day] Phytoplankton loss of carbon 
-lossC_d               = 0.10d0
-lossC_c		      = 0.10d0  
+lossC                 = 0.10d0      ! loss of carbon, small phytoplankton [1/day]
+lossC_d               = 0.10d0      ! loss of carbon, diatoms [1/day]
+lossC_c               = 0.10d0      ! loss of carbon, coccolithophores [1/day]
 /
 
 &paphytoplankton_ChlA
-deg_Chl               = 0.075 !0.2d0 !0.25d0      ! [1/day]
-deg_Chl_d             = 0.075 !0.3d0 !0.15d0
-deg_Chl_c	      = 0.075 !0.2d0   
+deg_Chl               = 0.075       ! chlorophyll degradation rate, small phytoplankton [1/day]
+deg_Chl_d             = 0.075       ! chlorophyll degradation rate, diatoms [1/day]
+deg_Chl_c             = 0.075       ! chlorophyll degradation rate, coccolithophores [1/day]
 /
 
+! ============================================================================
+! DETRITUS
+! ============================================================================
 &padetritus_N
-gfin                  = 0.3d0         ! [] Grazing efficiency (fraction of grazing flux into zooplankton pool)
-grazEff2              = 0.8d0         ! [] Grazing efficiency (fraction of grazing flux into second zooplankton pool)
-grazEff3              = 0.8d0         ! [] Grazing efficiency (fraction of grazing flux into microzooplankton pool)
-reminN                = 0.165d0       ! [1/day] Temperature dependent remineralisation rate of detritus	
+gfin                  = 0.3d0       ! grazing efficiency of the first zooplankton (fraction of the grazing flux it retains)
+grazEff2              = 0.8d0       ! grazing efficiency of the second zooplankton
+grazEff3              = 0.8d0       ! grazing efficiency of the microzooplankton
+reminN                = 0.165d0     ! temperature-dependent remineralization rate of detrital N [1/day]
 /
 
 &padetritus_C
-reminC                = 0.15d0      ! [1/day] Temperature dependent remineralisation rate of detritus
-rho_c2                = 0.1d0       ! [1/day] Temperature dependent C degradation of TEP-C
+reminC                = 0.15d0      ! temperature-dependent remineralization rate of detrital C [1/day]
+rho_c2                = 0.1d0       ! temperature-dependent degradation of TEP-C [1/day]
 /
 
+! ============================================================================
+! ZOOPLANKTON EXCRETION
+! ============================================================================
 &paheterotrophs
-lossN_z               = 0.15d0
-lossC_z               = 0.15d0
+lossN_z               = 0.15d0      ! DON excretion by the first zooplankton [1/day]
+lossC_z               = 0.15d0      ! DOC excretion by the first zooplankton [1/day]
 /
 
 &paseczooloss
-lossN_z2              = 0.02d0
-lossC_z2              = 0.02d0
+lossN_z2              = 0.02d0      ! DON excretion by the second zooplankton [1/day]
+lossC_z2              = 0.02d0      ! DOC excretion by the second zooplankton [1/day]
 /
 
 &pathirdzooloss
-lossN_z3              = 0.05d0    
-lossC_z3              = 0.05d0  
+lossN_z3              = 0.05d0      ! DON excretion by the microzooplankton [1/day]
+lossC_z3              = 0.05d0      ! DOC excretion by the microzooplankton [1/day]
 /
 
-&paco2lim                 
-Cunits         = 976.5625    ! Conversion factor between [mol/m3] (model) and [umol/kg] (function): (1000 * 1000) / 1024                                                                                                                      
-a_co2_phy      = 1.162e+00   ! [dimensionless]
-a_co2_dia      = 1.040e+00   ! [dimensionless]
-a_co2_cocco    = 1.109e+00   ! [dimensionless]
-a_co2_calc     = 1.102e+00   ! [dimensionless]
-b_co2_phy      = 4.888e+01   ! [mol/kg]
-b_co2_dia      = 2.890e+01   ! [mol/kg]
-b_co2_cocco    = 3.767e+01   ! [mol/kg]
-b_co2_calc     = 4.238e+01   ! [mol/kg]
-c_co2_phy      = 2.255e-01   ! [kg/mol]
-c_co2_dia      = 8.778e-01   ! [kg/mol]
-c_co2_cocco    = 3.912e-01   ! [kg/mol]
-c_co2_calc     = 7.079e-01   ! [kg/mol]
-d_co2_phy      = 1.023e+07   ! [kg/mol]
-d_co2_dia      = 2.640e+06   ! [kg/mol]
-d_co2_cocco    = 9.450e+06   ! [kg/mol]
-d_co2_calc     = 1.343e+07   ! [kg/mol]
+! ============================================================================
+! CO2 DEPENDENCE OF GROWTH AND CALCIFICATION (CO2lim)
+! ============================================================================
+! Response = a*HCO3/(b + HCO3) - exp(-c*CO2) - d*10**(-pH), with HCO3 and
+! CO2 converted by Cunits; one set per phytoplankton group and calcification.
+! ============================================================================
+&paco2lim
+Cunits         = 976.5625    ! conversion between [mol/m3] (model) and [umol/kg] (function): (1000 * 1000) / 1024
+a_co2_phy      = 1.162e+00   ! HCO3 response coefficient a, small phytoplankton [dimensionless]
+a_co2_dia      = 1.040e+00   ! HCO3 response coefficient a, diatoms [dimensionless]
+a_co2_cocco    = 1.109e+00   ! HCO3 response coefficient a, coccolithophores [dimensionless]
+a_co2_calc     = 1.102e+00   ! HCO3 response coefficient a, calcification [dimensionless]
+b_co2_phy      = 4.888e+01   ! HCO3 half-saturation b, small phytoplankton [mol/kg]
+b_co2_dia      = 2.890e+01   ! HCO3 half-saturation b, diatoms [mol/kg]
+b_co2_cocco    = 3.767e+01   ! HCO3 half-saturation b, coccolithophores [mol/kg]
+b_co2_calc     = 4.238e+01   ! HCO3 half-saturation b, calcification [mol/kg]
+c_co2_phy      = 2.255e-01   ! CO2 inhibition coefficient c, small phytoplankton [kg/mol]
+c_co2_dia      = 8.778e-01   ! CO2 inhibition coefficient c, diatoms [kg/mol]
+c_co2_cocco    = 3.912e-01   ! CO2 inhibition coefficient c, coccolithophores [kg/mol]
+c_co2_calc     = 7.079e-01   ! CO2 inhibition coefficient c, calcification [kg/mol]
+d_co2_phy      = 1.023e+07   ! H+ inhibition coefficient d, small phytoplankton [kg/mol]
+d_co2_dia      = 2.640e+06   ! H+ inhibition coefficient d, diatoms [kg/mol]
+d_co2_cocco    = 9.450e+06   ! H+ inhibition coefficient d, coccolithophores [kg/mol]
+d_co2_calc     = 1.343e+07   ! H+ inhibition coefficient d, calcification [kg/mol]
 /
 
+! ============================================================================
+! IRON
+! ============================================================================
 &pairon
-Fe2N                  = 0.033d0     ! Fe2C * 6.625
-Fe2N_benthos          = 0.15d0      ! test, default was 0.14 Fe2C_benthos * 6.625 - will have to be tuned. [umol/m2/day]
-kScavFe               = 0.07d0
-dust_sol              = 0.02d0      ! Dissolution of Dust for bioavaliable
-RiverFeConc           = 100
+Fe2N                  = 0.033d0     ! Fe:N ratio of organic matter (Fe2C * 6.625)
+Fe2N_benthos          = 0.15d0      ! Fe:N ratio of the benthic iron release (Fe2C_benthos * 6.625; was 0.14, still to be tuned)
+kScavFe               = 0.07d0      ! scavenging rate of free iron onto detritus
+dust_sol              = 0.02d0      ! soluble (bioavailable) fraction of dust iron
+RiverFeConc           = 100         ! mean dissolved iron concentration in rivers (useRivFe)
 /
 
+! ============================================================================
+! CALCITE
+! ============================================================================
 &pacalc
-calc_prod_ratio       = 0.02
-calc_diss_guts        = 0.0d0       ! set to zero if OmegaC_diss is set to false
-calc_diss_rate        = 0.005714d0  ! 20.d0/3500.d0
-calc_diss_rate2       = 0.005714d0
-calc_diss_omegac      = 0.197d0     ! Value from Aumont et al. 2015, is used with OmegaC_diss flag
-calc_diss_exp         = 1.d0        ! Exponent in the dissolution rate of calcite, is used with OmegaC_diss flag
+calc_prod_ratio       = 0.02        ! calcite production as a fraction of small phytoplankton carbon fixation
+calc_diss_guts        = 0.0d0       ! calcite dissolution in zooplankton guts (set to 0 when OmegaC_diss = .false.)
+calc_diss_rate        = 0.005714    ! calcite dissolution rate (20/3500) [1/day]
+calc_diss_rate2       = 0.005714d0  ! calcite dissolution rate of large detritus, scaled by its sinking speed / 20
+calc_diss_omegac      = 0.197d0     ! value from Aumont et al. (2015), used with OmegaC_diss
+calc_diss_exp         = 1.d0        ! exponent of the calcite dissolution rate, used with OmegaC_diss
 /
 
+! ============================================================================
+! BENTHOS
+! ============================================================================
 &pabenthos_decay_rate
-decayRateBenN         = 0.005d0
-decayRateBenC         = 0.005d0
-decayRateBenSi        = 0.005d0
+decayRateBenN         = 0.005d0     ! decay rate of benthic nitrogen [1/day]
+decayRateBenC         = 0.005d0     ! decay rate of benthic carbon [1/day]
+decayRateBenSi        = 0.005d0     ! decay rate of benthic silicon [1/day]
 q_NC_Denit            = 0.86d0      ! N:C quota of the denitrification process
 /
 
+! ============================================================================
+! AIR-SEA CO2 FLUX
+! ============================================================================
 &paco2_flux_param
-permil                = 0.000000976 ! 1.e-3/1024.5d0              ! Converting DIC from [mmol/m3] to [mol/kg]
-permeg                = 1.e-6                       ! [atm/uatm] Changes units from uatm to atm
+permil                = 0.000000976 ! converts DIC from [mmol/m3] to [mol/kg] (1.e-3/1024.5)
+permeg                = 1.e-6       ! converts uatm to atm [atm/uatm]
 !X1                    = exp(-5.d0*log(10.d0))       ! Lowest ph-value = 7.7 (phlo)
 !X2                    = exp(-9.d0*log(10.d0))       ! Highest ph-value = 9.5 (phhi)
-Xacc                  = 1.e-12                      ! Accuracy for ph-iteration (phacc)
-CO2_for_spinup        = 278.d0                      ! [uatm] Atmospheric partial pressure of CO2
+Xacc                  = 1.e-12      ! accuracy of the pH iteration
+CO2_for_spinup        = 278.d0      ! atmospheric pCO2 used with constant_CO2 = .true. [uatm]
 /
 
+! ============================================================================
+! ALKALINITY RESTORING
+! ============================================================================
 &paalkalinity_restoring
-surf_relax_Alk      = 3.2e-07 !10.d0/31536000.d0
+surf_relax_Alk        = 3.2e-07     ! surface alkalinity restoring velocity, 10 m per year [m/s] (restore_alkalinity)
 /
 
+! ============================================================================
+! BALLASTING (use_ballasting, see Cram et al. 2018)
+! ============================================================================
 &paballasting
-rho_POC              = 1033.d0   ! kg m-3; density of POC (see Table 1 in Cram et al., 2018)
-rho_PON              = 1033.d0   ! kg m-3; density of PON (see Table 1 in Cram et al., 2018)
-rho_CaCO3            = 2830.d0   ! kg m-3; density of CaCO3 (see Table 1 in Cram et al., 2018) 
-rho_opal             = 2090.d0   ! kg m-3; density of Opal (see Table 1 in Cram et al., 2018)
-rho_ref_part         = 1230.d0   ! kg m-3; reference particle density (see Cram et al., 2018)
-rho_ref_water        = 1027.d0   ! kg m-3; reference seawater density (see Cram et al., 2018)
-visc_ref_water       = 0.00158d0 ! kg m-1 s-1; reference seawater viscosity, at Temp=4 degC (see Cram et al., 2018)
-w_ref1               = 5.d0     ! m s-1; reference sinking velocity of small detritus
-w_ref2               = 200.d0    ! m s-1; reference sinking velocity of large detritus
-depth_scaling1       = 0.01d0   ! s-1; factor to increase sinking speed of det1 with depth, set to 0 if not wanted
-depth_scaling2       = 0.d0      ! s-1; factor to increase sinking speed of det2 with depth, set to 0 if not wanted
-max_sinking_velocity = 250.d0    ! d-1; for numerical stability, set a maximum possible sinking velocity here (applies to both detritus classes)
+rho_POC              = 1033.d0   ! density of POC [kg/m3] (Cram et al. 2018, Table 1)
+rho_PON              = 1033.d0   ! density of PON [kg/m3] (Cram et al. 2018, Table 1)
+rho_CaCO3            = 2830.d0   ! density of CaCO3 [kg/m3] (Cram et al. 2018, Table 1)
+rho_opal             = 2090.d0   ! density of opal [kg/m3] (Cram et al. 2018, Table 1)
+rho_ref_part         = 1230.d0   ! reference particle density [kg/m3]
+rho_ref_water        = 1027.d0   ! reference seawater density [kg/m3]
+visc_ref_water       = 0.00158d0 ! reference seawater viscosity at 4 degC [kg/(m s)]
+w_ref1               = 5.d0      ! reference sinking velocity of small detritus [m/day]
+w_ref2               = 200.d0    ! reference sinking velocity of large detritus [m/day]
+depth_scaling1       = 0.01d0    ! increase of small detritus sinking speed with depth [1/day], 0 = off
+depth_scaling2       = 0.d0      ! increase of large detritus sinking speed with depth [1/day], 0 = off
+max_sinking_velocity = 250.d0    ! upper limit of the sinking speed for numerical stability [m/day], both detritus classes
 /
 
+! ============================================================================
+! CARBON ISOTOPES (ciso)
+! ============================================================================
 &paciso
 ciso_init         = .false.     ! initial fractionation of bulk organic matter
-ciso_14           = .false.      ! include inorganic radiocarbon
+ciso_14           = .false.     ! include inorganic radiocarbon
 ciso_organic_14   = .false.     ! include organic radiocarbon
-lambda_14         = 3.8561e-12  ! corresponding to 1 year = 365.00 days
-delta_CO2_13      = -6.61       ! atmospheric d13C (permil), global-mean value
-big_delta_CO2_14(1)  = 0. ! atmospheric D14C (permil), northern hemisphere polewards of 30°N
-big_delta_CO2_14(2)  = 0. ! atmospheric D14C (permil), (sub) tropical zone 30°N - 30°S
-big_delta_CO2_14(3)  = 0. ! atmospheric D14C (permil), southern hemisphere polewards of 30°S
-atbox_spinup      = .false.
-cosmic_14_init    = 2.0
+lambda_14         = 3.8561e-12  ! radiocarbon decay constant [1/s] (1 year = 365.00 days)
+delta_CO2_13      = -6.61       ! atmospheric d13C, global mean [permil]
+big_delta_CO2_14(1)  = 0. ! atmospheric D14C north of 30°N [permil]
+big_delta_CO2_14(2)  = 0. ! atmospheric D14C between 30°N and 30°S [permil]
+big_delta_CO2_14(3)  = 0. ! atmospheric D14C south of 30°S [permil]
+atbox_spinup      = .false.     ! spin-up mode of the atmospheric 14C box
+cosmic_14_init    = 2.0         ! initial cosmogenic 14C production [atoms/(s cm²)]
 /
-
-

--- a/config/bin_2p1z1d/namelist.tra
+++ b/config/bin_2p1z1d/namelist.tra
@@ -1,9 +1,37 @@
+! ============================================================================
+! ============ Namelist file for FESOM2 tracer configuration =================
+! ============================================================================
+! This file contains configuration for ocean tracers (temperature, salinity,
+! and passive tracers):
+! - Tracer list and advection/diffusion schemes
+! - Initial conditions (3D ocean and 2D sea ice)
+! - Biharmonic diffusion options
+! - Vertical diffusion and time stepping
+! - Physical parameterizations (mixing, restoring)
+! ============================================================================
+
+! ============================================================================
+! TRACER ARRAY ALLOCATION
+! ============================================================================
 &tracer_listsize
-num_tracers=100 !number of tracers to allocate. shallbe large or equal to the number of streams in &nml_list
+num_tracers = 100         ! number of tracers to allocate (must be ≥ actual number of tracers)
 /
 
+! ============================================================================
+! TRACER LIST AND ADVECTION SCHEMES
+! ============================================================================
+! Format: ID, horizontal_advection, vertical_advection, horizontal_diffusion, Kh_factor, Kv_factor
+! Advection schemes: 'MFCT' (Multidimensional FCT), 'UPW1' (1st-order upwind), 'QR4C' (4th-order)
+! Diffusion schemes: 'FCT' (Flux-Corrected Transport), 'NON' (none)
+! Order switches   : hor./vert. Ord.=1.0 --> 4th order, =0.0 --> 3rd order, =0.5 --> mixed 3rd&4th order
+! ============================================================================
+! nml_tracer_list =
+! idx, hor. Adv, vert. Adv., use FCT, hor.Ord., vert. Ord. 
+! 1  , 'MFCT'  , 'QR4C'    , 'FCT ' , 1.      , 1.        ,   ! temperature
+! 2  , 'MFCT'  , 'QR4C'    , 'FCT ' , 1.      , 1.        ,   ! salinity
+!101 , 'UPW1'  , 'UPW1'    , 'NON ' , 0.      , 0.            ! example passive tracer
 &tracer_list
-nml_tracer_list =  
+nml_tracer_list =
 1  ,   'MFCT',       'QR4C',       'FCT ',        1.,          1., 
 2  ,   'MFCT',       'QR4C',       'FCT ',        1.,          1.,
 1001,  'MFCT',       'QR4C',       'FCT ',        1.,          1.,
@@ -43,49 +71,81 @@ nml_tracer_list =
 !101, 'UPW1',       'UPW1',       'NON ',        0.,          0.
 /
 
-&tracer_init3d                            ! initial conditions for tracers
-n_ic3d   = 8                              ! number of tracers to initialize
-idlist   = 1019, 1022, 1018, 1003, 1002, 1001, 2, 1 ! their IDs (0 is temperature, 1 is salinity, etc.). The reading order is defined here!
-filelist = 'fe_pisces_opa_eq_init_3D_changed_name.nc', 'woa18_all_o00_01_mmol_fesom2.nc', 'woa13_all_i00_01_fesom2.nc', 'GLODAPv2.2016b.TAlk_fesom2_mmol_fix_z_Fillvalue.nc', 'GLODAPv2.2016b.TCO2_fesom2_mmol_fix_z_Fillvalue.nc', 'woa13_all_n00_01_fesom2.nc', 'phc3.0_winter.nc', 'phc3.0_winter.nc'  ! list of files in ClimateDataPath to read (one file per tracer), same order as idlist
-varlist  = 'Fe', 'oxygen_mmol', 'i_an', 'TAlk_mmol', 'TCO2_mmol', 'n_an', 'salt', 'temp'                 ! variables to read from specified files
-t_insitu = .true.                         ! if T is insitu it will be converted to potential after reading it
+! ============================================================================
+! 3D TRACER INITIAL CONDITIONS (OCEAN)
+! ============================================================================
+&tracer_init3d
+n_ic3d   = 8  ! number of 3D tracers to initialize from files
+idlist   = 1019, 1022, 1018, 1003, 1002, 1001, 2, 1 ! tracer IDs to initialize (1=temperature, 2=salinity)
+filelist = 'fe_pisces_opa_eq_init_3D_changed_name.nc', 'woa18_all_o00_01_mmol_fesom2.nc', 'woa13_all_i00_01_fesom2.nc', 'GLODAPv2.2016b.TAlk_fesom2_mmol_fix_z_Fillvalue.nc', 'GLODAPv2.2016b.TCO2_fesom2_mmol_fix_z_Fillvalue.nc', 'woa13_all_n00_01_fesom2.nc', 'phc3.0_winter.nc', 'phc3.0_winter.nc' ! netCDF files in ClimateDataPath (one per tracer)
+varlist  = 'Fe', 'oxygen_mmol', 'i_an', 'TAlk_mmol', 'TCO2_mmol', 'n_an', 'salt', 'temp' ! variable names in the netCDF files
+t_insitu = .true.                                  ! if true, convert in-situ temperature to potential temperature
 /
 
-&tracer_init2d                                      ! initial conditions for 2D tracers (sea ice)
-n_ic2d   = 3                                        ! number of tracers to initialize
-idlist   = 1, 2, 3                                  ! their IDs (0 is a_ice, 1 is m_ice, 3 m_snow). The reading order is defined here!
-filelist = 'a_ice.nc', 'm_ice.nc', 'm_snow.nc' ! list of files in ClimateDataPath to read (one file per tracer), same order as idlist
-varlist  = 'a_ice', 'm_ice', 'm_snow'                 ! variables to read from specified files
-ini_ice_from_file=.false.
+! ============================================================================
+! 2D TRACER INITIAL CONDITIONS (SEA ICE)
+! ============================================================================
+&tracer_init2d
+n_ic2d            = 3                                    ! number of 2D tracers to initialize from files
+idlist            = 1, 2, 3                              ! tracer IDs (1=ice concentration, 2=ice thickness, 3=snow thickness)
+filelist          = 'a_ice.nc', 'm_ice.nc', 'm_snow.nc'  ! netCDF files in ClimateDataPath
+varlist           = 'a_ice', 'm_ice', 'm_snow'           ! variable names in the netCDF files
+ini_ice_from_file = .false.                              ! enable initialization from files (false = use default values)
 /
 
+! ============================================================================
+! TRACER GENERAL SETTINGS
+! ============================================================================
 &tracer_general
-! bharmonic diffusion for tracers. We recommend to use this option in very high resolution runs (Redi is generally off there).
-smooth_bh_tra =.false.     ! use biharmonic diffusion (filter implementation) for tracers
-gamma0_tra    = 0.0005     ! gammaX_tra are analogous to those in the dynamical part
-gamma1_tra    = 0.0125
-gamma2_tra    = 0.
-i_vert_diff   =.true.
+! --- Biharmonic Diffusion ---
+! Recommended for very high resolution runs (where Redi is typically disabled)
+smooth_bh_tra = .false.       ! enable biharmonic diffusion (filter implementation) for tracers
+gamma0_tra    = 0.0005        ! background biharmonic diffusion coefficient [dimensionless]
+gamma1_tra    = 0.0125        ! flow-aware biharmonic diffusion coefficient [dimensionless]
+gamma2_tra    = 0.            ! additional biharmonic diffusion coefficient [dimensionless]
+
+! --- Vertical Diffusion and Time Stepping ---
+i_vert_diff   = .true.        ! use implicit vertical diffusion (recommended for stability)
 /
 
+! ============================================================================
+! TRACER PHYSICS AND PARAMETERIZATIONS
+! ============================================================================
 &tracer_phys
-use_momix     = .true.     ! switch on/off  !Monin-Obukhov -> TB04 mixing
-momix_lat     = -50.0      ! latitidinal treshhold for TB04, =90 --> global
-momix_kv      = 0.01       ! PP/KPP, mixing coefficient within MO length
-use_instabmix = .true.     ! enhance convection in case of instable stratification
-instabmix_kv  = 0.1
-use_windmix   = .false.    ! enhance mixing trough wind only for PP mixing (for stability)
-windmix_kv    = 1.e-3
-windmix_nl    = 2
-diff_sh_limit=5.0e-3       ! for KPP, max diff due to shear instability
-Kv0_const=.true.
-double_diffusion=.false.   ! for KPP,dd switch
-K_ver=1.0e-5
-K_hor=3000.
-surf_relax_T=0.0
-surf_relax_S=1.929e-06   ! 50m/300days 6.43e-07! m/s 10./(180.*86400.)
-balance_salt_water =.true. ! balance virtual-salt or freshwater flux or not
-clim_relax=0.0	           ! 1/s, geometrical information has to be supplied
-ref_sss_local=.true.
-ref_sss=34.
+! --- Monin-Obukhov Mixing (TB04) ---
+use_momix          = .true.            ! enable Monin-Obukhov mixing (Timmermann & Beckmann 2004)
+momix_lat          = -50.0             ! latitude threshold for TB04 [degrees] (90 = global, -50 = south of 50°S)
+momix_kv           = 0.01              ! mixing coefficient within MO length [m²/s]
+
+! --- Convective Instability Mixing ---
+use_instabmix      = .true.            ! enhance mixing for unstable stratification (convection)
+instabmix_kv       = 0.1               ! mixing coefficient for unstable stratification [m²/s]
+
+! --- Wind Mixing (PP scheme only) ---
+use_windmix        = .false.           ! enhance near-surface mixing by wind (for PP mixing stability)
+windmix_kv         = 1.e-3             ! wind mixing coefficient [m²/s]
+windmix_nl         = 2                 ! number of surface layers for wind mixing
+
+! --- Shear Instability (KPP) ---
+diff_sh_limit      = 5.0e-3            ! maximum diffusivity due to shear instability [m²/s] (for KPP)
+
+! --- Background Diffusivity ---
+Kv0_const          = .true.            ! use constant background vertical diffusivity
+K_ver              = 1.0e-5            ! background vertical diffusivity [m²/s]
+K_hor              = 3000.             ! background horizontal diffusivity [m²/s]
+
+! --- Double Diffusion (KPP) ---
+double_diffusion   = .false.           ! enable double diffusion parameterization (for KPP)
+
+! --- Surface Restoring ---
+surf_relax_T       = 0.0               ! surface temperature restoring coefficient [m/s] (0 = disabled)
+surf_relax_S       = 1.929e-06         ! surface salinity restoring coefficient [m/s]
+balance_salt_water = .true.            ! balance virtual salt flux with freshwater flux
+
+! --- Climatology Restoring ---
+clim_relax         = 0.0               ! 3D climatology restoring coefficient [1/s] (0 = disabled)
+
+! --- Reference Salinity ---
+ref_sss_local      = .true.            ! use local reference SSS (true) or global constant (false)
+ref_sss            = 34.               ! global reference salinity [psu] (if ref_sss_local=false)
 /

--- a/config/bin_2p3z2d/namelist.forcing
+++ b/config/bin_2p3z2d/namelist.forcing
@@ -1,80 +1,154 @@
-! This is the namelist file for forcing
+! ============================================================================
+! ============= Namelist file for FESOM2 atmospheric forcing ================
+! ============================================================================
+! This file contains configuration for atmospheric forcing and surface boundary
+! conditions, including:
+! - Bulk formulae exchange coefficients (heat, momentum, moisture)
+! - Bulk formulae options and reference heights
+! - Land ice freshwater forcing
+! - Age tracer configuration
+! - Surface forcing data files and variables
+! - Runoff and salinity restoring
+! - Chlorophyll data for shortwave penetration
+! ============================================================================
+! ----------------------------------------------------------------------------
+! File names below are relative to ForcingDataPath in namelist.config. A name
+! starting with '/' is used as given, which is how files outside the forcing
+! tree (for example the Sweeney chlorophyll climatology) are pointed at.
+! ----------------------------------------------------------------------------
 
+! ============================================================================
+! BULK FORMULAE EXCHANGE COEFFICIENTS
+! ============================================================================
+! These coefficients control the turbulent exchange of heat, moisture, and
+! momentum between the atmosphere and ocean/ice surfaces.
+! ============================================================================
 &forcing_exchange_coeff
-Ce_atm_oce=0.00175 ! exchange coeff. of latent heat over open water
-Ch_atm_oce=0.00175 ! exchange coeff. of sensible heat over open water
-Cd_atm_oce=0.001  ! drag coefficient between atmosphere and water
-Ce_atm_ice=0.00175 ! exchange coeff. of latent heat over ice
-Ch_atm_ice=0.00175 ! exchange coeff. of sensible heat over ice
-Cd_atm_ice=0.0012  ! drag coefficient between atmosphere and ice 
-Swind     =0.0     ! parameterization for coupled current feedback
+Ce_atm_oce = 0.00175    ! exchange coefficient of latent heat over open water (dimensionless)
+Ch_atm_oce = 0.00175    ! exchange coefficient of sensible heat over open water (dimensionless)
+Cd_atm_oce = 0.001      ! drag coefficient between atmosphere and water (dimensionless)
+Ce_atm_ice = 0.00175    ! exchange coefficient of latent heat over ice (dimensionless)
+Ch_atm_ice = 0.00175    ! exchange coefficient of sensible heat over ice (dimensionless)
+Cd_atm_ice = 0.0012     ! drag coefficient between atmosphere and ice (dimensionless)
+Swind       = 0.0       ! parameterization for coupled current feedback (0.0 = disabled)
+                        ! non-zero values reduce wind stress based on ocean surface currents
 /
 
+! ============================================================================
+! BULK FORMULAE OPTIONS
+! ============================================================================
+! Configuration for bulk formulae calculations (turbulent fluxes).
+! Reference heights must match the forcing data specifications.
+! ============================================================================
 &forcing_bulk
-AOMIP_drag_coeff=.false.
-ncar_bulk_formulae=.true.
-ncar_bulk_z_wind=10.0 ! height at which wind forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-ncar_bulk_z_tair=10.0 ! height at which temp forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-ncar_bulk_z_shum=10.0 ! height at which humi forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-
+AOMIP_drag_coeff  = .false.  ! use AOMIP drag coefficient formulation (false = use standard)
+ncar_bulk_formulae = .true.  ! use NCAR bulk formulae (Large & Yeager 2004, 2009)
+ncar_bulk_z_wind   = 10.0    ! reference height for wind forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_tair   = 10.0    ! reference height for air temperature forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_shum   = 10.0    ! reference height for specific humidity forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
 /
 
+! ============================================================================
+! LAND ICE FRESHWATER FORCING
+! ============================================================================
+! Configuration for freshwater input from land ice (glaciers, ice sheets).
+! Requires use_landice_water=.true. in namelist.config to enable output.
+! ============================================================================
 &land_ice
-use_landice_water=.false.
-landice_start_mon=5
-landice_end_mon=10
-fwf_path='./mesh/'
-
+use_landice_water = .false.  ! enable land ice freshwater forcing
+landice_start_mon = 5        ! start month for land ice forcing (1-12)
+landice_end_mon   = 10       ! end month for land ice forcing (1-12)
+fwf_path          = './mesh/'    ! path to land ice freshwater flux data files
 /
 
+! ============================================================================
+! AGE TRACER CONFIGURATION
+! ============================================================================
+! Configuration for passive age tracer (tracks water mass age).
+! Requires use_age_tracer=.true. in namelist.config to enable output.
+! ============================================================================
 &age_tracer
-use_age_tracer=.false.
-use_age_mask=.false.
-age_tracer_path='./mesh/'
-age_start_year=2000
-
+use_age_tracer    = .false.  ! enable age tracer computation
+use_age_mask      = .false.  ! use spatial mask for age tracer initialization
+age_tracer_path   = './mesh/'    ! path to age tracer mask file (if use_age_mask=.true.)
+age_start_year    = 2000     ! year to start age tracer (tracer age = 0 at this year)
 /
 
+! ============================================================================
+! SURFACE BOUNDARY CONDITION (FORCING DATA)
+! ============================================================================
+! Specification of atmospheric forcing data files and variables.
+! File paths are relative to the run directory.
+! ============================================================================
 &nam_sbc
-   nm_xwind_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/uas.clim61'        ! name of file with winds, if nm_sbc=2
-   nm_ywind_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/vas.clim61'        ! name of file with winds, if nm_sbc=2
-   nm_xstre_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/uas.clim61'        ! name of file with winds, if nm_sbc=2
-   nm_ystre_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/vas.clim61'        ! name of file with winds, if nm_sbc=2
-   nm_humi_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/huss.clim61'        ! name of file with humidity
-   nm_qsr_file   = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/rsds.clim61'    ! name of file with solar heat
-   nm_qlw_file   = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/rlds.clim61'    ! name of file with Long wave
-   nm_tair_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/tas.clim61'        ! name of file with 2m air temperature
+   ! --- Forcing file paths ---
+   nm_xwind_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/uas.clim61' ! name of file with zonal wind speeds
+   nm_ywind_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/vas.clim61' ! name of file with meridional wind speeds
+   nm_xstre_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/uas.clim61' ! name of file with zonal wind stress
+   nm_ystre_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/vas.clim61' ! name of file with meridional wind stress
+   nm_humi_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/huss.clim61' ! name of file with air humidity
+   nm_qsr_file   = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/rsds.clim61' ! name of file with short wave radiation
+   nm_qlw_file   = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/rlds.clim61' ! name of file with long wave radiation
+   nm_tair_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/tas.clim61' ! name of file with 2m air temperature
    nm_prec_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/prra.clim61' ! name of file with total precipitation
-   nm_snow_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/prsn.clim61' ! name of file with snow  precipitation
+   nm_snow_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/prsn.clim61' ! name of file with snow precipitation
    nm_mslp_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/psl.clim61'         ! air_pressure_at_sea_level
-   nm_xwind_var  = 'uas'   ! name of variable in file with wind
-   nm_ywind_var  = 'vas'   ! name of variable in file with wind
-   nm_xstre_var  = 'uas'   ! name of variable in file with wind
-   nm_ystre_var  = 'vas'   ! name of variable in file with wind
-   nm_humi_var   = 'huss'  ! name of variable in file with humidity
-   nm_qsr_var    = 'rsds'  ! name of variable in file with solar heat
-   nm_qlw_var    = 'rlds'  ! name of variable in file with Long wave
-   nm_tair_var   = 'tas'   ! name of variable in file with 2m air temperature
-   nm_prec_var   = 'prra'  ! name of variable in file with total precipitation
-   nm_snow_var   = 'prsn'  ! name of variable in file with total precipitation
-   nm_mslp_var   = 'psl'   ! name of variable in file with air_pressure_at_sea_level
-   nm_nc_iyear   = 1900
-   nm_nc_imm     = 1            ! initial month of time axis in netCDF 
-   nm_nc_idd     = 1            ! initial day of time axis in netCDF
-   nm_nc_freq    = 1            ! data points per day (i.e. 86400 if the time axis is in seconds)
-   nm_nc_tmid    = 0            ! 1 if the time stamps are given at the mid points of the netcdf file, 0 otherwise (i.e. 1 in CORE1, CORE2; 0 in JRA55)
-   y_perpetual=.true.
-   l_xwind=.true. l_ywind=.true. l_xstre=.false. l_ystre=.false. l_humi=.true. l_qsr=.true. l_qlw=.true. l_tair=.true. l_prec=.true. l_mslp=.true. l_cloud=.false. l_snow=.true.
-   nm_runoff_file      ='/albedo/pool/FESOM/forcing/CORE2/runoff.nc'
-   runoff_data_source ='CORE2'	!Dai09, CORE2
-   !runoff_data_source ='Dai09'  !Dai09, CORE2, JRA55
-   !runoff_climatology =.true.
-   sss_data_source    ='CORE2'
-   nm_sss_data_file   ='/albedo/pool/FESOM/forcing/CORE2/PHC2_salx.nc'
-   chl_data_source    ='None' !'Sweeney' monthly chlorophyll climatology or 'NONE' for constant chl_const (below). Make use_sw_pene=.TRUE. in namelist.config!
-   nm_chl_data_file   ='/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/Sweeney/Sweeney_2005.nc'
-   chl_const          = 0.1
-   use_runoff_mapper  = .FALSE.
-   runoff_basins_file = 'runoff_maps_regular.nc'
-   runoff_radius      = 500000.
+
+   ! --- Variable names in netCDF forcing files ---
+   nm_xwind_var  = 'uas'      ! name of variable in file with zonal wind
+   nm_ywind_var  = 'vas'      ! name of variable in file with meridional wind
+   nm_xstre_var  = 'uas'      ! name of variable in file with zonal wind stress
+   nm_ystre_var  = 'vas'      ! name of variable in file with meridional wind stress
+   nm_humi_var   = 'huss'     ! name of variable in file with humidity
+   nm_qsr_var    = 'rsds'     ! name of variable in file with solar heat
+   nm_qlw_var    = 'rlds'     ! name of variable in file with long wave
+   nm_tair_var   = 'tas'      ! name of variable in file with 2m air temperature
+   nm_prec_var   = 'prra'     ! name of variable in file with total precipitation
+   nm_snow_var   = 'prsn'     ! name of variable in file with snow precipitation
+   nm_mslp_var   = 'psl'      ! name of variable in file with air_pressure_at_sea_level
+
+   ! --- Time axis configuration in forcing files ---
+   nm_nc_iyear   = 1900       ! initial year of forcing data time axis (note, not the first year in the file!)
+   nm_nc_imm     = 1          ! initial month of forcing data time axis (1-12)
+   nm_nc_idd     = 1          ! initial day of forcing data time axis (1-31)
+   nm_nc_freq    = 1          ! divisor converting the time axis of the forcing files to days (1 = days, 24 = hours, 86400 = seconds)
+   nm_nc_tmid    = 0          ! time stamp position: 1=mid-point, 0=start of interval
+   y_perpetual   = .true.     ! use perpetual year forcing (repeat single year)
+
+   ! --- Enable/disable individual forcing fields ---
+   l_xwind       = .true.     ! use zonal wind forcing
+   l_ystre=.false.
+   l_ywind       = .true.     ! use meridional wind forcing
+   l_humi        = .true.     ! use specific humidity forcing
+   l_qsr         = .true.     ! use shortwave radiation forcing
+   l_qlw         = .true.     ! use longwave radiation forcing
+   l_tair        = .true.     ! use air temperature forcing
+   l_xstre=.false.
+   l_prec        = .true.     ! use precipitation forcing
+   l_mslp        = .true.     ! use mean sea level pressure forcing
+   l_cloud       = .false.    ! use cloud cover forcing
+   l_snow        = .true.     ! use snow precipitation forcing
+
+   ! --- Runoff configuration ---
+   runoff_data_source = 'CORE2'       ! runoff data source: 'Dai09', 'JRA55', 'CORE1', 'CORE2' or 'NONE'
+   nm_runoff_file     = '/albedo/pool/FESOM/forcing/CORE2/runoff.nc' ! CORE2 monthly climatology with runoff_climatology=.true.
+   !nm_runoff_file     = 'friver.'  ! Dai09/JRA55 with runoff_climatology=.false.: prefix, year and '.nc' are appended (friver.1958.nc).
+
+   ! --- Sea surface salinity restoring ---
+   sss_data_source  = 'CORE2'  ! SSS restoring data source: 'CORE2', 'WOA', or 'NONE'
+   nm_sss_data_file = '/albedo/pool/FESOM/forcing/CORE2/PHC2_salx.nc' ! path to SSS restoring data file, e.g. PHC2_salx.nc
+
+   ! --- Chlorophyll data for shortwave penetration ---
+   chl_data_source  = 'None'      ! chlorophyll data source: 'Sweeney' (monthly climatology) or 'None' (constant)
+                               ! requires use_sw_pene=.true. in namelist.config
+   nm_chl_data_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/Sweeney/Sweeney_2005.nc' ! chlorophyll data file (if Sweeney)
+   chl_const        = 0.1      ! constant chlorophyll concentration [mg/m³] (if chl_data_source='None')
+
+   ! --- Runoff mapper (distributes runoff over coastal area) ---
+   use_runoff_mapper  = .false.  ! enable runoff mapper (spreads runoff spatially)
+   runoff_basins_file = 'runoff_maps_regular.nc' ! runoff basin mapping file
+   runoff_radius      = 500000.  ! radius for runoff spreading [m] (if use_runoff_mapper=.true.)
 /

--- a/config/bin_2p3z2d/namelist.ice
+++ b/config/bin_2p3z2d/namelist.ice
@@ -1,31 +1,76 @@
-! Ice namelist
+! ============================================================================
+! ============== Namelist file for FESOM2 sea ice model =====================
+! ============================================================================
+! This file contains configuration for sea ice dynamics and thermodynamics:
+! - EVP (Elastic-Viscous-Plastic) rheology options
+! - Ice strength and deformation parameters
+! - Ocean-ice drag
+! - Ice thermodynamics and thickness distribution
+! - Albedo parameterizations
+! ============================================================================
+
+! ============================================================================
+! SEA ICE DYNAMICS
+! ============================================================================
 &ice_dyn
-whichEVP=0             ! 0=standart; 1=mEVP; 2=aEVP
-Pstar=30000.0          ! [N/m^2]
-ellipse=2.0
-c_pressure=20.0        ! ice concentration parameter used in ice strength computation
-delta_min=1.0e-11      ! [s^(-1)]
-evp_rheol_steps=120    ! number of EVP subcycles
-alpha_evp=250          ! constant that control numerical stability of mEVP. Adjust with resolution. 
-beta_evp=250           ! constant that control numerical stability of mEVP. Adjust with resolution.
-c_aevp=0.15            ! a tuning constant in aEVP. Adjust with resolution.
-Cd_oce_ice=0.0055      ! drag coef. oce - ice 
-ice_gamma_fct=0.5      ! smoothing parameter
-ice_diff=0.0           ! diffusion to stabilize
-theta_io=0.0           ! rotation angle
-ice_ave_steps=1        ! ice step=ice_ave_steps*oce_step
+! --- EVP Rheology Options ---
+whichEVP       = 0              ! EVP solver type:
+                                !   0 = standard EVP
+                                !   1 = modified EVP (mEVP)
+                                !   2 = adaptive EVP (aEVP)
+
+! --- Ice Strength Parameters ---
+Pstar          = 30000.0        ! ice strength parameter [N/m²] (typical: 20000-30000)
+ellipse        = 2.0            ! aspect ratio of yield curve ellipse (dimensionless)
+c_pressure     = 20.0           ! ice concentration parameter for strength computation (dimensionless)
+
+! --- Ice Deformation ---
+delta_min      = 1.0e-11        ! minimum strain rate for viscosity regularization [s⁻¹]
+
+! --- EVP Subcycling ---
+evp_rheol_steps = 120           ! number of EVP subcycles per ice time step
+
+! --- mEVP Stability Parameters (for whichEVP=1) ---
+alpha_evp      = 250            ! mEVP stability constant (adjust with resolution)
+beta_evp       = 250            ! mEVP stability constant (adjust with resolution)
+
+! --- aEVP Tuning (for whichEVP=2) ---
+c_aevp         = 0.15           ! aEVP tuning constant (adjust with resolution)
+
+! --- Ocean-Ice Coupling ---
+Cd_oce_ice     = 0.0055         ! drag coefficient between ocean and ice (dimensionless, typical: 0.0055)
+
+! --- Numerical Stabilization ---
+ice_gamma_fct  = 0.5            ! smoothing parameter for ice dynamics (0.0-1.0)
+ice_diff       = 0.0            ! artificial diffusion for numerical stability [m²/s]
+theta_io       = 0.0            ! rotation angle for ice-ocean stress [degrees]
+
+! --- Time Stepping ---
+ice_ave_steps  = 1              ! ice time step = ice_ave_steps × ocean time step
 /
 
+! ============================================================================
+! SEA ICE THERMODYNAMICS
+! ============================================================================
 &ice_therm
-Sice=4.0               ! Ice salinity 3.2--5.0 ppt.
-h0=.5                  ! Lead closing parameter [m] 
-emiss_ice=0.97         ! Emissivity of Snow/Ice,
-emiss_wat=0.97         ! Emissivity of open water
-albsn=0.81             ! Albedo: frozen snow
-albsnm=0.77            !         melting snow
-albi=0.7               !         frozen ice
-albim=0.68             !         melting ice
-albw=0.1               !         open water
-con=2.1656             ! Thermal conductivities: ice; W/m/K
-consn=0.31             !                         snow
+! --- Ice Properties ---
+Sice           = 4.0            ! bulk ice salinity [ppt] (typical range: 3.2-5.0)
+
+! --- Lead Closing Parameters ---
+h0             = 0.5            ! lead closing parameter for Northern Hemisphere [m]
+
+! --- Emissivity (Longwave Radiation) ---
+emiss_ice      = 0.97           ! emissivity of snow/ice surface (dimensionless, 0-1)
+emiss_wat      = 0.97           ! emissivity of open water (dimensionless, 0-1)
+
+! --- Albedo (Shortwave Radiation) ---
+albsn             = 0.81           ! albedo of frozen snow (dimensionless, 0-1)
+albsnm            = 0.77           ! albedo of melting snow (dimensionless, 0-1)
+albi              = 0.7            ! albedo of frozen ice (dimensionless, 0-1)
+albim             = 0.68           ! albedo of melting ice (dimensionless, 0-1)
+albw              = 0.1            ! albedo of open water (dimensionless, 0-1)
+
+! --- Thermal Conductivity ---
+con            = 2.1656         ! thermal conductivity of ice [W/m/K]
+consn          = 0.31           ! thermal conductivity of snow [W/m/K]
 /

--- a/config/bin_2p3z2d/namelist.icepack
+++ b/config/bin_2p3z2d/namelist.icepack
@@ -1,4 +1,23 @@
-&env_nml                    ! In the original release these variables are defined in the icepack.settings
+! ============================================================================
+! =============== Namelist file for FESOM2 Icepack sea ice ===================
+! ============================================================================
+! This file contains configuration for the Icepack column physics package,
+! used when FESOM2 is built with Icepack (see docs/icepack_in_fesom.rst):
+! - Tracer array sizes and switches
+! - Ice thickness distribution and thermodynamics
+! - Shortwave radiation and albedo
+! - Melt ponds
+! - Surface forcing options
+! - Ridging and ice strength
+! - Icepack output variables
+! ============================================================================
+
+! ============================================================================
+! ENVIRONMENT (ARRAY SIZES)
+! ============================================================================
+! In the original Icepack release these are set in icepack.settings.
+! ============================================================================
+&env_nml
     nicecat   = 5           ! number of ice thickness categories
     nfsdcat   = 1           ! number of floe size categories
     nicelyr   = 4           ! number of vertical layers in the ice
@@ -6,110 +25,160 @@
     ntraero   = 0           ! number of aerosol tracers (up to max_aero in ice_domain_size.F90)
     trzaero   = 0           ! number of z aerosol tracers (up to max_aero = 6)
     tralg     = 0           ! number of algal tracers (up to max_algae = 3)
-    trdoc     = 0           ! number of dissolve organic carbon (up to max_doc = 3)
-    trdic     = 0           ! number of dissolve inorganic carbon (up to max_dic = 1)
-    trdon     = 0           ! number of dissolve organic nitrogen (up to max_don = 1)
-    trfed     = 0           ! number of dissolved iron tracers (up to max_fe  = 2)
-    trfep     = 0           ! number of particulate iron tracers (up to max_fe  = 2)
+    trdoc     = 0           ! number of dissolved organic carbon tracers (up to max_doc = 3)
+    trdic     = 0           ! number of dissolved inorganic carbon tracers (up to max_dic = 1)
+    trdon     = 0           ! number of dissolved organic nitrogen tracers (up to max_don = 1)
+    trfed     = 0           ! number of dissolved iron tracers (up to max_fe = 2)
+    trfep     = 0           ! number of particulate iron tracers (up to max_fe = 2)
     nbgclyr   = 0           ! number of zbgc layers
-    trbgcz    = 0           ! set to 1 for zbgc tracers (needs TRBGCS = 0 and TRBRI = 1)
-    trzs      = 0           ! set to 1 for zsalinity tracer (needs TRBRI = 1)
+    trbgcz    = 0           ! set to 1 for zbgc tracers (needs trbgcs = 0 and trbri = 1)
+    trzs      = 0           ! set to 1 for zsalinity tracer (needs trbri = 1)
     trbri     = 0           ! set to 1 for brine height tracer
     trage     = 0           ! set to 1 for ice age tracer
     trfy      = 0           ! set to 1 for first-year ice area tracer
     trlvl     = 0           ! set to 1 for level and deformed ice tracers
     trpnd     = 0           ! set to 1 for melt pond tracers
-    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs TRBGCZ = 0)
+    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs trbgcz = 0)
     ndtd      = 1           ! dynamic time steps per thermodynamic time step
 /
 
+! ============================================================================
+! ICE THICKNESS CATEGORIES
+! ============================================================================
 &grid_nml
-    kcatbound    = 1
+    kcatbound    = 1        ! category boundary formula:
+                            !   -1 = single category (column configurations, nicecat = 1)
+                            !    0 = old formula, 1 = new formula with round numbers
+                            !    2 = WMO standard categories (nicecat = 5, 6 or 7 only)
+                            !    3 = asymptotic scheme
 /
 
+! ============================================================================
+! TRACER SWITCHES
+! ============================================================================
+! Any melt pond scheme with calc_Tsfc = .true. needs shortwave = 'dEdd'.
+! ============================================================================
 &tracer_nml
-    tr_iage      = .false.
-    tr_FY        = .false.
-    tr_lvl       = .false.
-    tr_pond_cesm = .false.
-    tr_pond_topo = .false.
-    tr_pond_lvl  = .false.
-    tr_aero      = .false.
-    tr_fsd       = .false.
+    tr_iage      = .false.  ! ice age tracer
+    tr_FY        = .false.  ! first-year ice area tracer
+    tr_lvl       = .false.  ! level (undeformed) ice area and volume tracers
+    tr_pond_cesm = .false.  ! CESM melt pond scheme
+    tr_pond_topo = .false.  ! topographic melt pond scheme
+    tr_pond_lvl  = .false.  ! level-ice melt pond scheme (needs tr_lvl, forces hs0 = 0)
+    tr_aero      = .false.  ! aerosol tracers (needs shortwave = 'dEdd')
+    tr_fsd       = .false.  ! floe size distribution
 /
 
+! ============================================================================
+! THERMODYNAMICS
+! ============================================================================
 &thermo_nml
-    kitd              = 1
-    ktherm            = 1
-    conduct           = 'bubbly'
-    a_rapid_mode      =  0.5e-3
-    Rac_rapid_mode    =    10.0
-    aspect_rapid_mode =     1.0
-    dSdt_slow_mode    = -5.0e-8
-    phi_c_slow_mode   =    0.05
-    phi_i_mushy       =    0.85
-    ksno              = 0.3
+! --- Thickness Distribution and Thermodynamics Scheme ---
+    kitd              = 1           ! ice thickness distribution: 0 = delta function, 1 = linear remapping
+    ktherm            = 1           ! thermodynamics: 1 = Bitz & Lipscomb (1999), 2 = mushy layer
+                                    ! ktherm = 1 expects tfrz_option = 'linear_salt',
+                                    ! ktherm = 2 expects tfrz_option = 'mushy' and calc_Tsfc = .true.
+    conduct           = 'bubbly'    ! ice thermal conductivity (ktherm = 1):
+                                    !   'MU71' = Maykut & Untersteiner (1971), 'bubbly' = Pringle et al. (2007)
+
+! --- Mushy Layer Brine Drainage (ktherm = 2) ---
+    a_rapid_mode      =  0.5e-3     ! brine channel diameter [m]
+    Rac_rapid_mode    =    10.0     ! critical Rayleigh number for rapid drainage
+    aspect_rapid_mode =     1.0     ! brine convection aspect ratio
+    dSdt_slow_mode    = -5.0e-8     ! slow drainage strength parameter [m/(s K)]
+    phi_c_slow_mode   =    0.05     ! critical liquid fraction for slow drainage
+    phi_i_mushy       =    0.85     ! solid fraction at the lower ice boundary
+
+! --- Snow ---
+    ksno              = 0.3         ! thermal conductivity of snow [W/(m K)]
 /
 
+! ============================================================================
+! SHORTWAVE RADIATION AND ALBEDO
+! ============================================================================
 &shortwave_nml
-    shortwave       = 'ccsm3'
-    albedo_type     = 'ccsm3'
-    albicev         = 0.78
-    albicei         = 0.36
-    albsnowv        = 0.98
-    albsnowi        = 0.70
-    albocn          = 0.1
-    ahmax           = 0.3
-    R_ice           = 0.
-    R_pnd           = 0.
-    R_snw           = 1.5
-    dT_mlt          = 1.5
-    rsnw_mlt        = 1500.
-    kalg            = 0.6
+! --- Scheme Selection ---
+    shortwave       = 'ccsm3'   ! shortwave scheme: 'ccsm3' (bulk albedo) or 'dEdd' (Delta-Eddington)
+    albedo_type     = 'ccsm3'   ! albedo parameterization with shortwave = 'ccsm3': 'ccsm3' or 'constant'
+
+! --- Bulk Albedos (shortwave = 'ccsm3') ---
+    albicev         = 0.78      ! visible albedo of thick bare ice
+    albicei         = 0.36      ! near-infrared albedo of thick bare ice
+    albsnowv        = 0.98      ! visible albedo of cold snow
+    albsnowi        = 0.70      ! near-infrared albedo of cold snow
+    albocn          = 0.1       ! ocean albedo
+    ahmax           = 0.3       ! ice thickness above which the albedo is constant [m]
+
+! --- Delta-Eddington Tuning (shortwave = 'dEdd') ---
+    R_ice           = 0.        ! sea ice albedo tuning [standard deviations]
+    R_pnd           = 0.        ! melt pond albedo tuning [standard deviations]
+    R_snw           = 1.5       ! snow grain radius tuning [standard deviations]
+    dT_mlt          = 1.5       ! temperature change that gives rsnw_mlt [deg C]
+    rsnw_mlt        = 1500.     ! maximum melting snow grain radius [micrometres]
+    kalg            = 0.6       ! absorption coefficient for algae
 /
 
+! ============================================================================
+! MELT PONDS
+! ============================================================================
 &ponds_nml
-    hp1             = 0.01
-    hs0             = 0.
-    hs1             = 0.03
-    dpscale         = 1.e-3
-    frzpnd          = 'hlid'
-    rfracmin        = 0.15
-    rfracmax        = 1.
-    pndaspect       = 0.8
+    hp1             = 0.01      ! critical parameter for pond ice thickness [m]
+    hs0             = 0.        ! snow depth for transition to bare sea ice [m]
+    hs1             = 0.03      ! snow depth for transition to pond ice [m] (tr_pond_lvl)
+    dpscale         = 1.e-3     ! time scale for flushing in permeable ice (not used with tr_pond_cesm)
+    frzpnd          = 'hlid'    ! pond refreezing: 'cesm' or 'hlid' (Stefan refreezing with a pond ice lid)
+    rfracmin        = 0.15      ! minimum fraction of melt water added to ponds
+    rfracmax        = 1.        ! maximum fraction of melt water added to ponds
+    pndaspect       = 0.8       ! aspect ratio of pond changes (depth:area)
 /
 
+! ============================================================================
+! SURFACE FORCING OPTIONS
+! ============================================================================
 &forcing_nml
-    formdrag        = .false.
-    atmbndy         = 'default'
-    calc_strair     = .true.
-    calc_Tsfc       = .true.
-    highfreq        = .false.
-    natmiter        = 5
-    ustar_min       = 0.0005
-    emissivity      = 0.95
-    fbot_xfer_type  = 'constant'
-    update_ocn_f    = .false.
-    l_mpond_fresh   = .false.
-    tfrz_option     = 'linear_salt'
-    oceanmixed_ice  = .true.
-    wave_spec_type  = 'none'
+! --- Atmosphere-Ice Exchange ---
+    formdrag        = .false.       ! calculate form drag (needs calc_strair and tr_lvl, not atmbndy = 'constant')
+    atmbndy         = 'default'     ! atmospheric boundary layer: 'default' (stability dependent) or 'constant'
+    calc_strair     = .true.        ! calculate the wind stress in Icepack instead of reading it
+    calc_Tsfc       = .true.        ! calculate the surface temperature in Icepack instead of reading it
+    highfreq        = .false.       ! high-frequency atmosphere-ice coupling (Roberts et al. 2015)
+    natmiter        = 5             ! number of iterations for the atmospheric boundary layer fluxes
+    emissivity      = 0.95          ! emissivity of snow and ice
+
+! --- Ice-Ocean Exchange ---
+    ustar_min       = 0.0005        ! minimum friction velocity for the ice-ocean heat flux [m/s]
+    fbot_xfer_type  = 'constant'    ! ice-ocean heat transfer coefficient: 'constant' or 'Cdn_ocn' (needs formdrag)
+    update_ocn_f    = .false.       ! include frazil ice fluxes in the ocean flux fields
+    l_mpond_fresh   = .false.       ! retain (topo) pond water until the ponds drain
+    tfrz_option     = 'linear_salt' ! seawater freezing temperature: 'minus1p8', 'linear_salt' or 'mushy'
+    oceanmixed_ice  = .true.        ! active ocean mixed layer calculation in Icepack
+
+! --- Waves ---
+    wave_spec_type  = 'none'        ! wave spectrum for the floe size distribution: 'none', 'constant' or 'random'
 /
 
+! ============================================================================
+! RIDGING AND ICE STRENGTH
+! ============================================================================
 &dynamics_nml
-    kstrength       = 1
-    krdg_partic     = 1
-    krdg_redist     = 1
-    mu_rdg          = 3
-    Cf              = 17.
-    P_star          = 27000.
-    C_star          = 20.
+    kstrength       = 1         ! ice strength formulation: 0 = Hibler (1979), 1 = Rothrock (1975)
+    krdg_partic     = 1         ! ridging participation function: 0 = Thorndike et al. (1975), 1 = exponential
+    krdg_redist     = 1         ! ridging redistribution function: 0 = Hibler (1980), 1 = exponential
+    mu_rdg          = 3         ! e-folding scale of ridged ice [m^0.5] (krdg_redist = 1)
+    Cf              = 17.       ! ratio of ridging work to change in potential energy (kstrength = 1)
+    P_star          = 27000.    ! ice strength parameter [N/m²] (kstrength = 0)
+    C_star          = 20.       ! ice strength decay constant [dimensionless] (kstrength = 0)
 /
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!!!!!!!!!                Icepack output namelist                    !!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
+! ============================================================================
+! ICEPACK OUTPUT VARIABLES
+! ============================================================================
+! Format: 'variable_id', frequency, unit, precision
+!   frequency  = output frequency (integer)
+!   unit       = 'y' (yearly), 'm' (monthly), 'd' (daily), 'h' (hourly), 's' (steps)
+!   precision  = 4 (single precision) or 8 (double precision)
+! Remove the leading '!' to enable a variable.
+! ============================================================================
 &nml_list_icepack
 io_list_icepack =  'aicen     ',1, 'm', 4, ! Sea ice concentration
                    'vicen     ',1, 'm', 4, ! Volume per unit area of ice

--- a/config/bin_2p3z2d/namelist.icepack.cesm.ponds
+++ b/config/bin_2p3z2d/namelist.icepack.cesm.ponds
@@ -1,4 +1,23 @@
-&env_nml                    ! In the original release these variables are defined in the icepack.settings
+! ============================================================================
+! =============== Namelist file for FESOM2 Icepack sea ice ===================
+! ============================================================================
+! This file contains configuration for the Icepack column physics package,
+! used when FESOM2 is built with Icepack (see docs/icepack_in_fesom.rst):
+! - Tracer array sizes and switches
+! - Ice thickness distribution and thermodynamics
+! - Shortwave radiation and albedo
+! - Melt ponds
+! - Surface forcing options
+! - Ridging and ice strength
+! - Icepack output variables
+! ============================================================================
+
+! ============================================================================
+! ENVIRONMENT (ARRAY SIZES)
+! ============================================================================
+! In the original Icepack release these are set in icepack.settings.
+! ============================================================================
+&env_nml
     nicecat   = 5           ! number of ice thickness categories
     nfsdcat   = 1           ! number of floe size categories
     nicelyr   = 4           ! number of vertical layers in the ice
@@ -6,108 +25,156 @@
     ntraero   = 0           ! number of aerosol tracers (up to max_aero in ice_domain_size.F90)
     trzaero   = 0           ! number of z aerosol tracers (up to max_aero = 6)
     tralg     = 0           ! number of algal tracers (up to max_algae = 3)
-    trdoc     = 0           ! number of dissolve organic carbon (up to max_doc = 3)
-    trdic     = 0           ! number of dissolve inorganic carbon (up to max_dic = 1)
-    trdon     = 0           ! number of dissolve organic nitrogen (up to max_don = 1)
-    trfed     = 0           ! number of dissolved iron tracers (up to max_fe  = 2)
-    trfep     = 0           ! number of particulate iron tracers (up to max_fe  = 2)
+    trdoc     = 0           ! number of dissolved organic carbon tracers (up to max_doc = 3)
+    trdic     = 0           ! number of dissolved inorganic carbon tracers (up to max_dic = 1)
+    trdon     = 0           ! number of dissolved organic nitrogen tracers (up to max_don = 1)
+    trfed     = 0           ! number of dissolved iron tracers (up to max_fe = 2)
+    trfep     = 0           ! number of particulate iron tracers (up to max_fe = 2)
     nbgclyr   = 0           ! number of zbgc layers
-    trbgcz    = 0           ! set to 1 for zbgc tracers (needs TRBGCS = 0 and TRBRI = 1)
-    trzs      = 0           ! set to 1 for zsalinity tracer (needs TRBRI = 1)
+    trbgcz    = 0           ! set to 1 for zbgc tracers (needs trbgcs = 0 and trbri = 1)
+    trzs      = 0           ! set to 1 for zsalinity tracer (needs trbri = 1)
     trbri     = 0           ! set to 1 for brine height tracer
     trage     = 0           ! set to 1 for ice age tracer
     trfy      = 0           ! set to 1 for first-year ice area tracer
     trlvl     = 0           ! set to 1 for level and deformed ice tracers
     trpnd     = 1           ! set to 1 for melt pond tracers
-    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs TRBGCZ = 0)
+    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs trbgcz = 0)
     ndtd      = 1           ! dynamic time steps per thermodynamic time step
 /
 
+! ============================================================================
+! ICE THICKNESS CATEGORIES
+! ============================================================================
 &grid_nml
-    kcatbound    = 1
+    kcatbound    = 1        ! category boundary formula:
+                            !   -1 = single category (column configurations, nicecat = 1)
+                            !    0 = old formula, 1 = new formula with round numbers
+                            !    2 = WMO standard categories (nicecat = 5, 6 or 7 only)
+                            !    3 = asymptotic scheme
 /
 
+! ============================================================================
+! TRACER SWITCHES
+! ============================================================================
+! Any melt pond scheme with calc_Tsfc = .true. needs shortwave = 'dEdd'.
+! ============================================================================
 &tracer_nml
-    tr_iage      = .false.
-    tr_FY        = .false.
-    tr_lvl       = .false.
-    tr_pond_cesm = .true.
-    tr_pond_topo = .false.
-    tr_pond_lvl  = .false.
-    tr_aero      = .false.
-    tr_fsd       = .false.
+    tr_iage      = .false.  ! ice age tracer
+    tr_FY        = .false.  ! first-year ice area tracer
+    tr_lvl       = .false.  ! level (undeformed) ice area and volume tracers
+    tr_pond_cesm = .true.   ! CESM melt pond scheme
+    tr_pond_topo = .false.  ! topographic melt pond scheme
+    tr_pond_lvl  = .false.  ! level-ice melt pond scheme (needs tr_lvl, forces hs0 = 0)
+    tr_aero      = .false.  ! aerosol tracers (needs shortwave = 'dEdd')
+    tr_fsd       = .false.  ! floe size distribution
 /
 
+! ============================================================================
+! THERMODYNAMICS
+! ============================================================================
 &thermo_nml
-    kitd              = 1
-    ktherm            = 1
-    conduct           = 'bubbly'
-    a_rapid_mode      =  0.5e-3
-    Rac_rapid_mode    =    10.0
-    aspect_rapid_mode =     1.0
-    dSdt_slow_mode    = -5.0e-8
-    phi_c_slow_mode   =    0.05
-    phi_i_mushy       =    0.85
+! --- Thickness Distribution and Thermodynamics Scheme ---
+    kitd              = 1           ! ice thickness distribution: 0 = delta function, 1 = linear remapping
+    ktherm            = 1           ! thermodynamics: 1 = Bitz & Lipscomb (1999), 2 = mushy layer
+                                    ! ktherm = 1 expects tfrz_option = 'linear_salt',
+                                    ! ktherm = 2 expects tfrz_option = 'mushy' and calc_Tsfc = .true.
+    conduct           = 'bubbly'    ! ice thermal conductivity (ktherm = 1):
+                                    !   'MU71' = Maykut & Untersteiner (1971), 'bubbly' = Pringle et al. (2007)
+
+! --- Mushy Layer Brine Drainage (ktherm = 2) ---
+    a_rapid_mode      =  0.5e-3     ! brine channel diameter [m]
+    Rac_rapid_mode    =    10.0     ! critical Rayleigh number for rapid drainage
+    aspect_rapid_mode =     1.0     ! brine convection aspect ratio
+    dSdt_slow_mode    = -5.0e-8     ! slow drainage strength parameter [m/(s K)]
+    phi_c_slow_mode   =    0.05     ! critical liquid fraction for slow drainage
+    phi_i_mushy       =    0.85     ! solid fraction at the lower ice boundary
 /
 
+! ============================================================================
+! SHORTWAVE RADIATION AND ALBEDO
+! ============================================================================
 &shortwave_nml
-    shortwave       = 'dEdd'
-    albedo_type     = 'ccsm3'
-    albicev         = 0.78
-    albicei         = 0.36
-    albsnowv        = 0.98
-    albsnowi        = 0.70
-    ahmax           = 0.3
-    R_ice           = 0.
-    R_pnd           = 0.
-    R_snw           = 1.5
-    dT_mlt          = 1.5
-    rsnw_mlt        = 1500.
-    kalg            = 0.6
+! --- Scheme Selection ---
+    shortwave       = 'dEdd'    ! shortwave scheme: 'ccsm3' (bulk albedo) or 'dEdd' (Delta-Eddington)
+    albedo_type     = 'ccsm3'   ! albedo parameterization with shortwave = 'ccsm3': 'ccsm3' or 'constant'
+
+! --- Bulk Albedos (shortwave = 'ccsm3') ---
+    albicev         = 0.78      ! visible albedo of thick bare ice
+    albicei         = 0.36      ! near-infrared albedo of thick bare ice
+    albsnowv        = 0.98      ! visible albedo of cold snow
+    albsnowi        = 0.70      ! near-infrared albedo of cold snow
+    ahmax           = 0.3       ! ice thickness above which the albedo is constant [m]
+
+! --- Delta-Eddington Tuning (shortwave = 'dEdd') ---
+    R_ice           = 0.        ! sea ice albedo tuning [standard deviations]
+    R_pnd           = 0.        ! melt pond albedo tuning [standard deviations]
+    R_snw           = 1.5       ! snow grain radius tuning [standard deviations]
+    dT_mlt          = 1.5       ! temperature change that gives rsnw_mlt [deg C]
+    rsnw_mlt        = 1500.     ! maximum melting snow grain radius [micrometres]
+    kalg            = 0.6       ! absorption coefficient for algae
 /
 
+! ============================================================================
+! MELT PONDS
+! ============================================================================
 &ponds_nml
-    hp1             = 0.01
-    hs0             = 0.
-    hs1             = 0.03
-    dpscale         = 1.e-3
-    frzpnd          = 'hlid'
-    rfracmin        = 0.15
-    rfracmax        = 1.
-    pndaspect       = 0.8
+    hp1             = 0.01      ! critical parameter for pond ice thickness [m]
+    hs0             = 0.        ! snow depth for transition to bare sea ice [m]
+    hs1             = 0.03      ! snow depth for transition to pond ice [m] (tr_pond_lvl)
+    dpscale         = 1.e-3     ! time scale for flushing in permeable ice (not used with tr_pond_cesm)
+    frzpnd          = 'hlid'    ! pond refreezing: 'cesm' or 'hlid' (Stefan refreezing with a pond ice lid)
+    rfracmin        = 0.15      ! minimum fraction of melt water added to ponds
+    rfracmax        = 1.        ! maximum fraction of melt water added to ponds
+    pndaspect       = 0.8       ! aspect ratio of pond changes (depth:area)
 /
 
+! ============================================================================
+! SURFACE FORCING OPTIONS
+! ============================================================================
 &forcing_nml
-    formdrag        = .false.
-    atmbndy         = 'default'
-    calc_strair     = .true.
-    calc_Tsfc       = .true.
-    highfreq        = .false.
-    natmiter        = 5
-    ustar_min       = 0.0005
-    emissivity      = 0.95
-    fbot_xfer_type  = 'constant'
-    update_ocn_f    = .false.
-    l_mpond_fresh   = .false.
-    tfrz_option     = 'linear_salt'
-    oceanmixed_ice  = .true.
-    wave_spec_type  = 'none'
+! --- Atmosphere-Ice Exchange ---
+    formdrag        = .false.       ! calculate form drag (needs calc_strair and tr_lvl, not atmbndy = 'constant')
+    atmbndy         = 'default'     ! atmospheric boundary layer: 'default' (stability dependent) or 'constant'
+    calc_strair     = .true.        ! calculate the wind stress in Icepack instead of reading it
+    calc_Tsfc       = .true.        ! calculate the surface temperature in Icepack instead of reading it
+    highfreq        = .false.       ! high-frequency atmosphere-ice coupling (Roberts et al. 2015)
+    natmiter        = 5             ! number of iterations for the atmospheric boundary layer fluxes
+    emissivity      = 0.95          ! emissivity of snow and ice
+
+! --- Ice-Ocean Exchange ---
+    ustar_min       = 0.0005        ! minimum friction velocity for the ice-ocean heat flux [m/s]
+    fbot_xfer_type  = 'constant'    ! ice-ocean heat transfer coefficient: 'constant' or 'Cdn_ocn' (needs formdrag)
+    update_ocn_f    = .false.       ! include frazil ice fluxes in the ocean flux fields
+    l_mpond_fresh   = .false.       ! retain (topo) pond water until the ponds drain
+    tfrz_option     = 'linear_salt' ! seawater freezing temperature: 'minus1p8', 'linear_salt' or 'mushy'
+    oceanmixed_ice  = .true.        ! active ocean mixed layer calculation in Icepack
+
+! --- Waves ---
+    wave_spec_type  = 'none'        ! wave spectrum for the floe size distribution: 'none', 'constant' or 'random'
 /
 
+! ============================================================================
+! RIDGING AND ICE STRENGTH
+! ============================================================================
 &dynamics_nml
-    kstrength       = 1
-    krdg_partic     = 1
-    krdg_redist     = 1
-    mu_rdg          = 3
-    Cf              = 17.
-    P_star          = 27000.
-    C_star          = 20.
+    kstrength       = 1         ! ice strength formulation: 0 = Hibler (1979), 1 = Rothrock (1975)
+    krdg_partic     = 1         ! ridging participation function: 0 = Thorndike et al. (1975), 1 = exponential
+    krdg_redist     = 1         ! ridging redistribution function: 0 = Hibler (1980), 1 = exponential
+    mu_rdg          = 3         ! e-folding scale of ridged ice [m^0.5] (krdg_redist = 1)
+    Cf              = 17.       ! ratio of ridging work to change in potential energy (kstrength = 1)
+    P_star          = 27000.    ! ice strength parameter [N/m²] (kstrength = 0)
+    C_star          = 20.       ! ice strength decay constant [dimensionless] (kstrength = 0)
 /
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!!!!!!!!!                Icepack output namelist                    !!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
+! ============================================================================
+! ICEPACK OUTPUT VARIABLES
+! ============================================================================
+! Format: 'variable_id', frequency, unit, precision
+!   frequency  = output frequency (integer)
+!   unit       = 'y' (yearly), 'm' (monthly), 'd' (daily), 'h' (hourly), 's' (steps)
+!   precision  = 4 (single precision) or 8 (double precision)
+! Remove the leading '!' to enable a variable.
+! ============================================================================
 &nml_list_icepack
 io_list_icepack =  'aicen     ',1, 'm', 4, ! Sea ice concentration
                    'vicen     ',1, 'm', 4, ! Volume per unit area of ice

--- a/config/bin_2p3z2d/namelist.io
+++ b/config/bin_2p3z2d/namelist.io
@@ -51,6 +51,10 @@ compression_level = 1        ! compression level for netCDF output (1=fastest, 9
 !   frequency  = output frequency (integer)
 !   unit       = 'y' (yearly), 'm' (monthly), 'd' (daily), 'h' (hourly), 's' (steps)
 !   precision  = 4 (single precision) or 8 (double precision)
+!   Note: in a single-precision build (WP=4) a field requesting precision 8 is
+!   still honoured (written as NF_DOUBLE; means accumulated in real64), but its
+!   samples are single-precision-sourced. FESOM prints one summary line at
+!   startup listing such fields.
 ! ============================================================================
 &nml_list
 io_list =  'sst       ',6, 'h', 4,
@@ -282,9 +286,9 @@ io_list =  'sst       ',6, 'h', 4,
 ! 'respn     ',1, 'm', 4,  ! Respiration by small phytoplankton [mmolC/m2/d]
 ! 'respd     ',1, 'm', 4,  ! Respiration by diatoms [mmolC/m2/d]
 ! 'respc     ',1, 'm', 4,  ! Respiration by coccolithophores [mmolC/(m2*d)]
-! 'NPPn3D    ',1, 'm', 4,  ! Net primary production of small phytoplankton [mmolC/m2/d]
-! 'NPPd3D    ',1, 'm', 4,  ! Net primary production of diatoms [mmolC/m2/d]
-! 'NPPc3D    ',1, 'm', 4,  ! Net primary production of coccolithophores [mmolC/m2/d]
+! 'NPPn3D    ',1, 'm', 4,  ! Net primary production of small phytoplankton [mmolC/(m3*d)]
+! 'NPPd3D    ',1, 'm', 4,  ! Net primary production of diatoms [mmolC/(m3*d)]
+! 'NPPc3D    ',1, 'm', 4,  ! Net primary production of coccolithophores [mmolC/(m3*d)]
 
 ! --- WATER ISOTOPES IN OCEAN (require lwiso=.true.) ---
 ! 'h2o18     ',1, 'm', 4,  ! h2o18 concentration [kmol/m**3]

--- a/config/bin_2p3z2d/namelist.oce
+++ b/config/bin_2p3z2d/namelist.oce
@@ -25,7 +25,7 @@ SPP                = .false. ! enable Salt Plume Parameterization (for brine rej
 ! --- Gent-McWilliams (GM) Eddy Parameterization ---
 Fer_GM             = .true.  ! to swith on/off GM after Ferrari et al. 2010
 K_GM_max           = 1000.0  ! max. GM thickness diffusivity (m2/s)
-K_GM_min           = 2.0     ! max. GM thickness diffusivity (m2/s)
+K_GM_min           = 2.0     ! min. GM thickness diffusivity (m2/s)
 K_GM_bvref         = 1       ! def of bvref in ferreira scaling 0=srf,1=bot mld,2=mean over mld,3=weighted mean over mld
 K_GM_rampmax       = -1.0    ! Resol >K_GM_rampmax[km] GM on
 K_GM_rampmin       = -1.0    ! Resol <K_GM_rampmin[km] GM off, in between linear scaled down
@@ -74,3 +74,57 @@ concv              = 1.6     ! constant for pure convection (eq. 23 in Large et 
 ! --- Tidal Forcing ---
 use_global_tides   = .false. ! enable global tidal potential forcing
 /
+
+! ===================================================================
+! Initial condition perturbation settings
+! ===================================================================
+! This section controls random perturbation of initial temperature
+! and salinity fields. Useful for ensemble modeling and uncertainty
+! quantification.
+!
+! lperturb       : Enable/disable perturbation (.true./.false.)
+! perturb_mode   : When to apply perturbations
+!                  'initial_only' - Apply only during initial runs (not restarts)
+!                  'first_step'   - Apply during first time step (initial or restart)
+! perturb_method : Type of random distribution
+!                  'uniform'   - Uniform distribution between [min_val, max_val]
+!                  'gaussian'  - Gaussian distribution with mean=min_val, std_dev=max_val
+! perturb_seed   : Random seed for reproducible perturbations
+!                  -1 = use system time (different each run)
+!                  >0 = use specified seed (reproducible)
+! temp_perturb   : Temperature perturbation parameters
+!                  For uniform: [min_val, max_val] in Kelvin
+!                  For gaussian: [mean(=0.0), std_dev] in Kelvin
+! salt_perturb   : Salinity perturbation parameters
+!                  For uniform: [min_val, max_val] in PSU
+!                  For gaussian: [mean(=0.0), std_dev] in PSU
+!
+! Example for ensemble forecasting with Gaussian perturbations:
+!&oce_perturb
+!lperturb       = .true.
+!perturb_mode   = 'first_step'
+!perturb_method = 'gaussian'
+!perturb_seed   = 12345
+!temp_perturb   = 0.0, 1.D-13
+!salt_perturb   = 0.0, 2.D-13
+!/
+!
+! Example for sensitivity study with uniform perturbations:
+!&oce_perturb
+!lperturb       = .true.
+!perturb_mode   = 'initial_only'
+!perturb_method = 'uniform'
+!perturb_seed   = -1
+!temp_perturb   = -1.D-12, 1.D-12
+!salt_perturb   = -2.D-12, 2.D-12
+!/
+
+! Default behavior (no perturbations):
+!&oce_perturb
+!lperturb       = .false.
+!perturb_mode   = 'initial_only'
+!perturb_method = 'uniform'
+!perturb_seed   = -1
+!temp_perturb   = 0.0, 0.0
+!salt_perturb   = 0.0, 0.0
+!/

--- a/config/bin_2p3z2d/namelist.recom
+++ b/config/bin_2p3z2d/namelist.recom
@@ -1,360 +1,510 @@
-! This is the namelist file for recom
+! ============================================================================
+! ============ Namelist file for FESOM2 REcoM biogeochemistry ================
+! ============================================================================
+! This file contains configuration for the REcoM biogeochemical model:
+! - Surface boundary condition input files
+! - Model switches, tracer counts and sinking
+! - Phytoplankton, zooplankton and detritus parameters
+! - Carbonate chemistry, iron, calcite and benthos
+! - Ballasting and carbon isotopes
+!
+! Phytoplankton parameters come in sets: no suffix = small phytoplankton,
+! _d = diatoms, _c = coccolithophores, _p = Phaeocystis (where present).
+! Zooplankton: first = mesozooplankton, second (suffix 2) = macrozooplankton,
+! third (suffix 3) = microzooplankton.
+! ============================================================================
 
+! ============================================================================
+! SURFACE BOUNDARY CONDITION FILES
+! ============================================================================
+! Relative names of the dust, aeolian nitrogen and CO2 files are taken from
+! ClimateDataPath; the river and erosion files are used as given.
+! ============================================================================
 &nam_rsbc
-fe_data_source        ='Albani'
-nm_fe_data_file       ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/DustClimMonthlyAlbani.nc'
-nm_aen_data_file      ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/AeolianNitrogenDep.nc'
-nm_river_data_file    ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/RiverineInput.nc'
-nm_erosion_data_file  ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/ErosionInput.nc'
-nm_co2_data_file      ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/MonthlyAtmCO2_gcb2023.nc'
+fe_data_source        = 'Albani'    ! 'Albani' reads nm_fe_data_file; any other value switches the Albani dust input off
+nm_fe_data_file       = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/DustClimMonthlyAlbani.nc'
+                                    ! monthly dust deposition climatology (Albani)
+nm_aen_data_file      = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/AeolianNitrogenDep.nc'
+                                    ! aeolian nitrogen deposition (useAeolianN)
+nm_river_data_file    = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/RiverineInput.nc'
+                                    ! riverine nutrient input (useRivers)
+nm_erosion_data_file  = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/ErosionInput.nc'
+                                    ! input from erosion (useErosion)
+nm_co2_data_file      = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/MonthlyAtmCO2_gcb2023.nc'
+                                    ! atmospheric CO2 time series, read when constant_CO2 = .false.
 /
 
+! ============================================================================
+! TRACER SET
+! ============================================================================
+! bgc_num in &pavariables is checked against these switches at startup.
+! ============================================================================
 &parecomsetup
-enable_3zoo2det = .true.
-enable_coccos = .false.
+enable_3zoo2det       = .true.      ! three zooplankton groups and two detritus classes instead of one each
+enable_coccos         = .false.     ! coccolithophore and Phaeocystis tracers
 /
 
+! ============================================================================
+! MODEL SWITCHES, TRACER COUNTS AND SINKING
+! ============================================================================
 &pavariables
-use_REcoM             =.true.
-REcoM_restart         =.true.
+! --- Main Switches ---
+use_REcoM             = .true.      ! switch REcoM on
+REcoM_restart         = .true.      ! read the REcoM tracers from the restart (false = initialize from climatology)
+recom_debug           = .false.     ! extra REcoM debug output
+Diags                 = .true.      ! compute REcoM diagnostics
 
-bgc_num               = 31 !24 !38 !22
-diags3d_num           = 28          ! Number of diagnostic 3d tracers to be saved
-bgc_base_num          = 22          ! standard tracers
-VDet                  = 20.d0       ! Sinking velocity, constant through the water column and positive downwards
-VDet_zoo2             = 200.d0      ! Sinking velocity, constant through the water column
-VPhy                  = 0.d0        !!! If the number of sinking velocities are different from 3, code needs to be changed !!!
-VDia                  = 0.d0
-VCocco	       	      = 0.d0       
-allow_var_sinking     = .true.   
-biostep               = 1           ! Number of times biology should be stepped forward for each time step		 
-REcoM_Geider_limiter  = .false.     ! Decides what routine should be used to calculate limiters in sms
-REcoM_Grazing_Variable_Preference = .true. ! Decides if grazing should have preference for phyN or DiaN 
-Grazing_detritus      = .true.
-het_resp_noredfield   = .true.    ! Decides respiratation of copepod group
-diatom_mucus          = .true.    ! Decides nutrient limitation effect on aggregation
-O2dep_remin           = .true.    ! O2remin Add option for O2 dependency of organic matter remineralization
-use_ballasting        = .true.    
-use_density_scaling   = .true.   
-use_viscosity_scaling = .true.    
-OmegaC_diss           = .false.    ! Use OmegaC from Mocsy to compute calcite dissolution (after Aumont et al. 2015 and Gehlen et al. 2007) -> set calc_diss_guts to zero if this is false!!!!
-CO2lim                = .true.    ! CO2 dependence of growth and calcification
-Diags                 = .true.
-constant_CO2          = .true.
-UseFeDust             = .true.      ! Turns dust input of iron off when set to.false.
-UseDustClim           = .true.
-UseDustClimAlbani     = .true.     ! Use Albani dustclim field (If it is false Mahowald will be used)
-use_photodamage       = .true.      ! use Alvarez et al (2018) for chlorophyll degradation
-HetRespFlux_plus      = .true.      !MB More stable computation of zooplankton respiration fluxes adding a small number to HetN
+! --- Tracer Counts ---
+bgc_num               = 31          ! number of REcoM tracers, checked at startup against enable_3zoo2det and enable_coccos
+diags3d_num           = 28          ! number of 3D diagnostic tracers to be saved
+bgc_base_num          = 22          ! number of standard (base) BGC tracers
+benthos_num           = 4           ! number of benthic BGC tracers: 8 with ciso = .true., otherwise 4
+Nmocsy                = 1           ! length of the vector passed to mocsy (always 1 for REcoM)
+biostep               = 1           ! number of biology steps per ocean time step
+
+! --- Sinking ---
+VDet                  = 20.d0       ! sinking velocity of small detritus [m/day], positive downwards
+VDet_zoo2             = 200.d0      ! sinking velocity of large detritus [m/day]
+VPhy                  = 0.d0        ! sinking velocity of small phytoplankton [m/day]
+VDia                  = 0.d0        ! sinking velocity of diatoms [m/day]
+VCocco                = 0.d0        ! sinking velocity of coccolithophores [m/day]
+allow_var_sinking     = .true.      ! detritus sinking speed increases with depth (Vdet_a in &pasinking)
+
+! --- Process Options ---
+REcoM_Geider_limiter  = .false.     ! selects the routine that calculates the limiters in the sources-minus-sinks
+REcoM_Grazing_Variable_Preference = .true. ! grazing preferences weighted by prey abundance
+Grazing_detritus      = .true.      ! zooplankton also graze on detritus
+het_resp_noredfield   = .true.      ! respiration formulation of the first zooplankton (copepods)
+diatom_mucus          = .true.      ! nutrient limitation enhances diatom aggregation
+O2dep_remin           = .true.      ! oxygen-dependent remineralization of organic matter (k_o2_remin)
+use_photodamage       = .true.      ! light-dependent chlorophyll degradation after Alvarez et al. (2018)
+HetRespFlux_plus      = .true.      ! more stable zooplankton respiration flux (not used by the current code)
+CO2lim                = .true.      ! CO2 dependence of growth and calcification (&paco2lim)
+OmegaC_diss           = .false.     ! calcite dissolution from the mocsy saturation state OmegaC
+                                    ! (Aumont et al. 2015, Gehlen et al. 2007); set calc_diss_guts = 0 when .false.
+
+! --- Ballasting ---
+use_ballasting        = .true.      ! mineral ballasting of detritus sinking (&paballasting)
+use_density_scaling   = .true.      ! scale sinking with seawater density (ballasting)
+use_viscosity_scaling = .true.      ! scale sinking with seawater viscosity (ballasting)
+
+! --- External Sources ---
+UseFeDust             = .true.      ! iron input from dust (not used by the current code, see fe_data_source)
+UseDustClim           = .true.      ! dust deposition climatology (not used by the current code)
+UseDustClimAlbani     = .true.      ! Albani dust climatology, otherwise Mahowald (not used by the current code)
+useRivers             = .false.     ! riverine nutrient input (nm_river_data_file)
+useRivFe              = .false.     ! riverine iron source
+useErosion            = .false.     ! input from erosion (nm_erosion_data_file)
+NitrogenSS            = .false.     ! external nitrogen sources and sinks (riverine, aeolian and denitrification)
+useAeolianN           = .false.     ! aeolian nitrogen deposition (nm_aen_data_file)
 REcoMDataPath         = '/albedo/work/projects/MarESys/ogurses/input/mesh_CORE2_finaltopo_mean/'
-restore_alkalinity    = .true.
-useRivers             = .false.
-useRivFe              = .false.      ! When set to true, riverine Fe source is activated
-useErosion            = .false.
-NitrogenSS            = .false.     ! When set to true, external sources and sinks of nitrogen are activated (Riverine, aeolian and denitrification)
-useAeolianN           = .false.      ! When set to true, aeolian nitrogen deposition is activated
-firstyearoffesomcycle = 1958        ! The first year of the actual physical forcing (e.g. JRA-55) used
-lastyearoffesomcycle  = 2024        ! Last year of the actual physical forcing used
-numofCO2cycles        = 1           ! Number of cycles of the forcing planned 
-currentCO2cycle       = 1           ! Which CO2 cycle we are currently running
-Nmocsy                = 1           ! Length of the vector that is passed to mocsy (always one for recom)
-recom_debug           =.false.
-ciso                  =.false.     ! Main switch to enable/disable carbon isotopes (13|14C)
-benthos_num           = 4          ! number of benthic BGC tracers -> 8 if (ciso == .true.) otherwise -> 4
-use_MEDUSA            = .false.      ! Main switch for the sediment model MEDUSA
-sedflx_num            = 0           ! if 0: no file from MEDUSA is read but default sediment
-bottflx_num           = 4           ! if ciso&ciso_14: =8; if .not.ciso_14: =6; no ciso: =4
-use_atbox             = .false.
-add_loopback          = .false.     ! add loopback fluxes through rivers to the surface
-lb_tscale             = 1.0         ! /year: fraction of loopback fluxes yearly added to the surface
+                                    ! REcoM input directory (not used by the current code)
+
+! --- Carbon Chemistry and Atmospheric CO2 ---
+constant_CO2          = .true.      ! use CO2_for_spinup instead of the time series in nm_co2_data_file
+restore_alkalinity    = .true.      ! restore surface alkalinity (surf_relax_Alk)
+use_atbox             = .false.     ! atmospheric box model for CO2
+firstyearoffesomcycle = 1958        ! first year of the physical forcing used (e.g. JRA55)
+lastyearoffesomcycle  = 2024        ! last year of the physical forcing used
+numofCO2cycles        = 1           ! number of forcing cycles planned
+currentCO2cycle       = 1           ! forcing cycle currently running
+
+! --- Carbon Isotopes and Sediment ---
+ciso                  = .false.     ! main switch for carbon isotopes (13C, 14C), see &paciso
+use_MEDUSA            = .false.     ! main switch for the sediment model MEDUSA
+sedflx_num            = 0           ! number of sediment fluxes read from MEDUSA (0 = none, default sediment)
+bottflx_num           = 4           ! number of bottom fluxes: 8 with ciso and ciso_14, 6 with ciso only, 4 without ciso
+add_loopback          = .false.     ! return loopback fluxes to the surface through rivers
+lb_tscale             = 1.0         ! fraction of the loopback fluxes added to the surface per year [1/year]
 /
 
+! ============================================================================
+! DEPTH-DEPENDENT SINKING
+! ============================================================================
 &pasinking
-Vdet_a                = 0.0288      ! [1/day]
-Vcalc                 = 0.0144      ! [1/day]
+Vdet_a                = 0.0288      ! increase of detritus sinking speed with depth [1/day] (allow_var_sinking)
+Vcalc                 = 0.0144      ! depth dependence of calcite dissolution [1/day]
 /
 
+! ============================================================================
+! INITIALIZATION
+! ============================================================================
 &painitialization_N
-cPhyN                 = 0.2d0
-cHetN                 = 0.2d0
-cZoo2N                = 0.2d0
+cPhyN                 = 0.2d0       ! initial small phytoplankton N (not used by the current code)
+cHetN                 = 0.2d0       ! initial first zooplankton N (not used by the current code)
+cZoo2N                = 0.2d0       ! initial second zooplankton N (not used by the current code)
 /
 
+! ============================================================================
+! TEMPERATURE DEPENDENCE
+! ============================================================================
 &paArrhenius
-recom_Tref            = 288.15d0    ! [K]
-C2K                   = 273.15d0    ! Conversion from degrees C to K
-Ae                    = 4500.d0     ! [K] Slope of the linear part of the Arrhenius function
-reminSi               = 0.02d0
-k_o2_remin            = 15.d0       ! O2remin mmol m-3; Table 1 in Cram 2018 cites DeVries & Weber 2017 for a range of 0-30 mmol m-3
+recom_Tref            = 288.15d0    ! reference temperature of the Arrhenius function [K]
+C2K                   = 273.15d0    ! conversion from degrees C to K
+Ae                    = 4500.d0     ! slope of the linear part of the Arrhenius function [K]
+reminSi               = 0.02d0      ! lower bound of the silica remineralization rate [1/day]
+k_o2_remin            = 15.d0       ! half-saturation O2 for O2-dependent remineralization [mmol/m3] (O2dep_remin)
+                                    ! Cram et al. (2018), Table 1, cite 0-30 mmol/m3 (DeVries & Weber 2017)
 /
 
+! ============================================================================
+! LIMITATION FUNCTIONS
+! ============================================================================
 &palimiter_function
-NMinSlope             = 50.d0 
-SiMinSlope            = 1000.d0
-NCmin                 = 0.04d0
-NCmin_d               = 0.04d0
-NCmin_c		      = 0.04d0    
-SiCmin                = 0.04d0
-k_Fe                  = 0.04d0
-k_Fe_d                = 0.12d0
-k_Fe_c		      = 0.09d0    
-k_si                  = 4.d0
-P_cm                  = 3.0d0       ! [1/day]            Rate of C-specific photosynthesis 
-P_cm_d                = 3.5d0
-P_cm_c		      = 2.8d0	  
+! --- Limitation Function Slopes ---
+NMinSlope             = 50.d0       ! steepness of the nitrogen limitation function at the minimum quota
+SiMinSlope            = 1000.d0     ! steepness of the silicon limitation function at the minimum quota
+
+! --- Minimum Quotas ---
+NCmin                 = 0.04d0      ! minimum N:C quota, small phytoplankton [mmol N/mmol C]
+NCmin_d               = 0.04d0      ! minimum N:C quota, diatoms [mmol N/mmol C]
+NCmin_c               = 0.04d0      ! minimum N:C quota, coccolithophores [mmol N/mmol C]
+SiCmin                = 0.04d0      ! minimum Si:C quota, diatoms [mmol Si/mmol C]
+
+! --- Nutrient Half-Saturation ---
+k_Fe                  = 0.04d0      ! half-saturation constant for iron uptake, small phytoplankton [µmol Fe/m3]
+k_Fe_d                = 0.12d0      ! half-saturation constant for iron uptake, diatoms [µmol Fe/m3]
+k_Fe_c                = 0.09d0      ! half-saturation constant for iron uptake, coccolithophores [µmol Fe/m3]
+k_si                  = 4.d0        ! half-saturation constant for silicate uptake, diatoms [mmol Si/m3]
+
+! --- Maximum Photosynthesis ---
+P_cm                  = 3.0d0       ! maximum C-specific photosynthesis rate, small phytoplankton [1/day]
+P_cm_d                = 3.5d0       ! maximum C-specific photosynthesis rate, diatoms [1/day]
+P_cm_c                = 2.8d0       ! maximum C-specific photosynthesis rate, coccolithophores [1/day] (not used by the current code)
 /
 
+! ============================================================================
+! LIGHT
+! ============================================================================
 &palight_calculations
-k_w                   = 0.04d0      ! [1/m]              Light attenuation coefficient
-a_chl                 = 0.03d0      ! [1/m * 1/(mg Chl)] Chlorophyll specific attenuation coefficients
+k_w                   = 0.04d0      ! light attenuation coefficient of water [1/m]
+a_chl                 = 0.03d0      ! chlorophyll-specific attenuation coefficient [1/m * 1/(mg Chl)]
 /
 
+! ============================================================================
+! PHOTOSYNTHESIS
+! ============================================================================
 &paphotosynthesis
-alfa                  = 0.14d0	    ! [(mmol C*m2)/(mg Chl*W*day)] 
-alfa_d                = 0.19d0      ! An initial slope of the P-I curve
-alfa_c		      = 0.10d0     
-parFrac               = 0.43d0
+alfa                  = 0.14d0      ! initial slope of the P-I curve, small phytoplankton [(mmol C m²)/(mg Chl W day)]
+alfa_d                = 0.19d0      ! initial slope of the P-I curve, diatoms [(mmol C m²)/(mg Chl W day)]
+alfa_c                = 0.10d0      ! initial slope of the P-I curve, coccolithophores [(mmol C m²)/(mg Chl W day)]
+parFrac               = 0.43d0      ! photosynthetically active fraction of the shortwave radiation
 /
 
+! ============================================================================
+! NUTRIENT ASSIMILATION
+! ============================================================================
 &paassimilation
-V_cm_fact             = 0.7d0       ! scaling factor for temperature dependent maximum of C-specific N-uptake
-V_cm_fact_d           = 0.7d0  
-V_cm_fact_c	      = 0.7d0     
-NMaxSlope             = 1000.d0     ! Max slope for limiting function
-SiMaxSlope            = 1000.d0
-NCmax                 = 0.2d0       ! [mmol N/mmol C] Maximum cell quota of nitrogen (N:C)
-NCmax_d               = 0.2d0
-NCmax_c		      = 0.15d0     
-SiCmax                = 0.8d0
-NCuptakeRatio         = 0.2d0       ! [mmol N/mmol C] Maximum uptake ratio of N:C
-NCUptakeRatio_d       = 0.2d0
-NCUptakeRatio_c	      = 0.2d0     
-SiCUptakeRatio        = 0.2d0
-k_din                 = 0.55d0      ! [mmol N/m3] Half-saturation constant for nitrate uptake
-k_din_d               = 1.0d0
-k_din_c		      = 0.9d0     
-Chl2N_max             = 3.15d0      ! [mg CHL/mmol N] Maximum CHL a : N ratio = 0.3 gCHL gN^-1
-Chl2N_max_d           = 4.2d0
-Chl2N_max_c	      = 3.5d0     
-res_phy               = 0.01d0      ! [1/day] Maintenance respiration rate constant
-res_phy_d             = 0.01d0
-res_phy_c	      = 0.01d0    
-biosynth              = 2.33d0      ! [mmol C/mmol N] Cost of biosynthesis
-biosynthSi            = 0.d0
+! --- Nitrogen Uptake ---
+V_cm_fact             = 0.7d0       ! scaling of the temperature-dependent maximum C-specific N uptake, small phytoplankton
+V_cm_fact_d           = 0.7d0       ! scaling of the temperature-dependent maximum C-specific N uptake, diatoms
+V_cm_fact_c           = 0.7d0       ! scaling of the temperature-dependent maximum C-specific N uptake, coccolithophores
+NMaxSlope             = 1000.d0     ! steepness of the limitation function at the maximum N quota
+NCmax                 = 0.2d0       ! maximum N:C quota, small phytoplankton [mmol N/mmol C]
+NCmax_d               = 0.2d0       ! maximum N:C quota, diatoms [mmol N/mmol C]
+NCmax_c               = 0.15d0      ! maximum N:C quota, coccolithophores [mmol N/mmol C]
+NCuptakeRatio         = 0.2d0       ! maximum N:C uptake ratio, small phytoplankton [mmol N/mmol C]
+NCUptakeRatio_d       = 0.2d0       ! maximum N:C uptake ratio, diatoms [mmol N/mmol C]
+NCUptakeRatio_c       = 0.2d0       ! maximum N:C uptake ratio, coccolithophores [mmol N/mmol C]
+k_din                 = 0.55d0      ! half-saturation constant for nitrate uptake, small phytoplankton [mmol N/m3]
+k_din_d               = 1.0d0       ! half-saturation constant for nitrate uptake, diatoms [mmol N/m3]
+k_din_c               = 0.9d0       ! half-saturation constant for nitrate uptake, coccolithophores [mmol N/m3]
+
+! --- Silicon Uptake (Diatoms) ---
+SiMaxSlope            = 1000.d0     ! steepness of the limitation function at the maximum Si quota
+SiCmax                = 0.8d0       ! maximum Si:C quota [mmol Si/mmol C]
+SiCUptakeRatio        = 0.2d0       ! maximum Si:C uptake ratio [mmol Si/mmol C]
+
+! --- Chlorophyll ---
+Chl2N_max             = 3.15d0      ! maximum Chl:N ratio, small phytoplankton [mg Chl/mmol N]
+Chl2N_max_d           = 4.2d0       ! maximum Chl:N ratio, diatoms [mg Chl/mmol N]
+Chl2N_max_c           = 3.5d0       ! maximum Chl:N ratio, coccolithophores [mg Chl/mmol N]
+
+! --- Respiration ---
+res_phy               = 0.01d0      ! maintenance respiration rate, small phytoplankton [1/day]
+res_phy_d             = 0.01d0      ! maintenance respiration rate, diatoms [1/day]
+res_phy_c             = 0.01d0      ! maintenance respiration rate, coccolithophores [1/day]
+biosynth              = 2.33d0      ! cost of biosynthesis [mmol C/mmol N]
+biosynthSi            = 0.d0        ! cost of silica biosynthesis [mmol C/mmol Si]
 /
 
+! ============================================================================
+! IRON CHEMISTRY
+! ============================================================================
 &pairon_chem
-totalligand           = 1.d0        ! [mumol/m3] order 1. Total free ligand
-ligandStabConst       = 100.d0      ! [m3/mumol] order 100. Ligand-free iron stability constant
+totalligand           = 1.d0        ! total free ligand [µmol/m3] (order 1)
+ligandStabConst       = 100.d0      ! ligand-free iron stability constant [m3/µmol] (order 100)
 /
 
+! ============================================================================
+! FIRST ZOOPLANKTON (MESOZOOPLANKTON)
+! ============================================================================
 &pazooplankton
-graz_max              = 0.31d0      ! [mmol N/(m3 * day)] Maximum grazing loss parameter 
-epsilonr              = 0.09d0      ! [(mmol N)2 /m6] Half saturation constant for grazing loss 
-res_het               = 0.028d0     ! [1/day] Respiration by heterotrophs and mortality (loss to detritus)
-Redfield              = 6.625       ! [mmol C/mmol N] Redfield ratio of C:N = 106:16
-loss_het              = 0.04d0      ! [1/day] Temperature dependent N degradation of extracellular organic N (EON)
-pzDia                 = 0.5d0       ! Maximum diatom preference
-sDiaNsq               = 0.d0
-pzPhy                 = 0.04d0      ! Maximum small phytoplankton preference
-sPhyNsq               = 0.d0
-pzCocco		      = 0.4d0       ! Maximum coccolithophore preference  ! will not be used in the 2p3z3d version
-sCoccoNsq	      = 0.d0       
-pzMicZoo              = 1.0d0       ! Maximum microzooplankton preference
-sMicZooNsq            = 0.d0      
-tiny_het              = 1.d-5       ! for more stable computation of HetRespFlux (_plus). Value can be > tiny because HetRespFlux ~ hetC**2.
+graz_max              = 0.31d0      ! maximum grazing rate [mmol N/(m3 day)]
+epsilonr              = 0.09d0      ! half-saturation constant for grazing [(mmol N)^2/m^6]
+res_het               = 0.028d0     ! respiration and mortality (loss to detritus) [1/day]
+Redfield              = 6.625       ! Redfield C:N ratio (106:16) [mmol C/mmol N]
+loss_het              = 0.04d0      ! temperature-dependent N degradation of extracellular organic N (EON) [1/day]
+tiny_het              = 1.d-5       ! small number for a more stable HetRespFlux; may exceed tiny since HetRespFlux ~ HetC^2
+
+! --- Prey Preferences ---
+pzDia                 = 0.5d0       ! maximum diatom preference
+sDiaNsq               = 0.d0        ! not used by the current code
+pzPhy                 = 0.04d0      ! maximum small phytoplankton preference
+sPhyNsq               = 0.d0        ! not used by the current code
+pzCocco               = 0.4d0       ! maximum coccolithophore preference
+sCoccoNsq             = 0.d0        ! not used by the current code
+pzMicZoo              = 1.0d0       ! maximum microzooplankton preference
+sMicZooNsq            = 0.d0        ! not used by the current code
 /
 
+! ============================================================================
+! SECOND ZOOPLANKTON (MACROZOOPLANKTON)
+! ============================================================================
 &pasecondzooplankton
-graz_max2      = 0.1d0              ! [mmol N/(m3 * day)] Maximum grazing loss parameter                                                                                        
-epsilon2       = 0.0144d0           ! [(mmol N)2 /m6] Half saturation constant for grazing loss                                                                              
-res_zoo2       = 0.0107d0           ! [1/day] Respiration by heterotrophs and mortality (loss to detritus)                                                            
-loss_zoo2      = 0.003d0            ! [1/day] Temperature dependent N degradation of extracellular organic N (EON)
-fecal_rate_n      = 0.104d0         ! [1/day] Temperature dependent N degradation of \
-fecal_rate_c      = 0.236d0  
-fecal_rate_n_mes = 0.25d0           
-fecal_rate_c_mes = 0.32d0         
-pzDia2         = 1.0d0              ! Maximum diatom preference                                                                                                                 
-sDiaNsq2       = 0.d0
-pzPhy2         = 0.07d0              ! Maximum small phytoplankton preference                                                                                                                
-sPhyNsq2       = 0.d0
-pzCocco2       = 0.7d0              ! Maximum coccolithophore preference  ! will not be	used in	the 2p3z3d version
-sCoccoNsq2     = 0.d0		 
-pzHet          = 1.5d0              ! Maximum mesozooplankton preference 
-sHetNsq        = 0.d0
-pzMicZoo2      = 1.0d0              ! Maximum microzooplankton preference
-sMicZooNsq2    = 0.d0   
-t1_zoo2        = 28145.d0           ! Krill temp. function constant1                                                                                                       
-t2_zoo2        = 272.5d0            ! Krill temp. function constant2                                                                                                         
-t3_zoo2        = 105234.d0          ! Krill temp. function constant3                                                                                                      
-t4_zoo2        = 274.15d0           ! Krill temp. function constant3
+graz_max2             = 0.1d0       ! maximum grazing rate [mmol N/(m3 day)]
+epsilon2              = 0.0144d0    ! half-saturation constant for grazing [(mmol N)^2/m^6]
+res_zoo2              = 0.0107d0    ! respiration and mortality (loss to detritus) [1/day]
+loss_zoo2             = 0.003d0     ! temperature-dependent N degradation of extracellular organic N (EON) [1/day]
+
+! --- Fecal Pellets ---
+fecal_rate_n          = 0.104d0     ! fraction of the grazed nitrogen egested as fecal pellets
+fecal_rate_c          = 0.236d0     ! fraction of the grazed carbon egested as fecal pellets
+fecal_rate_n_mes      = 0.25d0      ! as fecal_rate_n, for the first zooplankton (mesozooplankton)
+fecal_rate_c_mes      = 0.32d0      ! as fecal_rate_c, for the first zooplankton (mesozooplankton)
+
+! --- Prey Preferences ---
+pzDia2                = 1.0d0       ! maximum diatom preference
+sDiaNsq2              = 0.d0        ! not used by the current code
+pzPhy2                = 0.07d0      ! maximum small phytoplankton preference
+sPhyNsq2              = 0.d0        ! not used by the current code
+pzCocco2              = 0.7d0       ! maximum coccolithophore preference
+sCoccoNsq2            = 0.d0        ! not used by the current code
+pzHet                 = 1.5d0       ! maximum preference for the first zooplankton
+sHetNsq               = 0.d0        ! not used by the current code
+pzMicZoo2             = 1.0d0       ! maximum microzooplankton preference
+sMicZooNsq2           = 0.d0        ! not used by the current code
+
+! --- Temperature Function (Krill) ---
+t1_zoo2               = 28145.d0    ! krill temperature function constant 1
+t2_zoo2               = 272.5d0     ! krill temperature function constant 2
+t3_zoo2               = 105234.d0   ! krill temperature function constant 3
+t4_zoo2               = 274.15d0    ! krill temperature function constant 4
 /
 
+! ============================================================================
+! THIRD ZOOPLANKTON (MICROZOOPLANKTON)
+! ============================================================================
 &pathirdzooplankton
-graz_max3      = 0.46d0             ! [mmol N/(m3 * day)] Maximum grazing loss parameter
-epsilon3       = 0.64d0             ! [(mmol N)2 /m6] Half saturation constant for grazing loss
-loss_miczoo    = 0.01d0             ! [1/day] Temperature dependent N degradation of extracellular organic N (EON)
-res_miczoo     = 0.02d0             ! [1/day] Respiration by heterotrophs and mortality (loss to detritus)
-pzDia3         = 0.04d0              ! Maximum diatom preference
-sDiaNsq3       = 0.d0               
-pzPhy3         = 0.07d0              ! Maximum small phytoplankton preference
-sPhyNsq3       = 0.d0               
-pzCocco3       = 0.7d0              ! Maximum coccolithophore preference  ! will not be	used in	the 2p3z3d version
-sCoccoNsq3     = 0.d0              
+graz_max3             = 0.46d0      ! maximum grazing rate [mmol N/(m3 day)]
+epsilon3              = 0.64d0      ! half-saturation constant for grazing [(mmol N)^2/m^6]
+loss_miczoo           = 0.01d0      ! temperature-dependent N degradation of extracellular organic N (EON) [1/day]
+res_miczoo            = 0.02d0      ! respiration and mortality (loss to detritus) [1/day]
+
+! --- Prey Preferences ---
+pzDia3                = 0.04d0      ! maximum diatom preference
+sDiaNsq3              = 0.d0        ! not used by the current code
+pzPhy3                = 0.07d0      ! maximum small phytoplankton preference
+sPhyNsq3              = 0.d0        ! not used by the current code
+pzCocco3              = 0.7d0       ! maximum coccolithophore preference (still to be tuned)
+sCoccoNsq3            = 0.d0        ! not used by the current code
 /
 
+! ============================================================================
+! GRAZING ON DETRITUS
+! ============================================================================
 &pagrazingdetritus
-pzDet         = 0.5d0               ! Maximum small detritus prefence by first zooplankton
-sDetNsq       = 0.d0
-pzDetZ2       = 0.5d0               ! Maximum large detritus preference by first zooplankton                                 
-sDetZ2Nsq     = 0.d0
-pzDet2        = 0.5d0               ! Maximum small detritus prefence by second zooplankton                               
-sDetNsq2      = 0.d0
-pzDetZ22      = 0.5d0               ! Maximum large detritus preference by second zooplankton
-sDetZ2Nsq2    = 0.d0
+pzDet                 = 0.5d0       ! maximum small detritus preference, first zooplankton
+sDetNsq               = 0.d0        ! not used by the current code
+pzDetZ2               = 0.5d0       ! maximum large detritus preference, first zooplankton
+sDetZ2Nsq             = 0.d0        ! not used by the current code
+pzDet2                = 0.5d0       ! maximum small detritus preference, second zooplankton
+sDetNsq2              = 0.d0        ! not used by the current code
+pzDetZ22              = 0.5d0       ! maximum large detritus preference, second zooplankton
+sDetZ2Nsq2            = 0.d0        ! not used by the current code
 /
 
+! ============================================================================
+! AGGREGATION
+! ============================================================================
 &paaggregation
-agg_PD                = 0.165d0     ! [m3/(mmol N * day)] Maximum aggregation loss parameter for DetN
-agg_PP                = 0.015d0     ! [m3/(mmol N * day)] Maximum aggregation loss parameter for PhyN and DiaN (plankton)
+agg_PD                = 0.165d0     ! maximum aggregation loss parameter for detritus [m3/(mmol N day)]
+agg_PP                = 0.015d0     ! maximum aggregation loss parameter for phytoplankton [m3/(mmol N day)]
 /
 
+! ============================================================================
+! DISSOLVED ORGANIC MATTER
+! ============================================================================
 &padin_rho_N
-rho_N                 = 0.11d0      ! [1/day] Temperature dependent N degradation of extracellular organic N (EON) (Remineralization of DON)
+rho_N                 = 0.11d0      ! temperature-dependent remineralization of DON (degradation of EON) [1/day]
 /
 
 &padic_rho_C1
-rho_C1                = 0.1d0       ! [1/day] Temperature dependent C degradation of extracellular organic C (EOC)
+rho_C1                = 0.1d0       ! temperature-dependent degradation of extracellular organic C (EOC) [1/day]
 /
 
+! ============================================================================
+! PHYTOPLANKTON LOSSES
+! ============================================================================
 &paphytoplankton_N
-lossN                 = 0.05d0      ! [1/day] Phytoplankton loss of organic N compounds
-lossN_d               = 0.05d0
-lossN_c		      = 0.05d0    
+lossN                 = 0.05d0      ! loss of organic N compounds, small phytoplankton [1/day]
+lossN_d               = 0.05d0      ! loss of organic N compounds, diatoms [1/day]
+lossN_c               = 0.05d0      ! loss of organic N compounds, coccolithophores [1/day]
 /
 
 &paphytoplankton_C
-lossC                 = 0.10d0      ! [1/day] Phytoplankton loss of carbon 
-lossC_d               = 0.10d0
-lossC_c		      = 0.10d0  
+lossC                 = 0.10d0      ! loss of carbon, small phytoplankton [1/day]
+lossC_d               = 0.10d0      ! loss of carbon, diatoms [1/day]
+lossC_c               = 0.10d0      ! loss of carbon, coccolithophores [1/day]
 /
 
 &paphytoplankton_ChlA
-deg_Chl               = 0.25d0 !0.075 !0.2d0 !0.25d0      ! [1/day]
-deg_Chl_d             = 0.15d0 !0.075 !0.2d0 !0.15d0
-deg_Chl_c	      = 0.2d0 !0.075 !0.2d0   
+deg_Chl               = 0.25d0      ! chlorophyll degradation rate, small phytoplankton [1/day]
+deg_Chl_d             = 0.15d0      ! chlorophyll degradation rate, diatoms [1/day]
+deg_Chl_c             = 0.2d0       ! chlorophyll degradation rate, coccolithophores [1/day]
 /
 
+! ============================================================================
+! DETRITUS
+! ============================================================================
 &padetritus_N
-gfin                  = 0.3d0         ! [] Grazing efficiency (fraction of grazing flux into zooplankton pool)
-grazEff2              = 0.8d0         ! [] Grazing efficiency (fraction of grazing flux into second zooplankton pool)
-grazEff3              = 0.8d0         ! [] Grazing efficiency (fraction of grazing flux into microzooplankton pool)
-reminN                = 0.165d0       ! [1/day] Temperature dependent remineralisation rate of detritus	
+gfin                  = 0.3d0       ! grazing efficiency of the first zooplankton (fraction of the grazing flux it retains)
+grazEff2              = 0.8d0       ! grazing efficiency of the second zooplankton
+grazEff3              = 0.8d0       ! grazing efficiency of the microzooplankton
+reminN                = 0.165d0     ! temperature-dependent remineralization rate of detrital N [1/day]
 /
 
 &padetritus_C
-reminC                = 0.15d0      ! [1/day] Temperature dependent remineralisation rate of detritus
-rho_c2                = 0.1d0       ! [1/day] Temperature dependent C degradation of TEP-C
+reminC                = 0.15d0      ! temperature-dependent remineralization rate of detrital C [1/day]
+rho_c2                = 0.1d0       ! temperature-dependent degradation of TEP-C [1/day]
 /
 
+! ============================================================================
+! ZOOPLANKTON EXCRETION
+! ============================================================================
 &paheterotrophs
-lossN_z               = 0.1d0
-lossC_z               = 0.1d0
+lossN_z               = 0.1d0       ! DON excretion by the first zooplankton [1/day]
+lossC_z               = 0.1d0       ! DOC excretion by the first zooplankton [1/day]
 /
 
 &paseczooloss
-lossN_z2              = 0.02d0
-lossC_z2              = 0.02d0
+lossN_z2              = 0.02d0      ! DON excretion by the second zooplankton [1/day]
+lossC_z2              = 0.02d0      ! DOC excretion by the second zooplankton [1/day]
 /
 
 &pathirdzooloss
-lossN_z3              = 0.05d0    
-lossC_z3              = 0.05d0  
+lossN_z3              = 0.05d0      ! DON excretion by the microzooplankton [1/day]
+lossC_z3              = 0.05d0      ! DOC excretion by the microzooplankton [1/day]
 /
 
-&paco2lim                 
-Cunits         = 976.5625    ! Conversion factor between [mol/m3] (model) and [umol/kg] (function): (1000 * 1000) / 1024                                                                                                                      
-a_co2_phy      = 1.162e+00   ! [dimensionless]
-a_co2_dia      = 1.040e+00   ! [dimensionless]
-a_co2_cocco    = 1.109e+00   ! [dimensionless]
-a_co2_calc     = 1.102e+00   ! [dimensionless]
-b_co2_phy      = 4.888e+01   ! [mol/kg]
-b_co2_dia      = 2.890e+01   ! [mol/kg]
-b_co2_cocco    = 3.767e+01   ! [mol/kg]
-b_co2_calc     = 4.238e+01   ! [mol/kg]
-c_co2_phy      = 2.255e-01   ! [kg/mol]
-c_co2_dia      = 8.778e-01   ! [kg/mol]
-c_co2_cocco    = 3.912e-01   ! [kg/mol]
-c_co2_calc     = 7.079e-01   ! [kg/mol]
-d_co2_phy      = 1.023e+07   ! [kg/mol]
-d_co2_dia      = 2.640e+06   ! [kg/mol]
-d_co2_cocco    = 9.450e+06   ! [kg/mol]
-d_co2_calc     = 1.343e+07   ! [kg/mol]
+! ============================================================================
+! CO2 DEPENDENCE OF GROWTH AND CALCIFICATION (CO2lim)
+! ============================================================================
+! Response = a*HCO3/(b + HCO3) - exp(-c*CO2) - d*10**(-pH), with HCO3 and
+! CO2 converted by Cunits; one set per phytoplankton group and calcification.
+! ============================================================================
+&paco2lim
+Cunits         = 976.5625    ! conversion between [mol/m3] (model) and [umol/kg] (function): (1000 * 1000) / 1024
+a_co2_phy      = 1.162e+00   ! HCO3 response coefficient a, small phytoplankton [dimensionless]
+a_co2_dia      = 1.040e+00   ! HCO3 response coefficient a, diatoms [dimensionless]
+a_co2_cocco    = 1.109e+00   ! HCO3 response coefficient a, coccolithophores [dimensionless]
+a_co2_calc     = 1.102e+00   ! HCO3 response coefficient a, calcification [dimensionless]
+b_co2_phy      = 4.888e+01   ! HCO3 half-saturation b, small phytoplankton [mol/kg]
+b_co2_dia      = 2.890e+01   ! HCO3 half-saturation b, diatoms [mol/kg]
+b_co2_cocco    = 3.767e+01   ! HCO3 half-saturation b, coccolithophores [mol/kg]
+b_co2_calc     = 4.238e+01   ! HCO3 half-saturation b, calcification [mol/kg]
+c_co2_phy      = 2.255e-01   ! CO2 inhibition coefficient c, small phytoplankton [kg/mol]
+c_co2_dia      = 8.778e-01   ! CO2 inhibition coefficient c, diatoms [kg/mol]
+c_co2_cocco    = 3.912e-01   ! CO2 inhibition coefficient c, coccolithophores [kg/mol]
+c_co2_calc     = 7.079e-01   ! CO2 inhibition coefficient c, calcification [kg/mol]
+d_co2_phy      = 1.023e+07   ! H+ inhibition coefficient d, small phytoplankton [kg/mol]
+d_co2_dia      = 2.640e+06   ! H+ inhibition coefficient d, diatoms [kg/mol]
+d_co2_cocco    = 9.450e+06   ! H+ inhibition coefficient d, coccolithophores [kg/mol]
+d_co2_calc     = 1.343e+07   ! H+ inhibition coefficient d, calcification [kg/mol]
 /
 
+! ============================================================================
+! IRON
+! ============================================================================
 &pairon
-Fe2N                  = 0.033d0     ! Fe2C * 6.625
-Fe2N_benthos          = 0.15d0      ! test, default was 0.14 Fe2C_benthos * 6.625 - will have to be tuned. [umol/m2/day]
-kScavFe               = 0.07d0
-dust_sol              = 0.02d0      ! Dissolution of Dust for bioavaliable
-RiverFeConc           = 100
+Fe2N                  = 0.033d0     ! Fe:N ratio of organic matter (Fe2C * 6.625)
+Fe2N_benthos          = 0.15d0      ! Fe:N ratio of the benthic iron release (Fe2C_benthos * 6.625; was 0.14, still to be tuned)
+kScavFe               = 0.07d0      ! scavenging rate of free iron onto detritus
+dust_sol              = 0.02d0      ! soluble (bioavailable) fraction of dust iron
+RiverFeConc           = 100         ! mean dissolved iron concentration in rivers (useRivFe)
 /
 
+! ============================================================================
+! CALCITE
+! ============================================================================
 &pacalc
-calc_prod_ratio       = 0.02
-calc_diss_guts        = 0.0d0       ! set to zero if OmegaC_diss is set to false
-calc_diss_rate        = 0.005714d0  ! 20.d0/3500.d0
-calc_diss_rate2       = 0.005714d0
-calc_diss_omegac      = 0.197d0     ! Value from Aumont et al. 2015, is used with OmegaC_diss flag
-calc_diss_exp         = 1.d0        ! Exponent in the dissolution rate of calcite, is used with OmegaC_diss flag
+calc_prod_ratio       = 0.02        ! calcite production as a fraction of small phytoplankton carbon fixation
+calc_diss_guts        = 0.0d0       ! calcite dissolution in zooplankton guts (set to 0 when OmegaC_diss = .false.)
+calc_diss_rate        = 0.005714    ! calcite dissolution rate (20/3500) [1/day]
+calc_diss_rate2       = 0.005714d0  ! calcite dissolution rate of large detritus, scaled by its sinking speed / 20
+calc_diss_omegac      = 0.197d0     ! value from Aumont et al. (2015), used with OmegaC_diss
+calc_diss_exp         = 1.d0        ! exponent of the calcite dissolution rate, used with OmegaC_diss
 /
 
+! ============================================================================
+! BENTHOS
+! ============================================================================
 &pabenthos_decay_rate
-decayRateBenN         = 0.005d0
-decayRateBenC         = 0.005d0
-decayRateBenSi        = 0.005d0
+decayRateBenN         = 0.005d0     ! decay rate of benthic nitrogen [1/day]
+decayRateBenC         = 0.005d0     ! decay rate of benthic carbon [1/day]
+decayRateBenSi        = 0.005d0     ! decay rate of benthic silicon [1/day]
 q_NC_Denit            = 0.86d0      ! N:C quota of the denitrification process
 /
 
+! ============================================================================
+! AIR-SEA CO2 FLUX
+! ============================================================================
 &paco2_flux_param
-permil                = 0.000000976 ! 1.e-3/1024.5d0              ! Converting DIC from [mmol/m3] to [mol/kg]
-permeg                = 1.e-6                       ! [atm/uatm] Changes units from uatm to atm
+permil                = 0.000000976 ! converts DIC from [mmol/m3] to [mol/kg] (1.e-3/1024.5)
+permeg                = 1.e-6       ! converts uatm to atm [atm/uatm]
 !X1                    = exp(-5.d0*log(10.d0))       ! Lowest ph-value = 7.7 (phlo)
 !X2                    = exp(-9.d0*log(10.d0))       ! Highest ph-value = 9.5 (phhi)
-Xacc                  = 1.e-12                      ! Accuracy for ph-iteration (phacc)
-CO2_for_spinup        = 278.d0                      ! [uatm] Atmospheric partial pressure of CO2
+Xacc                  = 1.e-12      ! accuracy of the pH iteration
+CO2_for_spinup        = 278.d0      ! atmospheric pCO2 used with constant_CO2 = .true. [uatm]
 /
 
+! ============================================================================
+! ALKALINITY RESTORING
+! ============================================================================
 &paalkalinity_restoring
-surf_relax_Alk      = 3.2e-07 !10.d0/31536000.d0
+surf_relax_Alk        = 3.2e-07     ! surface alkalinity restoring velocity, 10 m per year [m/s] (restore_alkalinity)
 /
 
+! ============================================================================
+! BALLASTING (use_ballasting, see Cram et al. 2018)
+! ============================================================================
 &paballasting
-rho_POC              = 1033.d0   ! kg m-3; density of POC (see Table 1 in Cram et al., 2018)
-rho_PON              = 1033.d0   ! kg m-3; density of PON (see Table 1 in Cram et al., 2018)
-rho_CaCO3            = 2830.d0   ! kg m-3; density of CaCO3 (see Table 1 in Cram et al., 2018) 
-rho_opal             = 2090.d0   ! kg m-3; density of Opal (see Table 1 in Cram et al., 2018)
-rho_ref_part         = 1230.d0   ! kg m-3; reference particle density (see Cram et al., 2018)
-rho_ref_water        = 1027.d0   ! kg m-3; reference seawater density (see Cram et al., 2018)
-visc_ref_water       = 0.00158d0 ! kg m-1 s-1; reference seawater viscosity, at Temp=4 degC (see Cram et al., 2018)
-w_ref1               = 5.d0     ! m s-1; reference sinking velocity of small detritus
-w_ref2               = 200.d0    ! m s-1; reference sinking velocity of large detritus
-depth_scaling1       = 0.01d0   ! s-1; factor to increase sinking speed of det1 with depth, set to 0 if not wanted
-depth_scaling2       = 0.d0      ! s-1; factor to increase sinking speed of det2 with depth, set to 0 if not wanted
-max_sinking_velocity = 250.d0    ! d-1; for numerical stability, set a maximum possible sinking velocity here (applies to both detritus classes)
+rho_POC              = 1033.d0   ! density of POC [kg/m3] (Cram et al. 2018, Table 1)
+rho_PON              = 1033.d0   ! density of PON [kg/m3] (Cram et al. 2018, Table 1)
+rho_CaCO3            = 2830.d0   ! density of CaCO3 [kg/m3] (Cram et al. 2018, Table 1)
+rho_opal             = 2090.d0   ! density of opal [kg/m3] (Cram et al. 2018, Table 1)
+rho_ref_part         = 1230.d0   ! reference particle density [kg/m3]
+rho_ref_water        = 1027.d0   ! reference seawater density [kg/m3]
+visc_ref_water       = 0.00158d0 ! reference seawater viscosity at 4 degC [kg/(m s)]
+w_ref1               = 5.d0      ! reference sinking velocity of small detritus [m/day]
+w_ref2               = 200.d0    ! reference sinking velocity of large detritus [m/day]
+depth_scaling1       = 0.01d0    ! increase of small detritus sinking speed with depth [1/day], 0 = off
+depth_scaling2       = 0.d0      ! increase of large detritus sinking speed with depth [1/day], 0 = off
+max_sinking_velocity = 250.d0    ! upper limit of the sinking speed for numerical stability [m/day], both detritus classes
 /
 
+! ============================================================================
+! CARBON ISOTOPES (ciso)
+! ============================================================================
 &paciso
 ciso_init         = .false.     ! initial fractionation of bulk organic matter
-ciso_14           = .false.      ! include inorganic radiocarbon
+ciso_14           = .false.     ! include inorganic radiocarbon
 ciso_organic_14   = .false.     ! include organic radiocarbon
-lambda_14         = 3.8561e-12  ! corresponding to 1 year = 365.00 days
-delta_CO2_13      = -6.61       ! atmospheric d13C (permil), global-mean value
-big_delta_CO2_14(1)  = 0. ! atmospheric D14C (permil), northern hemisphere polewards of 30°N
-big_delta_CO2_14(2)  = 0. ! atmospheric D14C (permil), (sub) tropical zone 30°N - 30°S
-big_delta_CO2_14(3)  = 0. ! atmospheric D14C (permil), southern hemisphere polewards of 30°S
-atbox_spinup      = .false.
-cosmic_14_init    = 2.0
+lambda_14         = 3.8561e-12  ! radiocarbon decay constant [1/s] (1 year = 365.00 days)
+delta_CO2_13      = -6.61       ! atmospheric d13C, global mean [permil]
+big_delta_CO2_14(1)  = 0. ! atmospheric D14C north of 30°N [permil]
+big_delta_CO2_14(2)  = 0. ! atmospheric D14C between 30°N and 30°S [permil]
+big_delta_CO2_14(3)  = 0. ! atmospheric D14C south of 30°S [permil]
+atbox_spinup      = .false.     ! spin-up mode of the atmospheric 14C box
+cosmic_14_init    = 2.0         ! initial cosmogenic 14C production [atoms/(s cm²)]
 /
-
-

--- a/config/bin_2p3z2d/namelist.tra
+++ b/config/bin_2p3z2d/namelist.tra
@@ -68,18 +68,17 @@ nml_tracer_list =
 /
 
 ! ============================================================================
-! 3D TRACER INITIAL CONDITIONS
-! One file per tracer, same order as idlist.
+! 3D TRACER INITIAL CONDITIONS (OCEAN)
+! ============================================================================
+&tracer_init3d
 ! IDs: 1=temperature, 2=salinity, 1001=nitrate, 1002=DIC, 1003=alkalinity,
 !      1018=silicate, 1019=iron, 1022=oxygen
 ! DIC (1002) ships the preindustrial GLODAP field; for present-day runs use
 !      GLODAPv2.2016b.TCO2_fesom2_mmol_fix_z_Fillvalue.nc with varlist TCO2_mmol
 ! NOTE: no inline "!" comments inside the value lists below - gfortran aborts
 !      the namelist read on them, silently leaving the remaining entries empty.
-! ============================================================================
-&tracer_init3d
-n_ic3d   = 8
-idlist   = 1, 2, 1001, 1002, 1003, 1018, 1019, 1022
+n_ic3d   = 8  ! number of 3D tracers to initialize from files
+idlist   = 1, 2, 1001, 1002, 1003, 1018, 1019, 1022 ! tracer IDs to initialize (1=temperature, 2=salinity)
 filelist = 'phc3.0_winter.nc', 'phc3.0_winter.nc',
            'woa13_all_n00_01_fesom2.nc',
            'GLODAPv2.2016b.PI_TCO2_fesom2_mmol_fix_z_Fillvalue.nc',
@@ -87,8 +86,8 @@ filelist = 'phc3.0_winter.nc', 'phc3.0_winter.nc',
            'woa13_all_i00_01_fesom2.nc',
            'fe_pisces_opa_eq_init_3D_changed_name.nc',
            'woa18_all_o00_01_mmol_fesom2.nc'
-varlist  = 'temp', 'salt', 'n_an', 'PI_TCO2_mmol', 'TAlk_mmol', 'i_an', 'Fe', 'oxygen_mmol'
-t_insitu = .true.
+varlist  = 'temp', 'salt', 'n_an', 'PI_TCO2_mmol', 'TAlk_mmol', 'i_an', 'Fe', 'oxygen_mmol' ! variable names in the netCDF files
+t_insitu = .true.                                  ! if true, convert in-situ temperature to potential temperature
 /
 
 ! ============================================================================

--- a/config/bin_3p3z2d/namelist.config
+++ b/config/bin_3p3z2d/namelist.config
@@ -1,76 +1,133 @@
-! This is the namelist file for model general configuration
+! ============================================================================
+! ============ Namelist file for FESOM2 general configuration ================
+! ============================================================================
+! This file contains the main configuration parameters for FESOM2, including:
+! - Model identification and run settings
+! - Time stepping and simulation duration
+! - Initial time/date settings
+! - File paths for mesh, forcing, and output
+! - Restart and logging configuration
+! - Vertical coordinate system (ALE)
+! - Grid geometry and rotation
+! - Calendar settings
+! - Model components (ice, cavities, etc.)
+! - Parallel decomposition
+! - Iceberg settings
+! ============================================================================
 
+! ============================================================================
+! RUN IDENTIFICATION
+! ============================================================================
 &modelname
-runid='fesom'
+runid = 'fesom'        ! run identifier (used in output filenames)
 /
 
+! ============================================================================
+! TIME STEPPING AND RUN LENGTH
+! ============================================================================
 &timestep
-step_per_day=32 !96 !96 !72 !72 !45 !72 !96
-run_length= 1 !62 !62 !62 !28
-run_length_unit='y' ! y, m, d, s
+step_per_day      = 32         ! number of time steps per day (determines dt = 86400/step_per_day seconds)
+                                ! common values: 32 (45min), 48 (30min), 72 (20min), 96 (15min), 192 (7min 30sec), 
+                                ! 216 (6min 40sec), 240 (6min), 288 (5min), 360 (4min), 720 (2min), 1440 (1min), 2880 (30sec)
+run_length        = 1          ! total length of simulation run
+run_length_unit   = 'y'        ! unit for run_length: 'y' (years), 'm' (months), 'd' (days), 's' (steps)
 /
 
-&clockinit              ! the model starts at
-timenew=0.0
-daynew=1
-yearnew=1958
+! ============================================================================
+! INITIAL TIME/DATE SETTINGS
+! ============================================================================
+&clockinit
+timenew = 0.0                  ! initial time within the day [seconds] (0.0 = midnight)
+daynew  = 1                    ! initial day of the month (1-31)
+yearnew = 1958                 ! initial year
 /
 
+! ============================================================================
+! MESH, INITIALIZATION & OUTPUT PATHS
+! ============================================================================
 &paths
-MeshPath='/albedo/work/projects/p_recompdaf/frbunsen/FESOM2/meshes/core2/'
-ClimateDataPath='/albedo/work/projects/MarESys/ogurses/input/corrected_input/'
-ResultPath='/albedo/work/user/...'
+MeshPath         = '/albedo/work/projects/p_recompdaf/frbunsen/FESOM2/meshes/core2/' ! path to mesh files (nod2d.out, elem2d.out, etc.)
+ClimateDataPath  = '/albedo/work/projects/MarESys/ogurses/input/corrected_input/' ! path to initial conditions (temperature, salinity)
+ResultPath       = '/albedo/work/user/...'  ! path for output files and fesom.clock file
 /
 
+! ============================================================================
+! RESTART AND LOGGING CONFIGURATION
+! ============================================================================
 &restart_log
-restart_length=1            ! --> do netcdf restart ( only required for d,h,s cases, y, m take 1)
-restart_length_unit='y'     !output period: y, d, h, s, off
-raw_restart_length=1        ! --> do core dump restart
-raw_restart_length_unit='off' ! e.g. y, d, h, s, off
-bin_restart_length=1        ! --> do derived type binary restart 
-bin_restart_length_unit='off' ! e.g. y, d, h, s, off
-logfile_outfreq=960         !in logfile info. output frequency, # steps
+restart_length          = 1        ! frequency for netCDF restart files (required for d,h,s; y,m use 1)
+restart_length_unit     = 'y'      ! unit: 'y' (years), 'm' (months), 'd' (days), 'h' (hours), 's' (steps), 'off' (disabled)
+raw_restart_length      = 1        ! frequency for raw core dump restart files
+raw_restart_length_unit = 'off'    ! unit: 'y', 'm', 'd', 'h', 's', 'off'
+bin_restart_length      = 1        ! frequency for binary derived type restart files
+bin_restart_length_unit = 'off'    ! unit: 'y', 'm', 'd', 'h', 's', 'off'
+logfile_outfreq         = 960      ! log file output frequency [number of time steps]
 /
 
+! ============================================================================
+! VERTICAL COORDINATE SYSTEM (ALE - Arbitrary Lagrangian-Eulerian)
+! ============================================================================
 &ale_def
-which_ALE='zstar'       ! 'linfs','zlevel', 'zstar'
-use_partial_cell=.true.
+which_ALE          = 'zstar'     ! vertical coordinate type:
+                                  !   'linfs'  = linear free surface
+                                  !   'zlevel' = z-level (fixed depth levels)
+                                  !   'zstar'  = z-star (terrain-following with SSH scaling)
+use_partial_cell   = .true.      ! use partial bottom cells for better topography representation (not recommended)
 /
 
+! ============================================================================
+! GRID GEOMETRY AND ROTATION
+! ============================================================================
 &geometry
-cartesian=.false.
-fplane=.false.
-cyclic_length=360       ![degree]
-rotated_grid=.true.     !option only valid for coupled model case now
-force_rotation=.true.
-alphaEuler=50.          ![degree] Euler angles, convention:
-betaEuler=15.           ![degree] first around z, then around new x,
-gammaEuler=-90.         ![degree] then around new z.
+cartesian       = .false.        ! use Cartesian coordinates (false = spherical Earth)
+fplane          = .false.        ! use f-plane approximation (constant Coriolis parameter)
+cyclic_length   = 360            ! length of cyclic domain [degrees] (360 = global)
+rotated_grid    = .true.         ! use rotated grid (typically for coupled models to avoid pole singularity)
+force_rotation  = .true.         ! force grid rotation even if not coupled
+alphaEuler      = 50.            ! first Euler angle (rotation around z-axis) [degrees]
+betaEuler       = 15.            ! second Euler angle (rotation around new x-axis) [degrees]
+gammaEuler      = -90.           ! third Euler angle (rotation around new z-axis) [degrees]
+                                  ! Euler angle convention: rotate first around z, then around new x, then around new z
 /
 
+! ============================================================================
+! CALENDAR SETTINGS
+! ============================================================================
 &calendar
-include_fleapyear=.false.
+include_fleapyear = .false.      ! include leap years in calendar (false = 365-day year, true = 365/366-day year)
 /
 
+! ============================================================================
+! MODEL COMPONENTS AND FEATURES
+! ============================================================================
 &run_config
-use_ice=.true.                  ! ocean+ice
-use_cavity=.false.              !
-use_cavity_partial_cell=.false. 
-use_floatice = .false.
-use_sw_pene=.true.
-flag_debug=.false.
-use_transit=.false.
+use_ice                  = .true.        ! enable sea ice model
+use_cavity               = .false.       ! enable ice shelf cavities
+use_cavity_partial_cell  = .false.       ! use partial cells in ice shelf cavities (not recommended)
+use_floatice             = .false.       ! enable floating ice (icebergs)
+use_sw_pene              = .true.        ! enable shortwave radiation penetration into ocean
+flag_debug               = .false.       ! enable debug output (verbose logging)
+use_transit              = .false.       ! enable transient tracer module (CFCs, SF6, etc.)
 /
 
+! ============================================================================
+! PARALLEL DECOMPOSITION (DOMAIN PARTITIONING)
+! ============================================================================
 &machine
-n_levels=2
-n_part= 12, 36          ! 432 number of partitions on each hierarchy level
+n_levels = 2             ! number of hierarchy levels for domain decomposition
+n_part   = 12, 36        ! number of partitions at each level (total CPUs = product of n_part)
+                         ! example: 2 x 128 = 256 MPI tasks
+                         ! adjust based on mesh size and available compute resources
+                         ! maximum scaling reached at ~300 FESOM2 2D nodes per CPU (see first line in nod2d.out for number of 2D nodes)
 /
 
+! ============================================================================
+! ICEBERG SETTINGS
+! ============================================================================
 &icebergs
-use_icesheet_coupling=.false.
-ib_num=1
-use_icebergs=.false.
-steps_per_ib_step=8
-ib_async_mode=0
+use_icesheet_coupling = .false.  ! enable ice sheet model
+ib_num                = 1        ! number of iceberg classes
+use_icebergs          = .false.  ! enable iceberg module
+steps_per_ib_step     = 8        ! ocean time steps per iceberg time step (iceberg subcycling)
+ib_async_mode         = 0        ! iceberg asynchronous mode (0=synchronous, 1=asynchronous)
 /

--- a/config/bin_3p3z2d/namelist.dyn
+++ b/config/bin_3p3z2d/namelist.dyn
@@ -1,24 +1,56 @@
+! ============================================================================
+! ========== Namelist file for FESOM2 momentum dynamics ======================
+! ============================================================================
+! This file contains configuration for momentum equations and dynamics:
+! - Horizontal viscosity schemes and parameters
+! - Momentum advection options
+! - Free-slip vs no-slip boundary conditions
+! - Vertical velocity splitting
+! - Split-explicit barotropic subcycling
+! - Energy diagnostics
+! ============================================================================
+
+! ============================================================================
+! HORIZONTAL VISCOSITY
+! ============================================================================
 &dynamics_visc
-visc_gamma0  = 0.003 ! [m/s],   backgroung viscosity= gamma0*len, it should be as small a s possible (keep it < 0.01 m/s).
-visc_gamma1  = 0.1   ! [nodim], for computation of the flow aware viscosity
-visc_gamma2  = 0.285 ! [s/m],   is only used in easy backscatter option
-visc_easybsreturn= 1.5
+! --- Biharmonic Viscosity Coefficients ---
+visc_gamma0        = 0.003       ! background viscosity coefficient [m/s]
+                                 ! viscosity = gamma0 × element_length
+                                 ! keep < 0.01 m/s for numerical stability
+visc_gamma1        = 0.1         ! flow-aware viscosity coefficient [dimensionless]
+visc_gamma2        = 0.285       ! additional viscosity coefficient [s/m]
+                                 ! only used for easy backscatter (opt_visc=5) and dynamic backscatter (opt_visc=8)
+visc_easybsreturn  = 1.5         ! energy return parameter for easy backscatter [dimensionless]
 
-opt_visc     = 5          
-! 5=Kinematic (easy) Backscatter
-! 6=Biharmonic flow aware (viscosity depends on velocity Laplacian)
-! 7=Biharmonic flow aware (viscosity depends on velocity differences)
-! 8=Dynamic Backscatter
+! --- Viscosity Scheme Selection ---
+opt_visc           = 5           ! horizontal viscosity scheme:
+                                 !   5 = Kinematic (easy) Backscatter
+                                 !   6 = Biharmonic flow-aware (depends on velocity Laplacian)
+                                 !   7 = Biharmonic flow-aware (depends on velocity differences)
+                                 !       + optional Laplacian when visc_gamma0_h or visc_gamma1_h > 0
+                                 !   8 = Dynamic Backscatter
 
-use_ivertvisc= .true.  
+! --- Vertical Viscosity ---
+use_ivertvisc      = .true.      ! use implicit vertical viscosity (recommended for stability)
 /
 
+! ============================================================================
+! GENERAL DYNAMICS SETTINGS
+! ============================================================================
 &dynamics_general
-momadv_opt   = 2       ! option for momentum advection in moment only =2
-use_freeslip = .false. ! Switch on free slip
-use_wsplit   = .false. ! Switch for implicite/explicte splitting of vert. velocity
-wsplit_maxcfl= 1.0     ! maximum allowed CFL criteria in vertical (0.5 < w_max_cfl < 1.) 
-                       ! in older FESOM it used to be w_exp_max=1.e-3
-ldiag_KE=.false.       ! activates energy diagnostics
+! --- Momentum Advection ---
+momadv_opt         = 2           ! momentum advection option (only 2 is currently supported)
+
+! --- Boundary Conditions ---
+use_freeslip       = .false.     ! enable free-slip lateral boundary conditions (false = no-slip)
+
+! --- Vertical Velocity Splitting ---
+use_wsplit         = .false.     ! enable implicit/explicit splitting of vertical velocity
+wsplit_maxcfl      = 1.0         ! maximum allowed vertical CFL criterion (range: 0.5-1.0)
+                                 ! in older FESOM versions this was w_exp_max=1.e-3
+
+! --- Energy Diagnostics ---
+ldiag_KE           = .false.     ! enable kinetic energy diagnostics (requires additional computation)
 /
 

--- a/config/bin_3p3z2d/namelist.forcing
+++ b/config/bin_3p3z2d/namelist.forcing
@@ -1,80 +1,154 @@
-! This is the namelist file for forcing
+! ============================================================================
+! ============= Namelist file for FESOM2 atmospheric forcing ================
+! ============================================================================
+! This file contains configuration for atmospheric forcing and surface boundary
+! conditions, including:
+! - Bulk formulae exchange coefficients (heat, momentum, moisture)
+! - Bulk formulae options and reference heights
+! - Land ice freshwater forcing
+! - Age tracer configuration
+! - Surface forcing data files and variables
+! - Runoff and salinity restoring
+! - Chlorophyll data for shortwave penetration
+! ============================================================================
+! ----------------------------------------------------------------------------
+! File names below are relative to ForcingDataPath in namelist.config. A name
+! starting with '/' is used as given, which is how files outside the forcing
+! tree (for example the Sweeney chlorophyll climatology) are pointed at.
+! ----------------------------------------------------------------------------
 
+! ============================================================================
+! BULK FORMULAE EXCHANGE COEFFICIENTS
+! ============================================================================
+! These coefficients control the turbulent exchange of heat, moisture, and
+! momentum between the atmosphere and ocean/ice surfaces.
+! ============================================================================
 &forcing_exchange_coeff
-Ce_atm_oce=0.00175 ! exchange coeff. of latent heat over open water
-Ch_atm_oce=0.00175 ! exchange coeff. of sensible heat over open water
-Cd_atm_oce=0.001  ! drag coefficient between atmosphere and water
-Ce_atm_ice=0.00175 ! exchange coeff. of latent heat over ice
-Ch_atm_ice=0.00175 ! exchange coeff. of sensible heat over ice
-Cd_atm_ice=0.0012  ! drag coefficient between atmosphere and ice 
-Swind     =0.0     ! parameterization for coupled current feedback
+Ce_atm_oce = 0.00175    ! exchange coefficient of latent heat over open water (dimensionless)
+Ch_atm_oce = 0.00175    ! exchange coefficient of sensible heat over open water (dimensionless)
+Cd_atm_oce = 0.001      ! drag coefficient between atmosphere and water (dimensionless)
+Ce_atm_ice = 0.00175    ! exchange coefficient of latent heat over ice (dimensionless)
+Ch_atm_ice = 0.00175    ! exchange coefficient of sensible heat over ice (dimensionless)
+Cd_atm_ice = 0.0012     ! drag coefficient between atmosphere and ice (dimensionless)
+Swind       = 0.0       ! parameterization for coupled current feedback (0.0 = disabled)
+                        ! non-zero values reduce wind stress based on ocean surface currents
 /
 
+! ============================================================================
+! BULK FORMULAE OPTIONS
+! ============================================================================
+! Configuration for bulk formulae calculations (turbulent fluxes).
+! Reference heights must match the forcing data specifications.
+! ============================================================================
 &forcing_bulk
-AOMIP_drag_coeff=.false.
-ncar_bulk_formulae=.true.
-ncar_bulk_z_wind=10.0 ! height at which wind forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-ncar_bulk_z_tair=10.0 ! height at which temp forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-ncar_bulk_z_shum=10.0 ! height at which humi forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-
+AOMIP_drag_coeff  = .false.  ! use AOMIP drag coefficient formulation (false = use standard)
+ncar_bulk_formulae = .true.  ! use NCAR bulk formulae (Large & Yeager 2004, 2009)
+ncar_bulk_z_wind   = 10.0    ! reference height for wind forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_tair   = 10.0    ! reference height for air temperature forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_shum   = 10.0    ! reference height for specific humidity forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
 /
 
+! ============================================================================
+! LAND ICE FRESHWATER FORCING
+! ============================================================================
+! Configuration for freshwater input from land ice (glaciers, ice sheets).
+! Requires use_landice_water=.true. in namelist.config to enable output.
+! ============================================================================
 &land_ice
-use_landice_water=.false.
-landice_start_mon=5
-landice_end_mon=10
-fwf_path='./mesh/'
-
+use_landice_water = .false.  ! enable land ice freshwater forcing
+landice_start_mon = 5        ! start month for land ice forcing (1-12)
+landice_end_mon   = 10       ! end month for land ice forcing (1-12)
+fwf_path          = './mesh/'    ! path to land ice freshwater flux data files
 /
 
+! ============================================================================
+! AGE TRACER CONFIGURATION
+! ============================================================================
+! Configuration for passive age tracer (tracks water mass age).
+! Requires use_age_tracer=.true. in namelist.config to enable output.
+! ============================================================================
 &age_tracer
-use_age_tracer=.false.
-use_age_mask=.false.
-age_tracer_path='./mesh/'
-age_start_year=2000
-
+use_age_tracer    = .false.  ! enable age tracer computation
+use_age_mask      = .false.  ! use spatial mask for age tracer initialization
+age_tracer_path   = './mesh/'    ! path to age tracer mask file (if use_age_mask=.true.)
+age_start_year    = 2000     ! year to start age tracer (tracer age = 0 at this year)
 /
 
+! ============================================================================
+! SURFACE BOUNDARY CONDITION (FORCING DATA)
+! ============================================================================
+! Specification of atmospheric forcing data files and variables.
+! File paths are relative to the run directory.
+! ============================================================================
 &nam_sbc
-   nm_xwind_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/uas.clim61'        ! name of file with winds, if nm_sbc=2
-   nm_ywind_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/vas.clim61'        ! name of file with winds, if nm_sbc=2
-   nm_xstre_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/uas.clim61'        ! name of file with winds, if nm_sbc=2
-   nm_ystre_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/vas.clim61'        ! name of file with winds, if nm_sbc=2
-   nm_humi_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/huss.clim61'        ! name of file with humidity
-   nm_qsr_file   = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/rsds.clim61'    ! name of file with solar heat
-   nm_qlw_file   = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/rlds.clim61'    ! name of file with Long wave
-   nm_tair_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/tas.clim61'        ! name of file with 2m air temperature
+   ! --- Forcing file paths ---
+   nm_xwind_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/uas.clim61' ! name of file with zonal wind speeds
+   nm_ywind_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/vas.clim61' ! name of file with meridional wind speeds
+   nm_xstre_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/uas.clim61' ! name of file with zonal wind stress
+   nm_ystre_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/vas.clim61' ! name of file with meridional wind stress
+   nm_humi_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/huss.clim61' ! name of file with air humidity
+   nm_qsr_file   = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/rsds.clim61' ! name of file with short wave radiation
+   nm_qlw_file   = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/rlds.clim61' ! name of file with long wave radiation
+   nm_tair_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/tas.clim61' ! name of file with 2m air temperature
    nm_prec_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/prra.clim61' ! name of file with total precipitation
-   nm_snow_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/prsn.clim61' ! name of file with snow  precipitation
+   nm_snow_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/prsn.clim61' ! name of file with snow precipitation
    nm_mslp_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/psl.clim61'         ! air_pressure_at_sea_level
-   nm_xwind_var  = 'uas'   ! name of variable in file with wind
-   nm_ywind_var  = 'vas'   ! name of variable in file with wind
-   nm_xstre_var  = 'uas'   ! name of variable in file with wind
-   nm_ystre_var  = 'vas'   ! name of variable in file with wind
-   nm_humi_var   = 'huss'  ! name of variable in file with humidity
-   nm_qsr_var    = 'rsds'  ! name of variable in file with solar heat
-   nm_qlw_var    = 'rlds'  ! name of variable in file with Long wave
-   nm_tair_var   = 'tas'   ! name of variable in file with 2m air temperature
-   nm_prec_var   = 'prra'  ! name of variable in file with total precipitation
-   nm_snow_var   = 'prsn'  ! name of variable in file with total precipitation
-   nm_mslp_var   = 'psl'   ! name of variable in file with air_pressure_at_sea_level
-   nm_nc_iyear   = 1900
-   nm_nc_imm     = 1            ! initial month of time axis in netCDF 
-   nm_nc_idd     = 1            ! initial day of time axis in netCDF
-   nm_nc_freq    = 1            ! data points per day (i.e. 86400 if the time axis is in seconds)
-   nm_nc_tmid    = 0            ! 1 if the time stamps are given at the mid points of the netcdf file, 0 otherwise (i.e. 1 in CORE1, CORE2; 0 in JRA55)
-   y_perpetual=.true.
-   l_xwind=.true. l_ywind=.true. l_xstre=.false. l_ystre=.false. l_humi=.true. l_qsr=.true. l_qlw=.true. l_tair=.true. l_prec=.true. l_mslp=.true. l_cloud=.false. l_snow=.true.
-   nm_runoff_file      ='/albedo/pool/FESOM/forcing/CORE2/runoff.nc'
-   runoff_data_source ='CORE2'	!Dai09, CORE2
-   !runoff_data_source ='Dai09'  !Dai09, CORE2, JRA55
-   !runoff_climatology =.true.
-   sss_data_source    ='CORE2'
-   nm_sss_data_file   ='/albedo/pool/FESOM/forcing/CORE2/PHC2_salx.nc'
-   chl_data_source    ='None' !'Sweeney' monthly chlorophyll climatology or 'NONE' for constant chl_const (below). Make use_sw_pene=.TRUE. in namelist.config!
-   nm_chl_data_file   ='/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/Sweeney/Sweeney_2005.nc'
-   chl_const          = 0.1
-   use_runoff_mapper  = .FALSE.
-   runoff_basins_file = 'runoff_maps_regular.nc'
-   runoff_radius      = 500000.
+
+   ! --- Variable names in netCDF forcing files ---
+   nm_xwind_var  = 'uas'      ! name of variable in file with zonal wind
+   nm_ywind_var  = 'vas'      ! name of variable in file with meridional wind
+   nm_xstre_var  = 'uas'      ! name of variable in file with zonal wind stress
+   nm_ystre_var  = 'vas'      ! name of variable in file with meridional wind stress
+   nm_humi_var   = 'huss'     ! name of variable in file with humidity
+   nm_qsr_var    = 'rsds'     ! name of variable in file with solar heat
+   nm_qlw_var    = 'rlds'     ! name of variable in file with long wave
+   nm_tair_var   = 'tas'      ! name of variable in file with 2m air temperature
+   nm_prec_var   = 'prra'     ! name of variable in file with total precipitation
+   nm_snow_var   = 'prsn'     ! name of variable in file with snow precipitation
+   nm_mslp_var   = 'psl'      ! name of variable in file with air_pressure_at_sea_level
+
+   ! --- Time axis configuration in forcing files ---
+   nm_nc_iyear   = 1900       ! initial year of forcing data time axis (note, not the first year in the file!)
+   nm_nc_imm     = 1          ! initial month of forcing data time axis (1-12)
+   nm_nc_idd     = 1          ! initial day of forcing data time axis (1-31)
+   nm_nc_freq    = 1          ! divisor converting the time axis of the forcing files to days (1 = days, 24 = hours, 86400 = seconds)
+   nm_nc_tmid    = 0          ! time stamp position: 1=mid-point, 0=start of interval
+   y_perpetual   = .true.     ! use perpetual year forcing (repeat single year)
+
+   ! --- Enable/disable individual forcing fields ---
+   l_xwind       = .true.     ! use zonal wind forcing
+   l_ystre=.false.
+   l_ywind       = .true.     ! use meridional wind forcing
+   l_humi        = .true.     ! use specific humidity forcing
+   l_qsr         = .true.     ! use shortwave radiation forcing
+   l_qlw         = .true.     ! use longwave radiation forcing
+   l_tair        = .true.     ! use air temperature forcing
+   l_xstre=.false.
+   l_prec        = .true.     ! use precipitation forcing
+   l_mslp        = .true.     ! use mean sea level pressure forcing
+   l_cloud       = .false.    ! use cloud cover forcing
+   l_snow        = .true.     ! use snow precipitation forcing
+
+   ! --- Runoff configuration ---
+   runoff_data_source = 'CORE2'       ! runoff data source: 'Dai09', 'JRA55', 'CORE1', 'CORE2' or 'NONE'
+   nm_runoff_file     = '/albedo/pool/FESOM/forcing/CORE2/runoff.nc' ! CORE2 monthly climatology with runoff_climatology=.true.
+   !nm_runoff_file     = 'friver.'  ! Dai09/JRA55 with runoff_climatology=.false.: prefix, year and '.nc' are appended (friver.1958.nc).
+
+   ! --- Sea surface salinity restoring ---
+   sss_data_source  = 'CORE2'  ! SSS restoring data source: 'CORE2', 'WOA', or 'NONE'
+   nm_sss_data_file = '/albedo/pool/FESOM/forcing/CORE2/PHC2_salx.nc' ! path to SSS restoring data file, e.g. PHC2_salx.nc
+
+   ! --- Chlorophyll data for shortwave penetration ---
+   chl_data_source  = 'None'      ! chlorophyll data source: 'Sweeney' (monthly climatology) or 'None' (constant)
+                               ! requires use_sw_pene=.true. in namelist.config
+   nm_chl_data_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/Sweeney/Sweeney_2005.nc' ! chlorophyll data file (if Sweeney)
+   chl_const        = 0.1      ! constant chlorophyll concentration [mg/m³] (if chl_data_source='None')
+
+   ! --- Runoff mapper (distributes runoff over coastal area) ---
+   use_runoff_mapper  = .false.  ! enable runoff mapper (spreads runoff spatially)
+   runoff_basins_file = 'runoff_maps_regular.nc' ! runoff basin mapping file
+   runoff_radius      = 500000.  ! radius for runoff spreading [m] (if use_runoff_mapper=.true.)
 /

--- a/config/bin_3p3z2d/namelist.ice
+++ b/config/bin_3p3z2d/namelist.ice
@@ -1,31 +1,76 @@
-! Ice namelist
+! ============================================================================
+! ============== Namelist file for FESOM2 sea ice model =====================
+! ============================================================================
+! This file contains configuration for sea ice dynamics and thermodynamics:
+! - EVP (Elastic-Viscous-Plastic) rheology options
+! - Ice strength and deformation parameters
+! - Ocean-ice drag
+! - Ice thermodynamics and thickness distribution
+! - Albedo parameterizations
+! ============================================================================
+
+! ============================================================================
+! SEA ICE DYNAMICS
+! ============================================================================
 &ice_dyn
-whichEVP=0             ! 0=standart; 1=mEVP; 2=aEVP
-Pstar=30000.0          ! [N/m^2]
-ellipse=2.0
-c_pressure=20.0        ! ice concentration parameter used in ice strength computation
-delta_min=1.0e-11      ! [s^(-1)]
-evp_rheol_steps=120    ! number of EVP subcycles
-alpha_evp=250          ! constant that control numerical stability of mEVP. Adjust with resolution. 
-beta_evp=250           ! constant that control numerical stability of mEVP. Adjust with resolution.
-c_aevp=0.15            ! a tuning constant in aEVP. Adjust with resolution.
-Cd_oce_ice=0.0055      ! drag coef. oce - ice 
-ice_gamma_fct=0.5      ! smoothing parameter
-ice_diff=0.0           ! diffusion to stabilize
-theta_io=0.0           ! rotation angle
-ice_ave_steps=1        ! ice step=ice_ave_steps*oce_step
+! --- EVP Rheology Options ---
+whichEVP       = 0              ! EVP solver type:
+                                !   0 = standard EVP
+                                !   1 = modified EVP (mEVP)
+                                !   2 = adaptive EVP (aEVP)
+
+! --- Ice Strength Parameters ---
+Pstar          = 30000.0        ! ice strength parameter [N/m²] (typical: 20000-30000)
+ellipse        = 2.0            ! aspect ratio of yield curve ellipse (dimensionless)
+c_pressure     = 20.0           ! ice concentration parameter for strength computation (dimensionless)
+
+! --- Ice Deformation ---
+delta_min      = 1.0e-11        ! minimum strain rate for viscosity regularization [s⁻¹]
+
+! --- EVP Subcycling ---
+evp_rheol_steps = 120           ! number of EVP subcycles per ice time step
+
+! --- mEVP Stability Parameters (for whichEVP=1) ---
+alpha_evp      = 250            ! mEVP stability constant (adjust with resolution)
+beta_evp       = 250            ! mEVP stability constant (adjust with resolution)
+
+! --- aEVP Tuning (for whichEVP=2) ---
+c_aevp         = 0.15           ! aEVP tuning constant (adjust with resolution)
+
+! --- Ocean-Ice Coupling ---
+Cd_oce_ice     = 0.0055         ! drag coefficient between ocean and ice (dimensionless, typical: 0.0055)
+
+! --- Numerical Stabilization ---
+ice_gamma_fct  = 0.5            ! smoothing parameter for ice dynamics (0.0-1.0)
+ice_diff       = 0.0            ! artificial diffusion for numerical stability [m²/s]
+theta_io       = 0.0            ! rotation angle for ice-ocean stress [degrees]
+
+! --- Time Stepping ---
+ice_ave_steps  = 1              ! ice time step = ice_ave_steps × ocean time step
 /
 
+! ============================================================================
+! SEA ICE THERMODYNAMICS
+! ============================================================================
 &ice_therm
-Sice=4.0               ! Ice salinity 3.2--5.0 ppt.
-h0=.5                  ! Lead closing parameter [m] 
-emiss_ice=0.97         ! Emissivity of Snow/Ice,
-emiss_wat=0.97         ! Emissivity of open water
-albsn=0.81             ! Albedo: frozen snow
-albsnm=0.77            !         melting snow
-albi=0.7               !         frozen ice
-albim=0.68             !         melting ice
-albw=0.1               !         open water
-con=2.1656             ! Thermal conductivities: ice; W/m/K
-consn=0.31             !                         snow
+! --- Ice Properties ---
+Sice           = 4.0            ! bulk ice salinity [ppt] (typical range: 3.2-5.0)
+
+! --- Lead Closing Parameters ---
+h0             = 0.5            ! lead closing parameter for Northern Hemisphere [m]
+
+! --- Emissivity (Longwave Radiation) ---
+emiss_ice      = 0.97           ! emissivity of snow/ice surface (dimensionless, 0-1)
+emiss_wat      = 0.97           ! emissivity of open water (dimensionless, 0-1)
+
+! --- Albedo (Shortwave Radiation) ---
+albsn             = 0.81           ! albedo of frozen snow (dimensionless, 0-1)
+albsnm            = 0.77           ! albedo of melting snow (dimensionless, 0-1)
+albi              = 0.7            ! albedo of frozen ice (dimensionless, 0-1)
+albim             = 0.68           ! albedo of melting ice (dimensionless, 0-1)
+albw              = 0.1            ! albedo of open water (dimensionless, 0-1)
+
+! --- Thermal Conductivity ---
+con            = 2.1656         ! thermal conductivity of ice [W/m/K]
+consn          = 0.31           ! thermal conductivity of snow [W/m/K]
 /

--- a/config/bin_3p3z2d/namelist.icepack
+++ b/config/bin_3p3z2d/namelist.icepack
@@ -1,4 +1,23 @@
-&env_nml                    ! In the original release these variables are defined in the icepack.settings
+! ============================================================================
+! =============== Namelist file for FESOM2 Icepack sea ice ===================
+! ============================================================================
+! This file contains configuration for the Icepack column physics package,
+! used when FESOM2 is built with Icepack (see docs/icepack_in_fesom.rst):
+! - Tracer array sizes and switches
+! - Ice thickness distribution and thermodynamics
+! - Shortwave radiation and albedo
+! - Melt ponds
+! - Surface forcing options
+! - Ridging and ice strength
+! - Icepack output variables
+! ============================================================================
+
+! ============================================================================
+! ENVIRONMENT (ARRAY SIZES)
+! ============================================================================
+! In the original Icepack release these are set in icepack.settings.
+! ============================================================================
+&env_nml
     nicecat   = 5           ! number of ice thickness categories
     nfsdcat   = 1           ! number of floe size categories
     nicelyr   = 4           ! number of vertical layers in the ice
@@ -6,110 +25,160 @@
     ntraero   = 0           ! number of aerosol tracers (up to max_aero in ice_domain_size.F90)
     trzaero   = 0           ! number of z aerosol tracers (up to max_aero = 6)
     tralg     = 0           ! number of algal tracers (up to max_algae = 3)
-    trdoc     = 0           ! number of dissolve organic carbon (up to max_doc = 3)
-    trdic     = 0           ! number of dissolve inorganic carbon (up to max_dic = 1)
-    trdon     = 0           ! number of dissolve organic nitrogen (up to max_don = 1)
-    trfed     = 0           ! number of dissolved iron tracers (up to max_fe  = 2)
-    trfep     = 0           ! number of particulate iron tracers (up to max_fe  = 2)
+    trdoc     = 0           ! number of dissolved organic carbon tracers (up to max_doc = 3)
+    trdic     = 0           ! number of dissolved inorganic carbon tracers (up to max_dic = 1)
+    trdon     = 0           ! number of dissolved organic nitrogen tracers (up to max_don = 1)
+    trfed     = 0           ! number of dissolved iron tracers (up to max_fe = 2)
+    trfep     = 0           ! number of particulate iron tracers (up to max_fe = 2)
     nbgclyr   = 0           ! number of zbgc layers
-    trbgcz    = 0           ! set to 1 for zbgc tracers (needs TRBGCS = 0 and TRBRI = 1)
-    trzs      = 0           ! set to 1 for zsalinity tracer (needs TRBRI = 1)
+    trbgcz    = 0           ! set to 1 for zbgc tracers (needs trbgcs = 0 and trbri = 1)
+    trzs      = 0           ! set to 1 for zsalinity tracer (needs trbri = 1)
     trbri     = 0           ! set to 1 for brine height tracer
     trage     = 0           ! set to 1 for ice age tracer
     trfy      = 0           ! set to 1 for first-year ice area tracer
     trlvl     = 0           ! set to 1 for level and deformed ice tracers
     trpnd     = 0           ! set to 1 for melt pond tracers
-    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs TRBGCZ = 0)
+    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs trbgcz = 0)
     ndtd      = 1           ! dynamic time steps per thermodynamic time step
 /
 
+! ============================================================================
+! ICE THICKNESS CATEGORIES
+! ============================================================================
 &grid_nml
-    kcatbound    = 1
+    kcatbound    = 1        ! category boundary formula:
+                            !   -1 = single category (column configurations, nicecat = 1)
+                            !    0 = old formula, 1 = new formula with round numbers
+                            !    2 = WMO standard categories (nicecat = 5, 6 or 7 only)
+                            !    3 = asymptotic scheme
 /
 
+! ============================================================================
+! TRACER SWITCHES
+! ============================================================================
+! Any melt pond scheme with calc_Tsfc = .true. needs shortwave = 'dEdd'.
+! ============================================================================
 &tracer_nml
-    tr_iage      = .false.
-    tr_FY        = .false.
-    tr_lvl       = .false.
-    tr_pond_cesm = .false.
-    tr_pond_topo = .false.
-    tr_pond_lvl  = .false.
-    tr_aero      = .false.
-    tr_fsd       = .false.
+    tr_iage      = .false.  ! ice age tracer
+    tr_FY        = .false.  ! first-year ice area tracer
+    tr_lvl       = .false.  ! level (undeformed) ice area and volume tracers
+    tr_pond_cesm = .false.  ! CESM melt pond scheme
+    tr_pond_topo = .false.  ! topographic melt pond scheme
+    tr_pond_lvl  = .false.  ! level-ice melt pond scheme (needs tr_lvl, forces hs0 = 0)
+    tr_aero      = .false.  ! aerosol tracers (needs shortwave = 'dEdd')
+    tr_fsd       = .false.  ! floe size distribution
 /
 
+! ============================================================================
+! THERMODYNAMICS
+! ============================================================================
 &thermo_nml
-    kitd              = 1
-    ktherm            = 1
-    conduct           = 'bubbly'
-    a_rapid_mode      =  0.5e-3
-    Rac_rapid_mode    =    10.0
-    aspect_rapid_mode =     1.0
-    dSdt_slow_mode    = -5.0e-8
-    phi_c_slow_mode   =    0.05
-    phi_i_mushy       =    0.85
-    ksno              = 0.3
+! --- Thickness Distribution and Thermodynamics Scheme ---
+    kitd              = 1           ! ice thickness distribution: 0 = delta function, 1 = linear remapping
+    ktherm            = 1           ! thermodynamics: 1 = Bitz & Lipscomb (1999), 2 = mushy layer
+                                    ! ktherm = 1 expects tfrz_option = 'linear_salt',
+                                    ! ktherm = 2 expects tfrz_option = 'mushy' and calc_Tsfc = .true.
+    conduct           = 'bubbly'    ! ice thermal conductivity (ktherm = 1):
+                                    !   'MU71' = Maykut & Untersteiner (1971), 'bubbly' = Pringle et al. (2007)
+
+! --- Mushy Layer Brine Drainage (ktherm = 2) ---
+    a_rapid_mode      =  0.5e-3     ! brine channel diameter [m]
+    Rac_rapid_mode    =    10.0     ! critical Rayleigh number for rapid drainage
+    aspect_rapid_mode =     1.0     ! brine convection aspect ratio
+    dSdt_slow_mode    = -5.0e-8     ! slow drainage strength parameter [m/(s K)]
+    phi_c_slow_mode   =    0.05     ! critical liquid fraction for slow drainage
+    phi_i_mushy       =    0.85     ! solid fraction at the lower ice boundary
+
+! --- Snow ---
+    ksno              = 0.3         ! thermal conductivity of snow [W/(m K)]
 /
 
+! ============================================================================
+! SHORTWAVE RADIATION AND ALBEDO
+! ============================================================================
 &shortwave_nml
-    shortwave       = 'ccsm3'
-    albedo_type     = 'ccsm3'
-    albicev         = 0.78
-    albicei         = 0.36
-    albsnowv        = 0.98
-    albsnowi        = 0.70
-    albocn          = 0.1
-    ahmax           = 0.3
-    R_ice           = 0.
-    R_pnd           = 0.
-    R_snw           = 1.5
-    dT_mlt          = 1.5
-    rsnw_mlt        = 1500.
-    kalg            = 0.6
+! --- Scheme Selection ---
+    shortwave       = 'ccsm3'   ! shortwave scheme: 'ccsm3' (bulk albedo) or 'dEdd' (Delta-Eddington)
+    albedo_type     = 'ccsm3'   ! albedo parameterization with shortwave = 'ccsm3': 'ccsm3' or 'constant'
+
+! --- Bulk Albedos (shortwave = 'ccsm3') ---
+    albicev         = 0.78      ! visible albedo of thick bare ice
+    albicei         = 0.36      ! near-infrared albedo of thick bare ice
+    albsnowv        = 0.98      ! visible albedo of cold snow
+    albsnowi        = 0.70      ! near-infrared albedo of cold snow
+    albocn          = 0.1       ! ocean albedo
+    ahmax           = 0.3       ! ice thickness above which the albedo is constant [m]
+
+! --- Delta-Eddington Tuning (shortwave = 'dEdd') ---
+    R_ice           = 0.        ! sea ice albedo tuning [standard deviations]
+    R_pnd           = 0.        ! melt pond albedo tuning [standard deviations]
+    R_snw           = 1.5       ! snow grain radius tuning [standard deviations]
+    dT_mlt          = 1.5       ! temperature change that gives rsnw_mlt [deg C]
+    rsnw_mlt        = 1500.     ! maximum melting snow grain radius [micrometres]
+    kalg            = 0.6       ! absorption coefficient for algae
 /
 
+! ============================================================================
+! MELT PONDS
+! ============================================================================
 &ponds_nml
-    hp1             = 0.01
-    hs0             = 0.
-    hs1             = 0.03
-    dpscale         = 1.e-3
-    frzpnd          = 'hlid'
-    rfracmin        = 0.15
-    rfracmax        = 1.
-    pndaspect       = 0.8
+    hp1             = 0.01      ! critical parameter for pond ice thickness [m]
+    hs0             = 0.        ! snow depth for transition to bare sea ice [m]
+    hs1             = 0.03      ! snow depth for transition to pond ice [m] (tr_pond_lvl)
+    dpscale         = 1.e-3     ! time scale for flushing in permeable ice (not used with tr_pond_cesm)
+    frzpnd          = 'hlid'    ! pond refreezing: 'cesm' or 'hlid' (Stefan refreezing with a pond ice lid)
+    rfracmin        = 0.15      ! minimum fraction of melt water added to ponds
+    rfracmax        = 1.        ! maximum fraction of melt water added to ponds
+    pndaspect       = 0.8       ! aspect ratio of pond changes (depth:area)
 /
 
+! ============================================================================
+! SURFACE FORCING OPTIONS
+! ============================================================================
 &forcing_nml
-    formdrag        = .false.
-    atmbndy         = 'default'
-    calc_strair     = .true.
-    calc_Tsfc       = .true.
-    highfreq        = .false.
-    natmiter        = 5
-    ustar_min       = 0.0005
-    emissivity      = 0.95
-    fbot_xfer_type  = 'constant'
-    update_ocn_f    = .false.
-    l_mpond_fresh   = .false.
-    tfrz_option     = 'linear_salt'
-    oceanmixed_ice  = .true.
-    wave_spec_type  = 'none'
+! --- Atmosphere-Ice Exchange ---
+    formdrag        = .false.       ! calculate form drag (needs calc_strair and tr_lvl, not atmbndy = 'constant')
+    atmbndy         = 'default'     ! atmospheric boundary layer: 'default' (stability dependent) or 'constant'
+    calc_strair     = .true.        ! calculate the wind stress in Icepack instead of reading it
+    calc_Tsfc       = .true.        ! calculate the surface temperature in Icepack instead of reading it
+    highfreq        = .false.       ! high-frequency atmosphere-ice coupling (Roberts et al. 2015)
+    natmiter        = 5             ! number of iterations for the atmospheric boundary layer fluxes
+    emissivity      = 0.95          ! emissivity of snow and ice
+
+! --- Ice-Ocean Exchange ---
+    ustar_min       = 0.0005        ! minimum friction velocity for the ice-ocean heat flux [m/s]
+    fbot_xfer_type  = 'constant'    ! ice-ocean heat transfer coefficient: 'constant' or 'Cdn_ocn' (needs formdrag)
+    update_ocn_f    = .false.       ! include frazil ice fluxes in the ocean flux fields
+    l_mpond_fresh   = .false.       ! retain (topo) pond water until the ponds drain
+    tfrz_option     = 'linear_salt' ! seawater freezing temperature: 'minus1p8', 'linear_salt' or 'mushy'
+    oceanmixed_ice  = .true.        ! active ocean mixed layer calculation in Icepack
+
+! --- Waves ---
+    wave_spec_type  = 'none'        ! wave spectrum for the floe size distribution: 'none', 'constant' or 'random'
 /
 
+! ============================================================================
+! RIDGING AND ICE STRENGTH
+! ============================================================================
 &dynamics_nml
-    kstrength       = 1
-    krdg_partic     = 1
-    krdg_redist     = 1
-    mu_rdg          = 3
-    Cf              = 17.
-    P_star          = 27000.
-    C_star          = 20.
+    kstrength       = 1         ! ice strength formulation: 0 = Hibler (1979), 1 = Rothrock (1975)
+    krdg_partic     = 1         ! ridging participation function: 0 = Thorndike et al. (1975), 1 = exponential
+    krdg_redist     = 1         ! ridging redistribution function: 0 = Hibler (1980), 1 = exponential
+    mu_rdg          = 3         ! e-folding scale of ridged ice [m^0.5] (krdg_redist = 1)
+    Cf              = 17.       ! ratio of ridging work to change in potential energy (kstrength = 1)
+    P_star          = 27000.    ! ice strength parameter [N/m²] (kstrength = 0)
+    C_star          = 20.       ! ice strength decay constant [dimensionless] (kstrength = 0)
 /
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!!!!!!!!!                Icepack output namelist                    !!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
+! ============================================================================
+! ICEPACK OUTPUT VARIABLES
+! ============================================================================
+! Format: 'variable_id', frequency, unit, precision
+!   frequency  = output frequency (integer)
+!   unit       = 'y' (yearly), 'm' (monthly), 'd' (daily), 'h' (hourly), 's' (steps)
+!   precision  = 4 (single precision) or 8 (double precision)
+! Remove the leading '!' to enable a variable.
+! ============================================================================
 &nml_list_icepack
 io_list_icepack =  'aicen     ',1, 'm', 4, ! Sea ice concentration
                    'vicen     ',1, 'm', 4, ! Volume per unit area of ice

--- a/config/bin_3p3z2d/namelist.icepack.cesm.ponds
+++ b/config/bin_3p3z2d/namelist.icepack.cesm.ponds
@@ -1,4 +1,23 @@
-&env_nml                    ! In the original release these variables are defined in the icepack.settings
+! ============================================================================
+! =============== Namelist file for FESOM2 Icepack sea ice ===================
+! ============================================================================
+! This file contains configuration for the Icepack column physics package,
+! used when FESOM2 is built with Icepack (see docs/icepack_in_fesom.rst):
+! - Tracer array sizes and switches
+! - Ice thickness distribution and thermodynamics
+! - Shortwave radiation and albedo
+! - Melt ponds
+! - Surface forcing options
+! - Ridging and ice strength
+! - Icepack output variables
+! ============================================================================
+
+! ============================================================================
+! ENVIRONMENT (ARRAY SIZES)
+! ============================================================================
+! In the original Icepack release these are set in icepack.settings.
+! ============================================================================
+&env_nml
     nicecat   = 5           ! number of ice thickness categories
     nfsdcat   = 1           ! number of floe size categories
     nicelyr   = 4           ! number of vertical layers in the ice
@@ -6,108 +25,156 @@
     ntraero   = 0           ! number of aerosol tracers (up to max_aero in ice_domain_size.F90)
     trzaero   = 0           ! number of z aerosol tracers (up to max_aero = 6)
     tralg     = 0           ! number of algal tracers (up to max_algae = 3)
-    trdoc     = 0           ! number of dissolve organic carbon (up to max_doc = 3)
-    trdic     = 0           ! number of dissolve inorganic carbon (up to max_dic = 1)
-    trdon     = 0           ! number of dissolve organic nitrogen (up to max_don = 1)
-    trfed     = 0           ! number of dissolved iron tracers (up to max_fe  = 2)
-    trfep     = 0           ! number of particulate iron tracers (up to max_fe  = 2)
+    trdoc     = 0           ! number of dissolved organic carbon tracers (up to max_doc = 3)
+    trdic     = 0           ! number of dissolved inorganic carbon tracers (up to max_dic = 1)
+    trdon     = 0           ! number of dissolved organic nitrogen tracers (up to max_don = 1)
+    trfed     = 0           ! number of dissolved iron tracers (up to max_fe = 2)
+    trfep     = 0           ! number of particulate iron tracers (up to max_fe = 2)
     nbgclyr   = 0           ! number of zbgc layers
-    trbgcz    = 0           ! set to 1 for zbgc tracers (needs TRBGCS = 0 and TRBRI = 1)
-    trzs      = 0           ! set to 1 for zsalinity tracer (needs TRBRI = 1)
+    trbgcz    = 0           ! set to 1 for zbgc tracers (needs trbgcs = 0 and trbri = 1)
+    trzs      = 0           ! set to 1 for zsalinity tracer (needs trbri = 1)
     trbri     = 0           ! set to 1 for brine height tracer
     trage     = 0           ! set to 1 for ice age tracer
     trfy      = 0           ! set to 1 for first-year ice area tracer
     trlvl     = 0           ! set to 1 for level and deformed ice tracers
     trpnd     = 1           ! set to 1 for melt pond tracers
-    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs TRBGCZ = 0)
+    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs trbgcz = 0)
     ndtd      = 1           ! dynamic time steps per thermodynamic time step
 /
 
+! ============================================================================
+! ICE THICKNESS CATEGORIES
+! ============================================================================
 &grid_nml
-    kcatbound    = 1
+    kcatbound    = 1        ! category boundary formula:
+                            !   -1 = single category (column configurations, nicecat = 1)
+                            !    0 = old formula, 1 = new formula with round numbers
+                            !    2 = WMO standard categories (nicecat = 5, 6 or 7 only)
+                            !    3 = asymptotic scheme
 /
 
+! ============================================================================
+! TRACER SWITCHES
+! ============================================================================
+! Any melt pond scheme with calc_Tsfc = .true. needs shortwave = 'dEdd'.
+! ============================================================================
 &tracer_nml
-    tr_iage      = .false.
-    tr_FY        = .false.
-    tr_lvl       = .false.
-    tr_pond_cesm = .true.
-    tr_pond_topo = .false.
-    tr_pond_lvl  = .false.
-    tr_aero      = .false.
-    tr_fsd       = .false.
+    tr_iage      = .false.  ! ice age tracer
+    tr_FY        = .false.  ! first-year ice area tracer
+    tr_lvl       = .false.  ! level (undeformed) ice area and volume tracers
+    tr_pond_cesm = .true.   ! CESM melt pond scheme
+    tr_pond_topo = .false.  ! topographic melt pond scheme
+    tr_pond_lvl  = .false.  ! level-ice melt pond scheme (needs tr_lvl, forces hs0 = 0)
+    tr_aero      = .false.  ! aerosol tracers (needs shortwave = 'dEdd')
+    tr_fsd       = .false.  ! floe size distribution
 /
 
+! ============================================================================
+! THERMODYNAMICS
+! ============================================================================
 &thermo_nml
-    kitd              = 1
-    ktherm            = 1
-    conduct           = 'bubbly'
-    a_rapid_mode      =  0.5e-3
-    Rac_rapid_mode    =    10.0
-    aspect_rapid_mode =     1.0
-    dSdt_slow_mode    = -5.0e-8
-    phi_c_slow_mode   =    0.05
-    phi_i_mushy       =    0.85
+! --- Thickness Distribution and Thermodynamics Scheme ---
+    kitd              = 1           ! ice thickness distribution: 0 = delta function, 1 = linear remapping
+    ktherm            = 1           ! thermodynamics: 1 = Bitz & Lipscomb (1999), 2 = mushy layer
+                                    ! ktherm = 1 expects tfrz_option = 'linear_salt',
+                                    ! ktherm = 2 expects tfrz_option = 'mushy' and calc_Tsfc = .true.
+    conduct           = 'bubbly'    ! ice thermal conductivity (ktherm = 1):
+                                    !   'MU71' = Maykut & Untersteiner (1971), 'bubbly' = Pringle et al. (2007)
+
+! --- Mushy Layer Brine Drainage (ktherm = 2) ---
+    a_rapid_mode      =  0.5e-3     ! brine channel diameter [m]
+    Rac_rapid_mode    =    10.0     ! critical Rayleigh number for rapid drainage
+    aspect_rapid_mode =     1.0     ! brine convection aspect ratio
+    dSdt_slow_mode    = -5.0e-8     ! slow drainage strength parameter [m/(s K)]
+    phi_c_slow_mode   =    0.05     ! critical liquid fraction for slow drainage
+    phi_i_mushy       =    0.85     ! solid fraction at the lower ice boundary
 /
 
+! ============================================================================
+! SHORTWAVE RADIATION AND ALBEDO
+! ============================================================================
 &shortwave_nml
-    shortwave       = 'dEdd'
-    albedo_type     = 'ccsm3'
-    albicev         = 0.78
-    albicei         = 0.36
-    albsnowv        = 0.98
-    albsnowi        = 0.70
-    ahmax           = 0.3
-    R_ice           = 0.
-    R_pnd           = 0.
-    R_snw           = 1.5
-    dT_mlt          = 1.5
-    rsnw_mlt        = 1500.
-    kalg            = 0.6
+! --- Scheme Selection ---
+    shortwave       = 'dEdd'    ! shortwave scheme: 'ccsm3' (bulk albedo) or 'dEdd' (Delta-Eddington)
+    albedo_type     = 'ccsm3'   ! albedo parameterization with shortwave = 'ccsm3': 'ccsm3' or 'constant'
+
+! --- Bulk Albedos (shortwave = 'ccsm3') ---
+    albicev         = 0.78      ! visible albedo of thick bare ice
+    albicei         = 0.36      ! near-infrared albedo of thick bare ice
+    albsnowv        = 0.98      ! visible albedo of cold snow
+    albsnowi        = 0.70      ! near-infrared albedo of cold snow
+    ahmax           = 0.3       ! ice thickness above which the albedo is constant [m]
+
+! --- Delta-Eddington Tuning (shortwave = 'dEdd') ---
+    R_ice           = 0.        ! sea ice albedo tuning [standard deviations]
+    R_pnd           = 0.        ! melt pond albedo tuning [standard deviations]
+    R_snw           = 1.5       ! snow grain radius tuning [standard deviations]
+    dT_mlt          = 1.5       ! temperature change that gives rsnw_mlt [deg C]
+    rsnw_mlt        = 1500.     ! maximum melting snow grain radius [micrometres]
+    kalg            = 0.6       ! absorption coefficient for algae
 /
 
+! ============================================================================
+! MELT PONDS
+! ============================================================================
 &ponds_nml
-    hp1             = 0.01
-    hs0             = 0.
-    hs1             = 0.03
-    dpscale         = 1.e-3
-    frzpnd          = 'hlid'
-    rfracmin        = 0.15
-    rfracmax        = 1.
-    pndaspect       = 0.8
+    hp1             = 0.01      ! critical parameter for pond ice thickness [m]
+    hs0             = 0.        ! snow depth for transition to bare sea ice [m]
+    hs1             = 0.03      ! snow depth for transition to pond ice [m] (tr_pond_lvl)
+    dpscale         = 1.e-3     ! time scale for flushing in permeable ice (not used with tr_pond_cesm)
+    frzpnd          = 'hlid'    ! pond refreezing: 'cesm' or 'hlid' (Stefan refreezing with a pond ice lid)
+    rfracmin        = 0.15      ! minimum fraction of melt water added to ponds
+    rfracmax        = 1.        ! maximum fraction of melt water added to ponds
+    pndaspect       = 0.8       ! aspect ratio of pond changes (depth:area)
 /
 
+! ============================================================================
+! SURFACE FORCING OPTIONS
+! ============================================================================
 &forcing_nml
-    formdrag        = .false.
-    atmbndy         = 'default'
-    calc_strair     = .true.
-    calc_Tsfc       = .true.
-    highfreq        = .false.
-    natmiter        = 5
-    ustar_min       = 0.0005
-    emissivity      = 0.95
-    fbot_xfer_type  = 'constant'
-    update_ocn_f    = .false.
-    l_mpond_fresh   = .false.
-    tfrz_option     = 'linear_salt'
-    oceanmixed_ice  = .true.
-    wave_spec_type  = 'none'
+! --- Atmosphere-Ice Exchange ---
+    formdrag        = .false.       ! calculate form drag (needs calc_strair and tr_lvl, not atmbndy = 'constant')
+    atmbndy         = 'default'     ! atmospheric boundary layer: 'default' (stability dependent) or 'constant'
+    calc_strair     = .true.        ! calculate the wind stress in Icepack instead of reading it
+    calc_Tsfc       = .true.        ! calculate the surface temperature in Icepack instead of reading it
+    highfreq        = .false.       ! high-frequency atmosphere-ice coupling (Roberts et al. 2015)
+    natmiter        = 5             ! number of iterations for the atmospheric boundary layer fluxes
+    emissivity      = 0.95          ! emissivity of snow and ice
+
+! --- Ice-Ocean Exchange ---
+    ustar_min       = 0.0005        ! minimum friction velocity for the ice-ocean heat flux [m/s]
+    fbot_xfer_type  = 'constant'    ! ice-ocean heat transfer coefficient: 'constant' or 'Cdn_ocn' (needs formdrag)
+    update_ocn_f    = .false.       ! include frazil ice fluxes in the ocean flux fields
+    l_mpond_fresh   = .false.       ! retain (topo) pond water until the ponds drain
+    tfrz_option     = 'linear_salt' ! seawater freezing temperature: 'minus1p8', 'linear_salt' or 'mushy'
+    oceanmixed_ice  = .true.        ! active ocean mixed layer calculation in Icepack
+
+! --- Waves ---
+    wave_spec_type  = 'none'        ! wave spectrum for the floe size distribution: 'none', 'constant' or 'random'
 /
 
+! ============================================================================
+! RIDGING AND ICE STRENGTH
+! ============================================================================
 &dynamics_nml
-    kstrength       = 1
-    krdg_partic     = 1
-    krdg_redist     = 1
-    mu_rdg          = 3
-    Cf              = 17.
-    P_star          = 27000.
-    C_star          = 20.
+    kstrength       = 1         ! ice strength formulation: 0 = Hibler (1979), 1 = Rothrock (1975)
+    krdg_partic     = 1         ! ridging participation function: 0 = Thorndike et al. (1975), 1 = exponential
+    krdg_redist     = 1         ! ridging redistribution function: 0 = Hibler (1980), 1 = exponential
+    mu_rdg          = 3         ! e-folding scale of ridged ice [m^0.5] (krdg_redist = 1)
+    Cf              = 17.       ! ratio of ridging work to change in potential energy (kstrength = 1)
+    P_star          = 27000.    ! ice strength parameter [N/m²] (kstrength = 0)
+    C_star          = 20.       ! ice strength decay constant [dimensionless] (kstrength = 0)
 /
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!!!!!!!!!                Icepack output namelist                    !!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
+! ============================================================================
+! ICEPACK OUTPUT VARIABLES
+! ============================================================================
+! Format: 'variable_id', frequency, unit, precision
+!   frequency  = output frequency (integer)
+!   unit       = 'y' (yearly), 'm' (monthly), 'd' (daily), 'h' (hourly), 's' (steps)
+!   precision  = 4 (single precision) or 8 (double precision)
+! Remove the leading '!' to enable a variable.
+! ============================================================================
 &nml_list_icepack
 io_list_icepack =  'aicen     ',1, 'm', 4, ! Sea ice concentration
                    'vicen     ',1, 'm', 4, ! Volume per unit area of ice

--- a/config/bin_3p3z2d/namelist.io
+++ b/config/bin_3p3z2d/namelist.io
@@ -1,26 +1,55 @@
+! ============================================================================
+! ============ Namelist file for FESOM2 output configuration =================
+! ============================================================================
+! This file contains configuration for model output and diagnostics:
+! - Diagnostic flags for optional output fields
+! - General output settings (compression, rotation)
+! - Output variable list with frequency and precision
+! - Complete catalog of all available output fields
+!
+! See the output catalog at the end of this file for all possible variables.
+! Some outputs require specific flags in &diag_list or other namelists.
+! ============================================================================
+
+! ============================================================================
+! DIAGNOSTIC FLAGS
+! ============================================================================
+! Enable/disable optional diagnostic computations and outputs.
+! Setting these to .true. enables additional output fields (see catalog below).
+! ============================================================================
 &diag_list
-ldiag_solver     =.false.
-lcurt_stress_surf=.false.
-ldiag_curl_vel3  =.false.
-ldiag_Ri         =.false.
-ldiag_turbflux   =.false.
-ldiag_salt3D     =.false.
-ldiag_dMOC       =.false.
-ldiag_DVD        =.false.
-ldiag_forc       =.false.
-ldiag_extflds    =.false.
+ldiag_solver      = .false.  ! enables solver diagnostics (convergence, iterations)
+lcurt_stress_surf = .false.  ! enables 'curl_surf' output (vorticity of surface stress)
+ldiag_curl_vel3   = .false.  ! enables 'curl_u' output (relative vorticity from 3D velocity)
+ldiag_Ri          = .false.  ! enables Richardson number diagnostics ('shear', 'Ri')
+ldiag_turbflux    = .false.  ! enables turbulent flux diagnostics ('KvdTdz', 'KvdSdz')
+ldiag_salt3D      = .false.  ! enables 3D salinity diagnostics
+ldiag_dMOC        = .false.  ! enables 'dMOC' output (density MOC diagnostics)
+ldiag_DVD         = .false.  ! enables 'DVD' output (Discrete Variance Decay diagnostics)
+ldiag_forc        = .false.  ! enables 'FORC' output (comprehensive forcing diagnostics)
+ldiag_extflds     = .false.  ! enables extended field diagnostics
 /
 
+! ============================================================================
+! GENERAL OUTPUT SETTINGS
+! ============================================================================
 &nml_general
-io_listsize    =150 !number of streams to allocate. shallbe large or equal to the number of streams in &nml_list
-vec_autorotate =.false.
+io_listsize       = 150      ! total number of streams to allocate. Shall be larger or equal to the number of streams in &nml_list (max. 150)
+vec_autorotate    = .false.  ! unrotate vector fields (velocities, winds) before writing to output files
 /
 
-! for sea ice related variables use_ice should be true, otherewise there will be no output
-! for 'curl_surf' to work lcurt_stress_surf must be .true. otherwise no output
-! for 'fer_C', 'bolus_u', 'bolus_v', 'bolus_w', 'fer_K' to work Fer_GM must be .true. otherwise no output
-! 'otracers' - all other tracers if applicable
-! for 'dMOC' to work ldiag_dMOC must be .true. otherwise no output
+! ============================================================================
+! OUTPUT VARIABLE LIST
+! ============================================================================
+! Format: 'variable_id', frequency, unit, precision
+!   frequency  = output frequency (integer)
+!   unit       = 'y' (yearly), 'm' (monthly), 'd' (daily), 'h' (hourly), 's' (steps)
+!   precision  = 4 (single precision) or 8 (double precision)
+!   Note: in a single-precision build (WP=4) a field requesting precision 8 is
+!   still honoured (written as NF_DOUBLE; means accumulated in real64), but its
+!   samples are single-precision-sourced. FESOM prints one summary line at
+!   startup listing such fields.
+! ============================================================================
 &nml_list
 io_list =  'sst       ',1, 'm', 4,
            'sss       ',1, 'm', 4,
@@ -88,3 +117,277 @@ io_list =  'sst       ',1, 'm', 4,
            'respd',1, 'm', 4,
            'respc',1, 'm', 4,
 /
+
+! ============================================================================
+! COMPLETE CATALOG OF ALL POSSIBLE OUTPUT FIELDS
+! ============================================================================
+! Below is a comprehensive list of all valid io_list IDs available in FESOM2.
+! To enable any field, copy the line to the &nml_list section above.
+! NOTE: Some fields require specific flags to be enabled (see comments).
+! ============================================================================
+
+! --- 2D OCEAN SURFACE FIELDS ---
+! 'sst       ',1, 'm', 4,  ! sea surface temperature [C]
+! 'sss       ',1, 'm', 4,  ! sea surface salinity [psu]
+! 'ssh       ',1, 'm', 4,  ! sea surface elevation [m]
+! 'vve_5     ',1, 'm', 4,  ! vertical velocity at 5th level [m/s]
+! 't_star    ',1, 'm', 4,  ! air temperature [C]
+! 'qsr       ',1, 'm', 4,  ! solar radiation [W/s^2]
+
+! --- 3D OCEAN FIELDS ---
+! 'temp      ',1, 'm', 4,  ! temperature [C]
+! 'salt      ',1, 'm', 8,  ! salinity [psu]
+! 'sigma0    ',1, 'm', 4,  ! potential density [kg/m3]
+! 'u         ',1, 'm', 4,  ! zonal velocity [m/s]
+! 'v         ',1, 'm', 4,  ! meridional velocity [m/s]
+! 'unod      ',1, 'm', 4,  ! zonal velocity at nodes [m/s]
+! 'vnod      ',1, 'm', 4,  ! meridional velocity at nodes [m/s]
+! 'w         ',1, 'm', 4,  ! vertical velocity [m/s]
+! 'otracers  ',1, 'm', 4,  ! all other tracers if applicable
+! 'age       ',1, 'm', 4,  ! water age tracer [year] (require use_age_tracer=.true.)
+
+! --- 2D SSH DIAGNOSTIC VARIABLES ---
+! 'ssh_rhs   ',1, 'm', 4,  ! ssh rhs [m/s]
+! 'ssh_rhs_old',1, 'm', 4, ! ssh rhs old [m/s]
+! 'd_eta     ',1, 'm', 4,  ! dssh from solver [m]
+! 'hbar      ',1, 'm', 4,  ! ssh n+0.5 tstep [m]
+! 'hbar_old  ',1, 'm', 4,  ! ssh n-0.5 tstep [m]
+! 'dhe       ',1, 'm', 4,  ! dhbar @ elem [m]
+
+! --- SEA ICE FIELDS (require use_ice=.true.) ---
+! 'uice      ',1, 'm', 4,  ! ice velocity x [m/s]
+! 'vice      ',1, 'm', 4,  ! ice velocity y [m/s]
+! 'a_ice     ',1, 'm', 4,  ! ice concentration [%]
+! 'm_ice     ',1, 'm', 4,  ! ice height per unit area [m]
+! 'thdgrice  ',1, 'm', 4,  ! thermodynamic growth rate ice [m/s]
+! 'thdgrarea ',1, 'm', 4,  ! thermodynamic growth rate ice concentration [frac/s]
+! 'dyngrarea' ,1, 'm', 4,  ! dynamic growth rate ice concentration [frac/s]
+! 'dyngrice  ',1, 'm', 4,  ! dynamic growth rate ice [m/s]
+! 'thdgrsn   ',1, 'm', 4,  ! thermodynamic growth rate snow [m/s]
+! 'dyngrsnw  ',1, 'm', 4,  ! dynamic growth rate snow [m/s] 
+! 'flice     ',1, 'm', 4,  ! flooding growth rate ice [m/s]
+! 'm_snow    ',1, 'm', 4,  ! snow height per unit area [m]
+! 'h_ice     ',1, 'm', 4,  ! ice thickness over ice-covered fraction [m]
+! 'h_snow    ',1, 'm', 4,  ! snow thickness over ice-covered fraction [m]
+! 'fw_ice    ',1, 'm', 4,  ! fresh water flux from ice ['m/s']
+! 'fw_snw    ',1, 'm', 4,  ! fresh water flux from snow ['m/s']
+
+! --- SEA ICE DEBUG VARIABLES (require use_ice=.true.) ---
+! 'strength_ice',1, 'm', 4,  ! ice strength [?]
+! 'inv_areamass',1, 'm', 4,  ! inv_areamass [?]
+! 'rhs_a     ',1, 'm', 4,  ! rhs_a [?]
+! 'rhs_m     ',1, 'm', 4,  ! rhs_m [?]
+! 'sgm11     ',1, 'm', 4,  ! sgm11 [?]
+! 'sgm12     ',1, 'm', 4,  ! sgm12 [?]
+! 'sgm22     ',1, 'm', 4,  ! sgm22 [?]
+! 'eps11     ',1, 'm', 4,  ! eps11 [?]
+! 'eps12     ',1, 'm', 4,  ! eps12 [?]
+! 'eps22     ',1, 'm', 4,  ! eps22 [?]
+! 'u_rhs_ice ',1, 'm', 4,  ! u_rhs_ice [?]
+! 'v_rhs_ice ',1, 'm', 4,  ! v_rhs_ice [?]
+! 'metric_fac',1, 'm', 4,  ! metric_fac [?]
+! 'elevat_ice',1, 'm', 4,  ! elevat_ice [?]
+! 'uwice     ',1, 'm', 4,  ! uwice [?]
+! 'vwice     ',1, 'm', 4,  ! vwice [?]
+! 'twice     ',1, 'm', 4,  ! twice [?]
+! 'swice     ',1, 'm', 4,  ! swice [?]
+
+! --- MIXED LAYER DEPTH ---
+! 'MLD1      ',1, 'm', 4,  ! Mixed Layer Depth [m] Large et al. 1997, bvfreq(nz, node) > db_max
+! 'MLD2      ',1, 'm', 4,  ! Mixed Layer Depth [m] Levitus treshold, rhopot(nz)-rhopot(1) > 0.125_WP kg/m
+! 'MLD3      ',1, 'm', 4,  ! Mixed Layer Depth [m] Griffies 2016 , rhopot(nz)-rhopot(1) > 0.03_WP kg/m
+
+! --- HEAT CONTENT (require ldiag_destine=.true.) ---
+! 'hc300m    ',1, 'm', 4,  ! Vertically integrated heat content upper 300m [J m**-2]
+! 'hc700m    ',1, 'm', 4,  ! Vertically integrated heat content upper 700m [J m**-2]
+! 'hc        ',1, 'm', 4,  ! Vertically integrated heat content total column [J m**-2]
+
+! --- WATER ISOTOPES IN SEA ICE (require lwiso=.true.) ---
+! 'h2o18_ice ',1, 'm', 4,  ! h2o18 concentration in sea ice [kmol/m**3]
+! 'hDo16_ice ',1, 'm', 4,  ! hDo16 concentration in sea ice [kmol/m**3]
+! 'h2o16_ice ',1, 'm', 4,  ! h2o16 concentration in sea ice [kmol/m**3]
+
+! --- FRESHWATER FLUX (require use_landice_water=.true.) ---
+! 'landice   ',1, 'm', 4,  ! freshwater flux [m/s]
+
+! --- SURFACE FORCING ---
+! 'tx_sur    ',1, 'm', 4,  ! zonal wind str. to ocean [N/m2]
+! 'ty_sur    ',1, 'm', 4,  ! meridional wind str. to ocean [N/m2]
+! 'curl_surf ',1, 'm', 4,  ! vorticity of the surface stress [none] (require lcurt_stress_surf=.true.)
+! 'fh        ',1, 'm', 4,  ! heat flux [W/m2]
+! 'fw        ',1, 'm', 4,  ! fresh water flux [m/s]
+! 'atmice_x  ',1, 'm', 4,  ! stress atmice x [N/m2]
+! 'atmice_y  ',1, 'm', 4,  ! stress atmice y [N/m2]
+! 'atmoce_x  ',1, 'm', 4,  ! stress atmoce x [N/m2]
+! 'atmoce_y  ',1, 'm', 4,  ! stress atmoce y [N/m2]
+! 'iceoce_x  ',1, 'm', 4,  ! stress iceoce x [N/m2]
+! 'iceoce_y  ',1, 'm', 4,  ! stress iceoce y [N/m2]
+! 'alpha     ',1, 'm', 4,  ! thermal expansion [none]
+! 'beta      ',1, 'm', 4,  ! saline contraction [none]
+! 'dens_flux ',1, 'm', 4,  ! density flux [kg/(m3*s)]
+! 'runoff    ',1, 'm', 4,  ! river runoff [m/s]
+! 'evap      ',1, 'm', 4,  ! evaporation [m/s]
+! 'prec      ',1, 'm', 4,  ! precipitation rain [m/s]
+! 'snow      ',1, 'm', 4,  ! precipitation snow [m/s]
+! 'tair      ',1, 'm', 4,  ! surface air temperature [°C]
+! 'shum      ',1, 'm', 4,  ! specific humidity []
+! 'swr       ',1, 'm', 4,  ! short wave radiation [W/m^2]
+! 'lwr       ',1, 'm', 4,  ! long wave radiation [W/m^2]
+! 'uwind     ',1, 'm', 4,  ! 10m zonal surface wind velocity [m/s]
+! 'vwind     ',1, 'm', 4,  ! 10m merid. surface wind velocity [m/s]
+! 'virtsalt  ',1, 'm', 4,  ! virtual salt flux [m/s*psu]
+! 'relaxsalt ',1, 'm', 4,  ! relaxation salt flux [m/s*psu]
+! 'realsalt  ',1, 'm', 4,  ! real salt flux from sea ice [m/s*psu]
+
+! --- KPP VERTICAL MIXING (require mix_scheme_nmb==1,17,3,37) ---
+! 'kpp_obldepth',1, 'm', 4, ! KPP ocean boundary layer depth [m]
+! 'kpp_sbuoyflx',1, 'm', 4, ! surface buoyancy flux [m2/s3]
+
+! --- RECOM 2D BIOGEOCHEMISTRY (require use_REcoM=.true. and __recom) ---
+! 'dpCO2s    ',1, 'm', 4,  ! Difference of oceanic pCO2 minus atmospheric pCO2 [uatm]
+! 'pCO2s     ',1, 'm', 4,  ! Partial pressure of oceanic CO2 [uatm]
+! 'CO2f      ',1, 'm', 4,  ! CO2-flux into the surface water [mmolC/m2/d]
+! 'O2f       ',1, 'm', 4,  ! O2-flux into the surface water [mmolO/m2/d]
+! 'Hp        ',1, 'm', 4,  ! Mean of H-plus ions in the surface water [mol/kg]
+! 'aFe       ',1, 'm', 4,  ! Atmospheric iron input [umolFe/m2/s]
+! 'aN        ',1, 'm', 4,  ! Atmospheric DIN input [mmolN/m2/s]
+! 'benN      ',1, 'm', 4,  ! Benthos Nitrogen [mmol]
+! 'benC      ',1, 'm', 4,  ! Benthos Carbon [mmol]
+! 'benSi     ',1, 'm', 4,  ! Benthos silicon [mmol]
+! 'benCalc   ',1, 'm', 4,  ! Benthos calcite [mmol]
+! 'NPPn      ',1, 'm', 4,  ! Mean NPP nanophytoplankton [mmolC/m2/d]
+! 'NPPd      ',1, 'm', 4,  ! Mean NPP diatoms [mmolC/m2/d]
+! 'GPPn      ',1, 'm', 4,  ! Mean GPP nanophytoplankton [mmolC/m2/d]
+! 'GPPd      ',1, 'm', 4,  ! Mean GPP diatoms [mmolC/m2/d]
+! 'NNAn      ',1, 'm', 4,  ! Net N-assimilation nanophytoplankton [mmolN/m2/d]
+! 'NNAd      ',1, 'm', 4,  ! Net N-assimilation diatoms [mmolN/m2/d]
+! 'Chldegn   ',1, 'm', 4,  ! Chlorophyll degradation nanophytoplankton [1/d]
+! 'Chldegd   ',1, 'm', 4,  ! Chlorophyll degradation diatoms [1/d]
+! 'NPPc      ',1, 'm', 4,  ! Mean NPP coccolithophores [mmolC/(m2*d)]
+! 'GPPc      ',1, 'm', 4,  ! Mean GPP coccolithophores [mmolC/m2/d]
+! 'NNAc      ',1, 'm', 4,  ! Net N-assimilation coccolithophores [mmolN/(m2*d)]
+! 'Chldegc   ',1, 'm', 4,  ! Chlorophyll degradation coccolithophores [1/d]
+
+! --- RECOM 3D BIOGEOCHEMISTRY (require use_REcoM=.true. and __recom) ---
+! 'PAR       ',1, 'm', 4,  ! PAR [W/m2]
+! 'respmeso  ',1, 'm', 4,  ! Respiration rate of mesozooplankton [mmolC/m2/d]
+! 'respmacro ',1, 'm', 4,  ! Respiration rate of macrozooplankton [mmolC/m2/d]
+! 'respmicro ',1, 'm', 4,  ! Respiration rate of microzooplankton [mmolC/m2/d]
+! 'calcdiss  ',1, 'm', 4,  ! Calcite dissolution [mmolC/m2/d]
+! 'calcif    ',1, 'm', 4,  ! Calcification [mmolC/m2/d]
+! 'aggn      ',1, 'm', 4,  ! Aggregation of small phytoplankton [mmolC/m2/d]
+! 'aggd      ',1, 'm', 4,  ! Aggregation of diatoms [mmolC/m2/d]
+! 'aggc      ',1, 'm', 4,  ! Aggregation of coccolithophores [mmolC/m2/d]
+! 'docexn    ',1, 'm', 4,  ! DOC excretion by small phytoplankton [mmolC/m2/d]
+! 'docexd    ',1, 'm', 4,  ! DOC excretion by diatoms [mmolC/m2/d]
+! 'docexc    ',1, 'm', 4,  ! DOC excretion by coccolithophores [mmolC/m2/d]
+! 'respn     ',1, 'm', 4,  ! Respiration by small phytoplankton [mmolC/m2/d]
+! 'respd     ',1, 'm', 4,  ! Respiration by diatoms [mmolC/m2/d]
+! 'respc     ',1, 'm', 4,  ! Respiration by coccolithophores [mmolC/(m2*d)]
+! 'NPPn3D    ',1, 'm', 4,  ! Net primary production of small phytoplankton [mmolC/(m3*d)]
+! 'NPPd3D    ',1, 'm', 4,  ! Net primary production of diatoms [mmolC/(m3*d)]
+! 'NPPc3D    ',1, 'm', 4,  ! Net primary production of coccolithophores [mmolC/(m3*d)]
+
+! --- WATER ISOTOPES IN OCEAN (require lwiso=.true.) ---
+! 'h2o18     ',1, 'm', 4,  ! h2o18 concentration [kmol/m**3]
+! 'hDo16     ',1, 'm', 4,  ! hDo16 concentration [kmol/m**3]
+! 'h2o16     ',1, 'm', 4,  ! h2o16 concentration [kmol/m**3]
+
+! --- NEUTRAL SLOPES ---
+! 'slopetap_x',1, 'm', 4,  ! neutral slope tapered X [none]
+! 'slopetap_y',1, 'm', 4,  ! neutral slope tapered Y [none]
+! 'slopetap_z',1, 'm', 4,  ! neutral slope tapered Z [none]
+! 'slope_x   ',1, 'm', 4,  ! neutral slope X [none]
+! 'slope_y   ',1, 'm', 4,  ! neutral slope Y [none]
+! 'slope_z   ',1, 'm', 4,  ! neutral slope Z [none]
+
+! --- MIXING AND DYNAMICS ---
+! 'N2        ',1, 'm', 4,  ! brunt väisälä [1/s2]
+! 'Kv        ',1, 'm', 4,  ! vertical diffusivity Kv [m2/s]
+! 'Av        ',1, 'm', 4,  ! vertical viscosity Av [m2/s]
+
+! --- VISCOSITY TENDENCIES (require dynamics%opt_visc==8) ---
+! 'u_dis_tend',1, 'm', 4,  ! horizontal velocity viscosity tendency [m/s]
+! 'v_dis_tend',1, 'm', 4,  ! meridional velocity viscosity tendency [m/s]
+! 'u_back_tend',1, 'm', 4, ! horizontal velocity backscatter tendency [m2/s2]
+! 'v_back_tend',1, 'm', 4, ! meridional velocity backscatter tendency [m2/s2]
+! 'u_total_tend',1, 'm', 4,! horizontal velocity total viscosity tendency [m/s]
+! 'v_total_tend',1, 'm', 4,! meridional velocity total viscosity tendency [m/s]
+
+! --- FERRARI/GM PARAMETERISATION (require Fer_GM=.true.) ---
+! 'bolus_u   ',1, 'm', 4,  ! GM bolus velocity U [m/s]
+! 'bolus_v   ',1, 'm', 4,  ! GM bolus velocity V [m/s]
+! 'bolus_w   ',1, 'm', 4,  ! GM bolus velocity W [m/s]
+! 'fer_K     ',1, 'm', 4,  ! GM, stirring diff. [m2/s]
+! 'fer_scal  ',1, 'm', 4,  ! GM surface scaling []
+! 'fer_C     ',1, 'm', 4,  ! GM, depth independent speed [m/s]
+! 'cfl_z     ',1, 'm', 4,  ! vertical CFL criteria [?]
+
+! --- DENSITY MOC DIAGNOSTICS (require ldiag_dMOC=.true.) ---
+! 'dMOC      ',1, 'm', 4,  ! fluxes for density MOC (multiple variables)
+
+! --- PRESSURE GRADIENT FORCE ---
+! 'pgf_x     ',1, 'm', 4,  ! zonal pressure gradient force [m/s^2]
+! 'pgf_y     ',1, 'm', 4,  ! meridional pressure gradient force [m/s^2]
+
+! --- ALE LAYER THICKNESS ---
+! 'hnode     ',1, 'm', 4,  ! vertice layer thickness [m]
+! 'hnode_new ',1, 'm', 4,  ! hnode_new [m]
+! 'helem     ',1, 'm', 4,  ! elemental layer thickness [m]
+
+! --- OIFS/IFS INTERFACE (require __oifs or __ifsinterface) ---
+! 'alb       ',1, 'm', 4,  ! ice albedo [none]
+! 'ist       ',1, 'm', 4,  ! ice surface temperature [K]
+! 'qsi       ',1, 'm', 4,  ! ice heat flux [W/m^2]
+! 'qso       ',1, 'm', 4,  ! oce heat flux [W/m^2]
+! 'enthalpy  ',1, 'm', 4,  ! enthalpy of fusion [W/m^2]
+! 'qcon      ',1, 'm', 4,  ! conductive heat flux [W/m^2]
+! 'qres      ',1, 'm', 4,  ! residual heat flux [W/m^2]
+! 'runoff_liquid',1, 'm', 4, ! liquid water runoff [m/s]
+! 'runoff_solid',1, 'm', 4, ! solid water runoff [m/s]
+
+! --- ICEBERG OUTPUTS (require use_icebergs=.true.) ---
+! 'icb       ',1, 'm', 4,  ! iceberg outputs (multiple variables)
+
+! --- TKE MIXING DIAGNOSTICS (require mix_scheme_nmb==5 or 56) ---
+! 'TKE       ',1, 'm', 4,  ! TKE diagnostics (multiple variables)
+
+! --- IDEMIX MIXING DIAGNOSTICS (require mod(mix_scheme_nmb,10)==6) ---
+! 'IDEMIX    ',1, 'm', 4,  ! IDEMIX diagnostics (multiple variables)
+
+! --- TIDAL MIXING DIAGNOSTICS (require mod(mix_scheme_nmb,10)==7) ---
+! 'TIDAL     ',1, 'm', 4,  ! TIDAL diagnostics (multiple variables)
+
+! --- FORCING DIAGNOSTICS (require ldiag_forc=.true.) ---
+! 'FORC      ',1, 'm', 4,  ! forcing diagnostics (multiple variables)
+
+! --- DISCRETE VARIANCE DECAY (require ldiag_DVD=.true.) ---
+! 'DVD       ',1, 'm', 4,  ! DVD diagnostics (multiple variables)
+
+! --- SPLIT-EXPLICIT SUBCYCLING (require dynamics%use_ssh_se_subcycl=.true.) ---
+! 'SPLIT-EXPL',1, 'm', 4,  ! split-explicit diagnostics (multiple variables)
+
+! --- SQUARED VELOCITIES (require ldiag_uvw_sqr=.true.) ---
+! 'UVW_SQR   ',1, 'm', 4,  ! squared velocities (u2, v2, w2)
+
+! --- TRACER GRADIENTS (require ldiag_trgrd_xyz=.true.) ---
+! 'TRGRD_XYZ ',1, 'm', 4,  ! horizontal and vertical tracer gradients
+
+! --- CMOR DIAGNOSTICS FOR CMIP6/CMIP7 (require ldiag_cmor=.true.) ---
+! 'tos       ',1, 'm', 8,  ! sea surface temperature [degC] (CMOR standard)
+! 'sos       ',1, 'm', 8,  ! sea surface salinity [psu] (CMOR standard)
+! 'pbo       ',1, 'm', 8,  ! sea water pressure at sea floor [Pa]
+! 'opottemptend',1, 'm', 8,! ocean potential temperature tendency [W/m^2]
+! 'volo      ',1, 'm', 8,  ! ocean volume [m^3] (global scalar)
+! 'soga      ',1, 'm', 8,  ! global mean sea water salinity [psu] (global scalar)
+! 'thetaoga  ',1, 'm', 8,  ! global mean sea water potential temperature [degC] (global scalar)
+! 'siarean   ',1, 'm', 8,  ! sea ice area Northern hemisphere [10^12 m^2] (global scalar)
+! 'siareas   ',1, 'm', 8,  ! sea ice area Southern hemisphere [10^12 m^2] (global scalar)
+! 'siextentn ',1, 'm', 8,  ! sea ice extent Northern hemisphere [10^12 m^2] (global scalar)
+! 'siextents ',1, 'm', 8,  ! sea ice extent Southern hemisphere [10^12 m^2] (global scalar)
+! 'sivoln    ',1, 'm', 8,  ! sea ice volume Northern hemisphere [10^9 m^3] (global scalar)
+! 'sivols    ',1, 'm', 8,  ! sea ice volume Southern hemisphere [10^9 m^3] (global scalar)
+
+! ============================================================================
+! END OF CATALOG
+! ============================================================================

--- a/config/bin_3p3z2d/namelist.oce
+++ b/config/bin_3p3z2d/namelist.oce
@@ -1,26 +1,105 @@
-! The namelist file for the finite-volume ocean model
+! ============================================================================
+! ============ Namelist file for FESOM2 ocean dynamics ======================
+! ============================================================================
+! This file contains configuration for ocean dynamics and parameterizations:
+! - Bottom drag and vertical viscosity
+! - Gent-McWilliams (GM) eddy parameterization
+! - Redi isopycnal diffusion
+! - Vertical mixing schemes (KPP, PP)
+! - Convection parameters
+! - Tidal forcing
+! ============================================================================
 
+! ============================================================================
+! OCEAN DYNAMICS AND PARAMETERIZATIONS
+! ============================================================================
 &oce_dyn
-C_d=0.0025             ! Bottom drag, nondimensional
-A_ver= 1.e-4	       ! Vertical viscosity, m^2/s
-scale_area=5.8e9       ! Visc. and diffus. are for an element with scale_area
-SPP=.false.                 ! Salt Plume Parameterization
-Fer_GM=.true.               ! to swith on/off GM after Ferrari et al. 2010
-K_GM_max     = 2000.0       ! max. GM thickness diffusivity (m2/s)
-K_GM_min     = 2.0          ! max. GM thickness diffusivity (m2/s)
-K_GM_bvref   = 2            ! def of bvref in ferreira scaling 0=srf,1=bot mld,2=mean over mld,3=weighted mean over mld
-K_GM_rampmax = -1.0         ! Resol >K_GM_rampmax[km] GM on
-K_GM_rampmin = -1.0         ! Resol <K_GM_rampmin[km] GM off, in between linear scaled down
-K_GM_resscalorder = 1
+! --- Basic ocean dynamics parameters ---
+C_d                = 0.0025  ! bottom drag coefficient (dimensionless, typical: 0.0025)
+A_ver              = 1.e-4   ! background vertical viscosity [m²/s]
+scale_area         = 5.8e9   ! reference element area for viscosity/diffusivity scaling [m²]
 
-scaling_Ferreira   =.false.  ! GM vertical scaling after Ferreira et al.(2005) (as also implemented by Qiang in FESOM 1.4)
-scaling_Rossby     =.false. ! GM is smoothly switched off according to Rossby radius (from 1. in coarse areas to 0. where resolution reaches 2 points/Rossby radius)
-scaling_resolution =.true.  ! GM is spatially scaled with resolution; A value of K_GM corresponds then to a resolution of 100km
-scaling_FESOM14    =.false.  ! special treatment of GM in the NH (as also implemented by Qiang in FESOM 1.4; it is zero within the boundary layer)
+! --- Salt Plume Parameterization ---
+SPP                = .false. ! enable Salt Plume Parameterization (for brine rejection under sea ice)
 
-Redi  =.true.
-visc_sh_limit=5.0e-3       ! for KPP, max visc due to shear instability
-mix_scheme='KPP'           ! vertical mixing scheme: KPP, PP 
-Ricr   = 0.3               ! critical bulk Richardson Number
-concv  = 1.6               ! constant for pure convection (eqn. 23) (Large 1.5-1.6; MOM default 1.8)
+! --- Gent-McWilliams (GM) Eddy Parameterization ---
+Fer_GM             = .true.  ! to swith on/off GM after Ferrari et al. 2010
+K_GM_max           = 2000.0  ! max. GM thickness diffusivity (m2/s)
+K_GM_min           = 2.0     ! min. GM thickness diffusivity (m2/s)
+K_GM_bvref         = 2       ! def of bvref in ferreira scaling 0=srf,1=bot mld,2=mean over mld,3=weighted mean over mld
+K_GM_rampmax       = -1.0    ! Resol >K_GM_rampmax[km] GM on
+K_GM_rampmin       = -1.0    ! Resol <K_GM_rampmin[km] GM off, in between linear scaled down
+K_GM_resscalorder  = 1       ! scaling order 1: resol scaling, 2: area scaling 
+
+! --- GM Scaling Options ---
+scaling_Ferreira   = .false. ! enable GM vertical scaling (Ferreira et al. 2005, as in FESOM 1.4)
+scaling_Rossby     = .false. ! scale GM with Rossby radius (1.0 in coarse regions, 0.0 at 2 points/Rossby radius)
+scaling_resolution = .true.  ! scale GM with horizontal resolution (K_GM corresponds to 100km resolution)
+scaling_FESOM14    = .false. ! use FESOM 1.4 GM treatment in Northern Hemisphere (zero within boundary layer)
+
+! --- Redi Isopycnal Diffusion ---
+Redi               = .true.  ! enable Redi isopycnal diffusion
+
+! --- Vertical Mixing Scheme ---
+visc_sh_limit      = 5.0e-3  ! maximum viscosity due to shear instability [m²/s] (for KPP)
+mix_scheme         = 'KPP'   ! vertical mixing scheme: 'KPP' (K-Profile Parameterization), 'PP' (Pacanowski-Philander), or 'cvmix_TKE' (Turbulent Kinetic Energy). For complete list of available shemes look at the oce_setup_step.F90. 
+
+! --- Convection Parameters ---
+Ricr               = 0.3     ! critical bulk Richardson number (for convection onset)
+concv              = 1.6     ! constant for pure convection (eq. 23 in Large et al.)
+                             ! typical values: Large 1.5-1.6, MOM default 1.8
 /
+
+! ===================================================================
+! Initial condition perturbation settings
+! ===================================================================
+! This section controls random perturbation of initial temperature
+! and salinity fields. Useful for ensemble modeling and uncertainty
+! quantification.
+!
+! lperturb       : Enable/disable perturbation (.true./.false.)
+! perturb_mode   : When to apply perturbations
+!                  'initial_only' - Apply only during initial runs (not restarts)
+!                  'first_step'   - Apply during first time step (initial or restart)
+! perturb_method : Type of random distribution
+!                  'uniform'   - Uniform distribution between [min_val, max_val]
+!                  'gaussian'  - Gaussian distribution with mean=min_val, std_dev=max_val
+! perturb_seed   : Random seed for reproducible perturbations
+!                  -1 = use system time (different each run)
+!                  >0 = use specified seed (reproducible)
+! temp_perturb   : Temperature perturbation parameters
+!                  For uniform: [min_val, max_val] in Kelvin
+!                  For gaussian: [mean(=0.0), std_dev] in Kelvin
+! salt_perturb   : Salinity perturbation parameters
+!                  For uniform: [min_val, max_val] in PSU
+!                  For gaussian: [mean(=0.0), std_dev] in PSU
+!
+! Example for ensemble forecasting with Gaussian perturbations:
+!&oce_perturb
+!lperturb       = .true.
+!perturb_mode   = 'first_step'
+!perturb_method = 'gaussian'
+!perturb_seed   = 12345
+!temp_perturb   = 0.0, 1.D-13
+!salt_perturb   = 0.0, 2.D-13
+!/
+!
+! Example for sensitivity study with uniform perturbations:
+!&oce_perturb
+!lperturb       = .true.
+!perturb_mode   = 'initial_only'
+!perturb_method = 'uniform'
+!perturb_seed   = -1
+!temp_perturb   = -1.D-12, 1.D-12
+!salt_perturb   = -2.D-12, 2.D-12
+!/
+
+! Default behavior (no perturbations):
+!&oce_perturb
+!lperturb       = .false.
+!perturb_mode   = 'initial_only'
+!perturb_method = 'uniform'
+!perturb_seed   = -1
+!temp_perturb   = 0.0, 0.0
+!salt_perturb   = 0.0, 0.0
+!/

--- a/config/bin_3p3z2d/namelist.recom
+++ b/config/bin_3p3z2d/namelist.recom
@@ -1,361 +1,511 @@
-! This is the namelist file for recom
+! ============================================================================
+! ============ Namelist file for FESOM2 REcoM biogeochemistry ================
+! ============================================================================
+! This file contains configuration for the REcoM biogeochemical model:
+! - Surface boundary condition input files
+! - Model switches, tracer counts and sinking
+! - Phytoplankton, zooplankton and detritus parameters
+! - Carbonate chemistry, iron, calcite and benthos
+! - Ballasting and carbon isotopes
+!
+! Phytoplankton parameters come in sets: no suffix = small phytoplankton,
+! _d = diatoms, _c = coccolithophores, _p = Phaeocystis (where present).
+! Zooplankton: first = mesozooplankton, second (suffix 2) = macrozooplankton,
+! third (suffix 3) = microzooplankton.
+! ============================================================================
 
+! ============================================================================
+! SURFACE BOUNDARY CONDITION FILES
+! ============================================================================
+! Relative names of the dust, aeolian nitrogen and CO2 files are taken from
+! ClimateDataPath; the river and erosion files are used as given.
+! ============================================================================
 &nam_rsbc
-fe_data_source        ='Albani'
-nm_fe_data_file       ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/DustClimMonthlyAlbani.nc'
-nm_aen_data_file      ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/AeolianNitrogenDep.nc'
-nm_river_data_file    ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/RiverineInput.nc'
-nm_erosion_data_file  ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/ErosionInput.nc'
-nm_co2_data_file      ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/MonthlyAtmCO2_gcb2023.nc'
+fe_data_source        = 'Albani'    ! 'Albani' reads nm_fe_data_file; any other value switches the Albani dust input off
+nm_fe_data_file       = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/DustClimMonthlyAlbani.nc'
+                                    ! monthly dust deposition climatology (Albani)
+nm_aen_data_file      = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/AeolianNitrogenDep.nc'
+                                    ! aeolian nitrogen deposition (useAeolianN)
+nm_river_data_file    = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/RiverineInput.nc'
+                                    ! riverine nutrient input (useRivers)
+nm_erosion_data_file  = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/ErosionInput.nc'
+                                    ! input from erosion (useErosion)
+nm_co2_data_file      = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/MonthlyAtmCO2_gcb2023.nc'
+                                    ! atmospheric CO2 time series, read when constant_CO2 = .false.
 /
 
+! ============================================================================
+! TRACER SET
+! ============================================================================
+! bgc_num in &pavariables is checked against these switches at startup.
+! ============================================================================
 &parecomsetup
-enable_3zoo2det = .true.
-enable_coccos = .false.
+enable_3zoo2det       = .true.      ! three zooplankton groups and two detritus classes instead of one each
+enable_coccos         = .false.     ! coccolithophore and Phaeocystis tracers
 /
 
+! ============================================================================
+! MODEL SWITCHES, TRACER COUNTS AND SINKING
+! ============================================================================
 &pavariables
-use_REcoM             =.true.
-REcoM_restart         =.true.
+! --- Main Switches ---
+use_REcoM             = .true.      ! switch REcoM on
+REcoM_restart         = .true.      ! read the REcoM tracers from the restart (false = initialize from climatology)
+recom_debug           = .false.     ! extra REcoM debug output
+Diags                 = .true.      ! compute REcoM diagnostics
 
-bgc_num               = 33 !24 !38 !22
-diags3d_num           = 28          ! Number of diagnostic 3d tracers to be saved
-bgc_base_num          = 22          ! standard tracers
-VDet                  = 20.d0       ! Sinking velocity, constant through the water column and positive downwards
-VDet_zoo2             = 200.d0      ! Sinking velocity, constant through the water column
-VPhy                  = 0.d0        !!! If the number of sinking velocities are different from 3, code needs to be changed !!!
-VDia                  = 0.d0
-VCocco	       	      = 0.d0       
-allow_var_sinking     = .true.   
-biostep               = 1           ! Number of times biology should be stepped forward for each time step		 
-REcoM_Geider_limiter  = .false.     ! Decides what routine should be used to calculate limiters in sms
-REcoM_Grazing_Variable_Preference = .true. ! Decides if grazing should have preference for phyN or DiaN 
-Grazing_detritus      = .true.
-het_resp_noredfield   = .true.    ! Decides respiratation of copepod group
-diatom_mucus          = .true.    ! Decides nutrient limitation effect on aggregation
-O2dep_remin           = .true.    ! O2remin Add option for O2 dependency of organic matter remineralization
-use_ballasting        = .true.    
-use_density_scaling   = .true.   
-use_viscosity_scaling = .true.    
-OmegaC_diss           = .true.    ! Use OmegaC from Mocsy to compute calcite dissolution (after Aumont et al. 2015 and Gehlen et al. 2007) -> set calc_diss_guts to zero if this is false!!!!
-CO2lim                = .true.    ! CO2 dependence of growth and calcification
-Diags                 = .true.
-constant_CO2          = .true.
-UseFeDust             = .true.      ! Turns dust input of iron off when set to.false.
-UseDustClim           = .true.
-UseDustClimAlbani     = .true.     ! Use Albani dustclim field (If it is false Mahowald will be used)
-use_photodamage       = .true.      ! use Alvarez et al (2018) for chlorophyll degradation
-HetRespFlux_plus      = .true.      !MB More stable computation of zooplankton respiration fluxes adding a small number to HetN
+! --- Tracer Counts ---
+bgc_num               = 33          ! number of REcoM tracers, checked at startup against enable_3zoo2det and enable_coccos
+diags3d_num           = 28          ! number of 3D diagnostic tracers to be saved
+bgc_base_num          = 22          ! number of standard (base) BGC tracers
+benthos_num           = 4           ! number of benthic BGC tracers: 8 with ciso = .true., otherwise 4
+Nmocsy                = 1           ! length of the vector passed to mocsy (always 1 for REcoM)
+biostep               = 1           ! number of biology steps per ocean time step
+
+! --- Sinking ---
+VDet                  = 20.d0       ! sinking velocity of small detritus [m/day], positive downwards
+VDet_zoo2             = 200.d0      ! sinking velocity of large detritus [m/day]
+VPhy                  = 0.d0        ! sinking velocity of small phytoplankton [m/day]
+VDia                  = 0.d0        ! sinking velocity of diatoms [m/day]
+VCocco                = 0.d0        ! sinking velocity of coccolithophores [m/day]
+allow_var_sinking     = .true.      ! detritus sinking speed increases with depth (Vdet_a in &pasinking)
+
+! --- Process Options ---
+REcoM_Geider_limiter  = .false.     ! selects the routine that calculates the limiters in the sources-minus-sinks
+REcoM_Grazing_Variable_Preference = .true. ! grazing preferences weighted by prey abundance
+Grazing_detritus      = .true.      ! zooplankton also graze on detritus
+het_resp_noredfield   = .true.      ! respiration formulation of the first zooplankton (copepods)
+diatom_mucus          = .true.      ! nutrient limitation enhances diatom aggregation
+O2dep_remin           = .true.      ! oxygen-dependent remineralization of organic matter (k_o2_remin)
+use_photodamage       = .true.      ! light-dependent chlorophyll degradation after Alvarez et al. (2018)
+HetRespFlux_plus      = .true.      ! more stable zooplankton respiration flux (not used by the current code)
+CO2lim                = .true.      ! CO2 dependence of growth and calcification (&paco2lim)
+OmegaC_diss           = .true.      ! calcite dissolution from the mocsy saturation state OmegaC
+                                    ! (Aumont et al. 2015, Gehlen et al. 2007); set calc_diss_guts = 0 when .false.
+
+! --- Ballasting ---
+use_ballasting        = .true.      ! mineral ballasting of detritus sinking (&paballasting)
+use_density_scaling   = .true.      ! scale sinking with seawater density (ballasting)
+use_viscosity_scaling = .true.      ! scale sinking with seawater viscosity (ballasting)
+
+! --- External Sources ---
+UseFeDust             = .true.      ! iron input from dust (not used by the current code, see fe_data_source)
+UseDustClim           = .true.      ! dust deposition climatology (not used by the current code)
+UseDustClimAlbani     = .true.      ! Albani dust climatology, otherwise Mahowald (not used by the current code)
+useRivers             = .false.     ! riverine nutrient input (nm_river_data_file)
+useRivFe              = .false.     ! riverine iron source
+useErosion            = .false.     ! input from erosion (nm_erosion_data_file)
+NitrogenSS            = .false.     ! external nitrogen sources and sinks (riverine, aeolian and denitrification)
+useAeolianN           = .false.     ! aeolian nitrogen deposition (nm_aen_data_file)
 REcoMDataPath         = '/albedo/work/projects/MarESys/ogurses/input/mesh_CORE2_finaltopo_mean/'
-restore_alkalinity    = .true.
-useRivers             = .false.
-useRivFe              = .false.      ! When set to true, riverine Fe source is activated
-useErosion            = .false.
-NitrogenSS            = .false.     ! When set to true, external sources and sinks of nitrogen are activated (Riverine, aeolian and denitrification)
-useAeolianN           = .false.      ! When set to true, aeolian nitrogen deposition is activated
-firstyearoffesomcycle = 1958        ! The first year of the actual physical forcing (e.g. JRA-55) used
-lastyearoffesomcycle  = 2024        ! Last year of the actual physical forcing used
-numofCO2cycles        = 1           ! Number of cycles of the forcing planned 
-currentCO2cycle       = 1           ! Which CO2 cycle we are currently running
-DIC_PI                = .true.
-Nmocsy                = 1           ! Length of the vector that is passed to mocsy (always one for recom)
-recom_debug           =.false.
-ciso                  =.false.     ! Main switch to enable/disable carbon isotopes (13|14C)
-benthos_num           = 4          ! number of benthic BGC tracers -> 8 if (ciso == .true.) otherwise -> 4
-use_MEDUSA            = .false.      ! Main switch for the sediment model MEDUSA
-sedflx_num            = 0           ! if 0: no file from MEDUSA is read but default sediment
-bottflx_num           = 4           ! if ciso&ciso_14: =8; if .not.ciso_14: =6; no ciso: =4
-use_atbox             = .false.
-add_loopback          = .false.     ! add loopback fluxes through rivers to the surface
-lb_tscale             = 1.0         ! /year: fraction of loopback fluxes yearly added to the surface
+                                    ! REcoM input directory (not used by the current code)
+
+! --- Carbon Chemistry and Atmospheric CO2 ---
+constant_CO2          = .true.      ! use CO2_for_spinup instead of the time series in nm_co2_data_file
+DIC_PI                = .true.      ! initialize DIC with the preindustrial GLODAP field
+restore_alkalinity    = .true.      ! restore surface alkalinity (surf_relax_Alk)
+use_atbox             = .false.     ! atmospheric box model for CO2
+firstyearoffesomcycle = 1958        ! first year of the physical forcing used (e.g. JRA55)
+lastyearoffesomcycle  = 2024        ! last year of the physical forcing used
+numofCO2cycles        = 1           ! number of forcing cycles planned
+currentCO2cycle       = 1           ! forcing cycle currently running
+
+! --- Carbon Isotopes and Sediment ---
+ciso                  = .false.     ! main switch for carbon isotopes (13C, 14C), see &paciso
+use_MEDUSA            = .false.     ! main switch for the sediment model MEDUSA
+sedflx_num            = 0           ! number of sediment fluxes read from MEDUSA (0 = none, default sediment)
+bottflx_num           = 4           ! number of bottom fluxes: 8 with ciso and ciso_14, 6 with ciso only, 4 without ciso
+add_loopback          = .false.     ! return loopback fluxes to the surface through rivers
+lb_tscale             = 1.0         ! fraction of the loopback fluxes added to the surface per year [1/year]
 /
 
+! ============================================================================
+! DEPTH-DEPENDENT SINKING
+! ============================================================================
 &pasinking
-Vdet_a                = 0.0288      ! [1/day]
-Vcalc                 = 0.0144      ! [1/day]
+Vdet_a                = 0.0288      ! increase of detritus sinking speed with depth [1/day] (allow_var_sinking)
+Vcalc                 = 0.0144      ! depth dependence of calcite dissolution [1/day]
 /
 
+! ============================================================================
+! INITIALIZATION
+! ============================================================================
 &painitialization_N
-cPhyN                 = 0.2d0
-cHetN                 = 0.2d0
-cZoo2N                = 0.2d0
+cPhyN                 = 0.2d0       ! initial small phytoplankton N (not used by the current code)
+cHetN                 = 0.2d0       ! initial first zooplankton N (not used by the current code)
+cZoo2N                = 0.2d0       ! initial second zooplankton N (not used by the current code)
 /
 
+! ============================================================================
+! TEMPERATURE DEPENDENCE
+! ============================================================================
 &paArrhenius
-recom_Tref            = 288.15d0    ! [K]
-C2K                   = 273.15d0    ! Conversion from degrees C to K
-Ae                    = 4500.d0     ! [K] Slope of the linear part of the Arrhenius function
-reminSi               = 0.02d0
-k_o2_remin            = 15.d0       ! O2remin mmol m-3; Table 1 in Cram 2018 cites DeVries & Weber 2017 for a range of 0-30 mmol m-3
+recom_Tref            = 288.15d0    ! reference temperature of the Arrhenius function [K]
+C2K                   = 273.15d0    ! conversion from degrees C to K
+Ae                    = 4500.d0     ! slope of the linear part of the Arrhenius function [K]
+reminSi               = 0.02d0      ! lower bound of the silica remineralization rate [1/day]
+k_o2_remin            = 15.d0       ! half-saturation O2 for O2-dependent remineralization [mmol/m3] (O2dep_remin)
+                                    ! Cram et al. (2018), Table 1, cite 0-30 mmol/m3 (DeVries & Weber 2017)
 /
 
+! ============================================================================
+! LIMITATION FUNCTIONS
+! ============================================================================
 &palimiter_function
-NMinSlope             = 50.d0 
-SiMinSlope            = 1000.d0
-NCmin                 = 0.04d0
-NCmin_d               = 0.04d0
-NCmin_c		      = 0.04d0    
-SiCmin                = 0.04d0
-k_Fe                  = 0.04d0
-k_Fe_d                = 0.12d0
-k_Fe_c		      = 0.09d0    
-k_si                  = 4.d0
-P_cm                  = 3.0d0       ! [1/day]            Rate of C-specific photosynthesis 
-P_cm_d                = 3.5d0
-P_cm_c		      = 2.8d0	  
+! --- Limitation Function Slopes ---
+NMinSlope             = 50.d0       ! steepness of the nitrogen limitation function at the minimum quota
+SiMinSlope            = 1000.d0     ! steepness of the silicon limitation function at the minimum quota
+
+! --- Minimum Quotas ---
+NCmin                 = 0.04d0      ! minimum N:C quota, small phytoplankton [mmol N/mmol C]
+NCmin_d               = 0.04d0      ! minimum N:C quota, diatoms [mmol N/mmol C]
+NCmin_c               = 0.04d0      ! minimum N:C quota, coccolithophores [mmol N/mmol C]
+SiCmin                = 0.04d0      ! minimum Si:C quota, diatoms [mmol Si/mmol C]
+
+! --- Nutrient Half-Saturation ---
+k_Fe                  = 0.04d0      ! half-saturation constant for iron uptake, small phytoplankton [µmol Fe/m3]
+k_Fe_d                = 0.12d0      ! half-saturation constant for iron uptake, diatoms [µmol Fe/m3]
+k_Fe_c                = 0.09d0      ! half-saturation constant for iron uptake, coccolithophores [µmol Fe/m3]
+k_si                  = 4.d0        ! half-saturation constant for silicate uptake, diatoms [mmol Si/m3]
+
+! --- Maximum Photosynthesis ---
+P_cm                  = 3.0d0       ! maximum C-specific photosynthesis rate, small phytoplankton [1/day]
+P_cm_d                = 3.5d0       ! maximum C-specific photosynthesis rate, diatoms [1/day]
+P_cm_c                = 2.8d0       ! maximum C-specific photosynthesis rate, coccolithophores [1/day] (not used by the current code)
 /
 
+! ============================================================================
+! LIGHT
+! ============================================================================
 &palight_calculations
-k_w                   = 0.04d0      ! [1/m]              Light attenuation coefficient
-a_chl                 = 0.03d0      ! [1/m * 1/(mg Chl)] Chlorophyll specific attenuation coefficients
+k_w                   = 0.04d0      ! light attenuation coefficient of water [1/m]
+a_chl                 = 0.03d0      ! chlorophyll-specific attenuation coefficient [1/m * 1/(mg Chl)]
 /
 
+! ============================================================================
+! PHOTOSYNTHESIS
+! ============================================================================
 &paphotosynthesis
-alfa                  = 0.14d0	    ! [(mmol C*m2)/(mg Chl*W*day)] 
-alfa_d                = 0.19d0      ! An initial slope of the P-I curve
-alfa_c		      = 0.10d0     
-parFrac               = 0.43d0
+alfa                  = 0.14d0      ! initial slope of the P-I curve, small phytoplankton [(mmol C m²)/(mg Chl W day)]
+alfa_d                = 0.19d0      ! initial slope of the P-I curve, diatoms [(mmol C m²)/(mg Chl W day)]
+alfa_c                = 0.10d0      ! initial slope of the P-I curve, coccolithophores [(mmol C m²)/(mg Chl W day)]
+parFrac               = 0.43d0      ! photosynthetically active fraction of the shortwave radiation
 /
 
+! ============================================================================
+! NUTRIENT ASSIMILATION
+! ============================================================================
 &paassimilation
-V_cm_fact             = 0.7d0       ! scaling factor for temperature dependent maximum of C-specific N-uptake
-V_cm_fact_d           = 0.7d0  
-V_cm_fact_c	      = 0.7d0     
-NMaxSlope             = 1000.d0     ! Max slope for limiting function
-SiMaxSlope            = 1000.d0
-NCmax                 = 0.2d0       ! [mmol N/mmol C] Maximum cell quota of nitrogen (N:C)
-NCmax_d               = 0.2d0
-NCmax_c		      = 0.15d0     
-SiCmax                = 0.8d0
-NCuptakeRatio         = 0.2d0       ! [mmol N/mmol C] Maximum uptake ratio of N:C
-NCUptakeRatio_d       = 0.2d0
-NCUptakeRatio_c	      = 0.2d0     
-SiCUptakeRatio        = 0.2d0
-k_din                 = 0.55d0      ! [mmol N/m3] Half-saturation constant for nitrate uptake
-k_din_d               = 1.0d0
-k_din_c		      = 0.9d0     
-Chl2N_max             = 3.15d0      ! [mg CHL/mmol N] Maximum CHL a : N ratio = 0.3 gCHL gN^-1
-Chl2N_max_d           = 4.2d0
-Chl2N_max_c	      = 3.5d0     
-res_phy               = 0.01d0      ! [1/day] Maintenance respiration rate constant
-res_phy_d             = 0.01d0
-res_phy_c	      = 0.01d0    
-biosynth              = 2.33d0      ! [mmol C/mmol N] Cost of biosynthesis
-biosynthSi            = 0.d0
+! --- Nitrogen Uptake ---
+V_cm_fact             = 0.7d0       ! scaling of the temperature-dependent maximum C-specific N uptake, small phytoplankton
+V_cm_fact_d           = 0.7d0       ! scaling of the temperature-dependent maximum C-specific N uptake, diatoms
+V_cm_fact_c           = 0.7d0       ! scaling of the temperature-dependent maximum C-specific N uptake, coccolithophores
+NMaxSlope             = 1000.d0     ! steepness of the limitation function at the maximum N quota
+NCmax                 = 0.2d0       ! maximum N:C quota, small phytoplankton [mmol N/mmol C]
+NCmax_d               = 0.2d0       ! maximum N:C quota, diatoms [mmol N/mmol C]
+NCmax_c               = 0.15d0      ! maximum N:C quota, coccolithophores [mmol N/mmol C]
+NCuptakeRatio         = 0.2d0       ! maximum N:C uptake ratio, small phytoplankton [mmol N/mmol C]
+NCUptakeRatio_d       = 0.2d0       ! maximum N:C uptake ratio, diatoms [mmol N/mmol C]
+NCUptakeRatio_c       = 0.2d0       ! maximum N:C uptake ratio, coccolithophores [mmol N/mmol C]
+k_din                 = 0.55d0      ! half-saturation constant for nitrate uptake, small phytoplankton [mmol N/m3]
+k_din_d               = 1.0d0       ! half-saturation constant for nitrate uptake, diatoms [mmol N/m3]
+k_din_c               = 0.9d0       ! half-saturation constant for nitrate uptake, coccolithophores [mmol N/m3]
+
+! --- Silicon Uptake (Diatoms) ---
+SiMaxSlope            = 1000.d0     ! steepness of the limitation function at the maximum Si quota
+SiCmax                = 0.8d0       ! maximum Si:C quota [mmol Si/mmol C]
+SiCUptakeRatio        = 0.2d0       ! maximum Si:C uptake ratio [mmol Si/mmol C]
+
+! --- Chlorophyll ---
+Chl2N_max             = 3.15d0      ! maximum Chl:N ratio, small phytoplankton [mg Chl/mmol N]
+Chl2N_max_d           = 4.2d0       ! maximum Chl:N ratio, diatoms [mg Chl/mmol N]
+Chl2N_max_c           = 3.5d0       ! maximum Chl:N ratio, coccolithophores [mg Chl/mmol N]
+
+! --- Respiration ---
+res_phy               = 0.01d0      ! maintenance respiration rate, small phytoplankton [1/day]
+res_phy_d             = 0.01d0      ! maintenance respiration rate, diatoms [1/day]
+res_phy_c             = 0.01d0      ! maintenance respiration rate, coccolithophores [1/day]
+biosynth              = 2.33d0      ! cost of biosynthesis [mmol C/mmol N]
+biosynthSi            = 0.d0        ! cost of silica biosynthesis [mmol C/mmol Si]
 /
 
+! ============================================================================
+! IRON CHEMISTRY
+! ============================================================================
 &pairon_chem
-totalligand           = 1.d0        ! [mumol/m3] order 1. Total free ligand
-ligandStabConst       = 100.d0      ! [m3/mumol] order 100. Ligand-free iron stability constant
+totalligand           = 1.d0        ! total free ligand [µmol/m3] (order 1)
+ligandStabConst       = 100.d0      ! ligand-free iron stability constant [m3/µmol] (order 100)
 /
 
+! ============================================================================
+! FIRST ZOOPLANKTON (MESOZOOPLANKTON)
+! ============================================================================
 &pazooplankton
-graz_max              = 0.31d0      ! [mmol N/(m3 * day)] Maximum grazing loss parameter 
-epsilonr              = 0.09d0      ! [(mmol N)2 /m6] Half saturation constant for grazing loss 
-res_het               = 0.028d0     ! [1/day] Respiration by heterotrophs and mortality (loss to detritus)
-Redfield              = 6.625       ! [mmol C/mmol N] Redfield ratio of C:N = 106:16
-loss_het              = 0.04d0      ! [1/day] Temperature dependent N degradation of extracellular organic N (EON)
-pzDia                 = 0.5d0       ! Maximum diatom preference
-sDiaNsq               = 0.d0
-pzPhy                 = 0.04d0      ! Maximum small phytoplankton preference
-sPhyNsq               = 0.d0
-pzCocco		      = 0.4d0       ! Maximum coccolithophore preference
-sCoccoNsq	      = 0.d0       
-pzMicZoo              = 1.0d0       ! Maximum microzooplankton preference
-sMicZooNsq            = 0.d0      
-tiny_het              = 1.d-5       ! for more stable computation of HetRespFlux (_plus). Value can be > tiny because HetRespFlux ~ hetC**2.
+graz_max              = 0.31d0      ! maximum grazing rate [mmol N/(m3 day)]
+epsilonr              = 0.09d0      ! half-saturation constant for grazing [(mmol N)^2/m^6]
+res_het               = 0.028d0     ! respiration and mortality (loss to detritus) [1/day]
+Redfield              = 6.625       ! Redfield C:N ratio (106:16) [mmol C/mmol N]
+loss_het              = 0.04d0      ! temperature-dependent N degradation of extracellular organic N (EON) [1/day]
+tiny_het              = 1.d-5       ! small number for a more stable HetRespFlux; may exceed tiny since HetRespFlux ~ HetC^2
+
+! --- Prey Preferences ---
+pzDia                 = 0.5d0       ! maximum diatom preference
+sDiaNsq               = 0.d0        ! not used by the current code
+pzPhy                 = 0.04d0      ! maximum small phytoplankton preference
+sPhyNsq               = 0.d0        ! not used by the current code
+pzCocco               = 0.4d0       ! maximum coccolithophore preference
+sCoccoNsq             = 0.d0        ! not used by the current code
+pzMicZoo              = 1.0d0       ! maximum microzooplankton preference
+sMicZooNsq            = 0.d0        ! not used by the current code
 /
 
+! ============================================================================
+! SECOND ZOOPLANKTON (MACROZOOPLANKTON)
+! ============================================================================
 &pasecondzooplankton
-graz_max2      = 0.1d0              ! [mmol N/(m3 * day)] Maximum grazing loss parameter                                                                                        
-epsilon2       = 0.0144d0           ! [(mmol N)2 /m6] Half saturation constant for grazing loss                                                                              
-res_zoo2       = 0.0107d0           ! [1/day] Respiration by heterotrophs and mortality (loss to detritus)                                                            
-loss_zoo2      = 0.003d0            ! [1/day] Temperature dependent N degradation of extracellular organic N (EON)
-fecal_rate_n      = 0.104d0         ! [1/day] Temperature dependent N degradation of \
-fecal_rate_c      = 0.236d0  
-fecal_rate_n_mes = 0.25d0           
-fecal_rate_c_mes = 0.32d0         
-pzDia2         = 1.0d0              ! Maximum diatom preference                                                                                                                 
-sDiaNsq2       = 0.d0
-pzPhy2         = 0.07d0             ! Maximum small phytoplankton preference                                                                                                                
-sPhyNsq2       = 0.d0
-pzCocco2       = 0.7d0              ! Maximum coccolithophore preference
-sCoccoNsq2     = 0.d0		 
-pzHet          = 1.5d0              ! Maximum mesozooplankton preference 
-sHetNsq        = 0.d0
-pzMicZoo2      = 1.0d0              ! Maximum microzooplankton preference
-sMicZooNsq2    = 0.d0   
-t1_zoo2        = 28145.d0           ! Krill temp. function constant1                                                                                                       
-t2_zoo2        = 272.5d0            ! Krill temp. function constant2                                                                                                         
-t3_zoo2        = 105234.d0          ! Krill temp. function constant3                                                                                                      
-t4_zoo2        = 274.15d0           ! Krill temp. function constant3
+graz_max2             = 0.1d0       ! maximum grazing rate [mmol N/(m3 day)]
+epsilon2              = 0.0144d0    ! half-saturation constant for grazing [(mmol N)^2/m^6]
+res_zoo2              = 0.0107d0    ! respiration and mortality (loss to detritus) [1/day]
+loss_zoo2             = 0.003d0     ! temperature-dependent N degradation of extracellular organic N (EON) [1/day]
+
+! --- Fecal Pellets ---
+fecal_rate_n          = 0.104d0     ! fraction of the grazed nitrogen egested as fecal pellets
+fecal_rate_c          = 0.236d0     ! fraction of the grazed carbon egested as fecal pellets
+fecal_rate_n_mes      = 0.25d0      ! as fecal_rate_n, for the first zooplankton (mesozooplankton)
+fecal_rate_c_mes      = 0.32d0      ! as fecal_rate_c, for the first zooplankton (mesozooplankton)
+
+! --- Prey Preferences ---
+pzDia2                = 1.0d0       ! maximum diatom preference
+sDiaNsq2              = 0.d0        ! not used by the current code
+pzPhy2                = 0.07d0      ! maximum small phytoplankton preference
+sPhyNsq2              = 0.d0        ! not used by the current code
+pzCocco2              = 0.7d0       ! maximum coccolithophore preference
+sCoccoNsq2            = 0.d0        ! not used by the current code
+pzHet                 = 1.5d0       ! maximum preference for the first zooplankton
+sHetNsq               = 0.d0        ! not used by the current code
+pzMicZoo2             = 1.0d0       ! maximum microzooplankton preference
+sMicZooNsq2           = 0.d0        ! not used by the current code
+
+! --- Temperature Function (Krill) ---
+t1_zoo2               = 28145.d0    ! krill temperature function constant 1
+t2_zoo2               = 272.5d0     ! krill temperature function constant 2
+t3_zoo2               = 105234.d0   ! krill temperature function constant 3
+t4_zoo2               = 274.15d0    ! krill temperature function constant 4
 /
 
+! ============================================================================
+! THIRD ZOOPLANKTON (MICROZOOPLANKTON)
+! ============================================================================
 &pathirdzooplankton
-graz_max3      = 0.46d0             ! [mmol N/(m3 * day)] Maximum grazing loss parameter
-epsilon3       = 0.64d0             ! [(mmol N)2 /m6] Half saturation constant for grazing loss
-loss_miczoo    = 0.01d0             ! [1/day] Temperature dependent N degradation of extracellular organic N (EON)
-res_miczoo     = 0.02d0             ! [1/day] Respiration by heterotrophs and mortality (loss to detritus)
-pzDia3         = 0.04d0             ! Maximum diatom preference
-sDiaNsq3       = 0.d0               
-pzPhy3         = 0.07d0             ! Maximum small phytoplankton preference
-sPhyNsq3       = 0.d0               
-pzCocco3       = 0.7d0              ! Maximum coccolithophore preference
-sCoccoNsq3     = 0.d0              
+graz_max3             = 0.46d0      ! maximum grazing rate [mmol N/(m3 day)]
+epsilon3              = 0.64d0      ! half-saturation constant for grazing [(mmol N)^2/m^6]
+loss_miczoo           = 0.01d0      ! temperature-dependent N degradation of extracellular organic N (EON) [1/day]
+res_miczoo            = 0.02d0      ! respiration and mortality (loss to detritus) [1/day]
+
+! --- Prey Preferences ---
+pzDia3                = 0.04d0      ! maximum diatom preference
+sDiaNsq3              = 0.d0        ! not used by the current code
+pzPhy3                = 0.07d0      ! maximum small phytoplankton preference
+sPhyNsq3              = 0.d0        ! not used by the current code
+pzCocco3              = 0.7d0       ! maximum coccolithophore preference (still to be tuned)
+sCoccoNsq3            = 0.d0        ! not used by the current code
 /
 
+! ============================================================================
+! GRAZING ON DETRITUS
+! ============================================================================
 &pagrazingdetritus
-pzDet         = 0.5d0               ! Maximum small detritus prefence by first zooplankton
-sDetNsq       = 0.d0
-pzDetZ2       = 0.5d0               ! Maximum large detritus preference by first zooplankton                                 
-sDetZ2Nsq     = 0.d0
-pzDet2        = 0.5d0               ! Maximum small detritus prefence by second zooplankton                               
-sDetNsq2      = 0.d0
-pzDetZ22      = 0.5d0               ! Maximum large detritus preference by second zooplankton
-sDetZ2Nsq2    = 0.d0
+pzDet                 = 0.5d0       ! maximum small detritus preference, first zooplankton
+sDetNsq               = 0.d0        ! not used by the current code
+pzDetZ2               = 0.5d0       ! maximum large detritus preference, first zooplankton
+sDetZ2Nsq             = 0.d0        ! not used by the current code
+pzDet2                = 0.5d0       ! maximum small detritus preference, second zooplankton
+sDetNsq2              = 0.d0        ! not used by the current code
+pzDetZ22              = 0.5d0       ! maximum large detritus preference, second zooplankton
+sDetZ2Nsq2            = 0.d0        ! not used by the current code
 /
 
+! ============================================================================
+! AGGREGATION
+! ============================================================================
 &paaggregation
-agg_PD                = 0.165d0     ! [m3/(mmol N * day)] Maximum aggregation loss parameter for DetN
-agg_PP                = 0.015d0     ! [m3/(mmol N * day)] Maximum aggregation loss parameter for PhyN and DiaN (plankton)
+agg_PD                = 0.165d0     ! maximum aggregation loss parameter for detritus [m3/(mmol N day)]
+agg_PP                = 0.015d0     ! maximum aggregation loss parameter for phytoplankton [m3/(mmol N day)]
 /
 
+! ============================================================================
+! DISSOLVED ORGANIC MATTER
+! ============================================================================
 &padin_rho_N
-rho_N                 = 0.11d0      ! [1/day] Temperature dependent N degradation of extracellular organic N (EON) (Remineralization of DON)
+rho_N                 = 0.11d0      ! temperature-dependent remineralization of DON (degradation of EON) [1/day]
 /
 
 &padic_rho_C1
-rho_C1                = 0.1d0       ! [1/day] Temperature dependent C degradation of extracellular organic C (EOC)
+rho_C1                = 0.1d0       ! temperature-dependent degradation of extracellular organic C (EOC) [1/day]
 /
 
+! ============================================================================
+! PHYTOPLANKTON LOSSES
+! ============================================================================
 &paphytoplankton_N
-lossN                 = 0.05d0      ! [1/day] Phytoplankton loss of organic N compounds
-lossN_d               = 0.05d0
-lossN_c		      = 0.05d0    
+lossN                 = 0.05d0      ! loss of organic N compounds, small phytoplankton [1/day]
+lossN_d               = 0.05d0      ! loss of organic N compounds, diatoms [1/day]
+lossN_c               = 0.05d0      ! loss of organic N compounds, coccolithophores [1/day]
 /
 
 &paphytoplankton_C
-lossC                 = 0.10d0      ! [1/day] Phytoplankton loss of carbon 
-lossC_d               = 0.10d0
-lossC_c		      = 0.10d0  
+lossC                 = 0.10d0      ! loss of carbon, small phytoplankton [1/day]
+lossC_d               = 0.10d0      ! loss of carbon, diatoms [1/day]
+lossC_c               = 0.10d0      ! loss of carbon, coccolithophores [1/day]
 /
 
 &paphytoplankton_ChlA
-deg_Chl               = 0.075 !0.2d0 !0.25d0      ! [1/day]
-deg_Chl_d             = 0.075 !0.2d0 !0.15d0
-deg_Chl_c	      = 0.075 !0.2d0   
+deg_Chl               = 0.075       ! chlorophyll degradation rate, small phytoplankton [1/day]
+deg_Chl_d             = 0.075       ! chlorophyll degradation rate, diatoms [1/day]
+deg_Chl_c             = 0.075       ! chlorophyll degradation rate, coccolithophores [1/day]
 /
 
+! ============================================================================
+! DETRITUS
+! ============================================================================
 &padetritus_N
-gfin                  = 0.3d0         ! [] Grazing efficiency (fraction of grazing flux into zooplankton pool)
-grazEff2              = 0.8d0         ! [] Grazing efficiency (fraction of grazing flux into second zooplankton pool)
-grazEff3              = 0.8d0         ! [] Grazing efficiency (fraction of grazing flux into microzooplankton pool)
-reminN                = 0.165d0       ! [1/day] Temperature dependent remineralisation rate of detritus	
+gfin                  = 0.3d0       ! grazing efficiency of the first zooplankton (fraction of the grazing flux it retains)
+grazEff2              = 0.8d0       ! grazing efficiency of the second zooplankton
+grazEff3              = 0.8d0       ! grazing efficiency of the microzooplankton
+reminN                = 0.165d0     ! temperature-dependent remineralization rate of detrital N [1/day]
 /
 
 &padetritus_C
-reminC                = 0.15d0      ! [1/day] Temperature dependent remineralisation rate of detritus
-rho_c2                = 0.1d0       ! [1/day] Temperature dependent C degradation of TEP-C
+reminC                = 0.15d0      ! temperature-dependent remineralization rate of detrital C [1/day]
+rho_c2                = 0.1d0       ! temperature-dependent degradation of TEP-C [1/day]
 /
 
+! ============================================================================
+! ZOOPLANKTON EXCRETION
+! ============================================================================
 &paheterotrophs
-lossN_z               = 0.1d0
-lossC_z               = 0.1d0
+lossN_z               = 0.1d0       ! DON excretion by the first zooplankton [1/day]
+lossC_z               = 0.1d0       ! DOC excretion by the first zooplankton [1/day]
 /
 
 &paseczooloss
-lossN_z2              = 0.02d0
-lossC_z2              = 0.02d0
+lossN_z2              = 0.02d0      ! DON excretion by the second zooplankton [1/day]
+lossC_z2              = 0.02d0      ! DOC excretion by the second zooplankton [1/day]
 /
 
 &pathirdzooloss
-lossN_z3              = 0.05d0    
-lossC_z3              = 0.05d0  
+lossN_z3              = 0.05d0      ! DON excretion by the microzooplankton [1/day]
+lossC_z3              = 0.05d0      ! DOC excretion by the microzooplankton [1/day]
 /
 
-&paco2lim                 
-Cunits         = 976.5625    ! Conversion factor between [mol/m3] (model) and [umol/kg] (function): (1000 * 1000) / 1024                                                                                                                      
-a_co2_phy      = 1.162e+00   ! [dimensionless]
-a_co2_dia      = 1.040e+00   ! [dimensionless]
-a_co2_cocco    = 1.109e+00   ! [dimensionless]
-a_co2_calc     = 1.102e+00   ! [dimensionless]
-b_co2_phy      = 4.888e+01   ! [mol/kg]
-b_co2_dia      = 2.890e+01   ! [mol/kg]
-b_co2_cocco    = 3.767e+01   ! [mol/kg]
-b_co2_calc     = 4.238e+01   ! [mol/kg]
-c_co2_phy      = 2.255e-01   ! [kg/mol]
-c_co2_dia      = 8.778e-01   ! [kg/mol]
-c_co2_cocco    = 3.912e-01   ! [kg/mol]
-c_co2_calc     = 7.079e-01   ! [kg/mol]
-d_co2_phy      = 1.023e+07   ! [kg/mol]
-d_co2_dia      = 2.640e+06   ! [kg/mol]
-d_co2_cocco    = 9.450e+06   ! [kg/mol]
-d_co2_calc     = 1.343e+07   ! [kg/mol]
+! ============================================================================
+! CO2 DEPENDENCE OF GROWTH AND CALCIFICATION (CO2lim)
+! ============================================================================
+! Response = a*HCO3/(b + HCO3) - exp(-c*CO2) - d*10**(-pH), with HCO3 and
+! CO2 converted by Cunits; one set per phytoplankton group and calcification.
+! ============================================================================
+&paco2lim
+Cunits         = 976.5625    ! conversion between [mol/m3] (model) and [umol/kg] (function): (1000 * 1000) / 1024
+a_co2_phy      = 1.162e+00   ! HCO3 response coefficient a, small phytoplankton [dimensionless]
+a_co2_dia      = 1.040e+00   ! HCO3 response coefficient a, diatoms [dimensionless]
+a_co2_cocco    = 1.109e+00   ! HCO3 response coefficient a, coccolithophores [dimensionless]
+a_co2_calc     = 1.102e+00   ! HCO3 response coefficient a, calcification [dimensionless]
+b_co2_phy      = 4.888e+01   ! HCO3 half-saturation b, small phytoplankton [mol/kg]
+b_co2_dia      = 2.890e+01   ! HCO3 half-saturation b, diatoms [mol/kg]
+b_co2_cocco    = 3.767e+01   ! HCO3 half-saturation b, coccolithophores [mol/kg]
+b_co2_calc     = 4.238e+01   ! HCO3 half-saturation b, calcification [mol/kg]
+c_co2_phy      = 2.255e-01   ! CO2 inhibition coefficient c, small phytoplankton [kg/mol]
+c_co2_dia      = 8.778e-01   ! CO2 inhibition coefficient c, diatoms [kg/mol]
+c_co2_cocco    = 3.912e-01   ! CO2 inhibition coefficient c, coccolithophores [kg/mol]
+c_co2_calc     = 7.079e-01   ! CO2 inhibition coefficient c, calcification [kg/mol]
+d_co2_phy      = 1.023e+07   ! H+ inhibition coefficient d, small phytoplankton [kg/mol]
+d_co2_dia      = 2.640e+06   ! H+ inhibition coefficient d, diatoms [kg/mol]
+d_co2_cocco    = 9.450e+06   ! H+ inhibition coefficient d, coccolithophores [kg/mol]
+d_co2_calc     = 1.343e+07   ! H+ inhibition coefficient d, calcification [kg/mol]
 /
 
+! ============================================================================
+! IRON
+! ============================================================================
 &pairon
-Fe2N                  = 0.033d0     ! Fe2C * 6.625
-Fe2N_benthos          = 0.15d0      ! test, default was 0.14 Fe2C_benthos * 6.625 - will have to be tuned. [umol/m2/day]
-kScavFe               = 0.07d0
-dust_sol              = 0.02d0      ! Dissolution of Dust for bioavaliable
-RiverFeConc           = 100
+Fe2N                  = 0.033d0     ! Fe:N ratio of organic matter (Fe2C * 6.625)
+Fe2N_benthos          = 0.15d0      ! Fe:N ratio of the benthic iron release (Fe2C_benthos * 6.625; was 0.14, still to be tuned)
+kScavFe               = 0.07d0      ! scavenging rate of free iron onto detritus
+dust_sol              = 0.02d0      ! soluble (bioavailable) fraction of dust iron
+RiverFeConc           = 100         ! mean dissolved iron concentration in rivers (useRivFe)
 /
 
+! ============================================================================
+! CALCITE
+! ============================================================================
 &pacalc
-calc_prod_ratio       = 0.02
-calc_diss_guts        = 0.5d0       ! set to zero if OmegaC_diss is set to false
-calc_diss_rate        = 0.005714d0  ! 20.d0/3500.d0
-calc_diss_rate2       = 0.005714d0
-calc_diss_omegac      = 0.197d0     ! Value from Aumont et al. 2015, is used with OmegaC_diss flag
-calc_diss_exp         = 1.d0        ! Exponent in the dissolution rate of calcite, is used with OmegaC_diss flag
+calc_prod_ratio       = 0.02        ! calcite production as a fraction of small phytoplankton carbon fixation
+calc_diss_guts        = 0.5d0       ! calcite dissolution in zooplankton guts (set to 0 when OmegaC_diss = .false.)
+calc_diss_rate        = 0.005714    ! calcite dissolution rate (20/3500) [1/day]
+calc_diss_rate2       = 0.005714d0  ! calcite dissolution rate of large detritus, scaled by its sinking speed / 20
+calc_diss_omegac      = 0.197d0     ! value from Aumont et al. (2015), used with OmegaC_diss
+calc_diss_exp         = 1.d0        ! exponent of the calcite dissolution rate, used with OmegaC_diss
 /
 
+! ============================================================================
+! BENTHOS
+! ============================================================================
 &pabenthos_decay_rate
-decayRateBenN         = 0.005d0
-decayRateBenC         = 0.005d0
-decayRateBenSi        = 0.005d0
+decayRateBenN         = 0.005d0     ! decay rate of benthic nitrogen [1/day]
+decayRateBenC         = 0.005d0     ! decay rate of benthic carbon [1/day]
+decayRateBenSi        = 0.005d0     ! decay rate of benthic silicon [1/day]
 q_NC_Denit            = 0.86d0      ! N:C quota of the denitrification process
 /
 
+! ============================================================================
+! AIR-SEA CO2 FLUX
+! ============================================================================
 &paco2_flux_param
-permil                = 0.000000976 ! 1.e-3/1024.5d0              ! Converting DIC from [mmol/m3] to [mol/kg]
-permeg                = 1.e-6                       ! [atm/uatm] Changes units from uatm to atm
+permil                = 0.000000976 ! converts DIC from [mmol/m3] to [mol/kg] (1.e-3/1024.5)
+permeg                = 1.e-6       ! converts uatm to atm [atm/uatm]
 !X1                    = exp(-5.d0*log(10.d0))       ! Lowest ph-value = 7.7 (phlo)
 !X2                    = exp(-9.d0*log(10.d0))       ! Highest ph-value = 9.5 (phhi)
-Xacc                  = 1.e-12                      ! Accuracy for ph-iteration (phacc)
-CO2_for_spinup        = 278.d0                      ! [uatm] Atmospheric partial pressure of CO2
+Xacc                  = 1.e-12      ! accuracy of the pH iteration
+CO2_for_spinup        = 278.d0      ! atmospheric pCO2 used with constant_CO2 = .true. [uatm]
 /
 
+! ============================================================================
+! ALKALINITY RESTORING
+! ============================================================================
 &paalkalinity_restoring
-surf_relax_Alk      = 3.2e-07 !10.d0/31536000.d0
+surf_relax_Alk        = 3.2e-07     ! surface alkalinity restoring velocity, 10 m per year [m/s] (restore_alkalinity)
 /
 
+! ============================================================================
+! BALLASTING (use_ballasting, see Cram et al. 2018)
+! ============================================================================
 &paballasting
-rho_POC              = 1033.d0   ! kg m-3; density of POC (see Table 1 in Cram et al., 2018)
-rho_PON              = 1033.d0   ! kg m-3; density of PON (see Table 1 in Cram et al., 2018)
-rho_CaCO3            = 2830.d0   ! kg m-3; density of CaCO3 (see Table 1 in Cram et al., 2018) 
-rho_opal             = 2090.d0   ! kg m-3; density of Opal (see Table 1 in Cram et al., 2018)
-rho_ref_part         = 1230.d0   ! kg m-3; reference particle density (see Cram et al., 2018)
-rho_ref_water        = 1027.d0   ! kg m-3; reference seawater density (see Cram et al., 2018)
-visc_ref_water       = 0.00158d0 ! kg m-1 s-1; reference seawater viscosity, at Temp=4 degC (see Cram et al., 2018)
-w_ref1               = 10.d0     ! m s-1; reference sinking velocity of small detritus
-w_ref2               = 200.d0    ! m s-1; reference sinking velocity of large detritus
-depth_scaling1       = 0.01d0   ! s-1; factor to increase sinking speed of det1 with depth, set to 0 if not wanted
-depth_scaling2       = 0.d0      ! s-1; factor to increase sinking speed of det2 with depth, set to 0 if not wanted
-max_sinking_velocity = 250.d0    ! d-1; for numerical stability, set a maximum possible sinking velocity here (applies to both detritus classes)
+rho_POC              = 1033.d0   ! density of POC [kg/m3] (Cram et al. 2018, Table 1)
+rho_PON              = 1033.d0   ! density of PON [kg/m3] (Cram et al. 2018, Table 1)
+rho_CaCO3            = 2830.d0   ! density of CaCO3 [kg/m3] (Cram et al. 2018, Table 1)
+rho_opal             = 2090.d0   ! density of opal [kg/m3] (Cram et al. 2018, Table 1)
+rho_ref_part         = 1230.d0   ! reference particle density [kg/m3]
+rho_ref_water        = 1027.d0   ! reference seawater density [kg/m3]
+visc_ref_water       = 0.00158d0 ! reference seawater viscosity at 4 degC [kg/(m s)]
+w_ref1               = 10.d0     ! reference sinking velocity of small detritus [m/day]
+w_ref2               = 200.d0    ! reference sinking velocity of large detritus [m/day]
+depth_scaling1       = 0.01d0    ! increase of small detritus sinking speed with depth [1/day], 0 = off
+depth_scaling2       = 0.d0      ! increase of large detritus sinking speed with depth [1/day], 0 = off
+max_sinking_velocity = 250.d0    ! upper limit of the sinking speed for numerical stability [m/day], both detritus classes
 /
 
+! ============================================================================
+! CARBON ISOTOPES (ciso)
+! ============================================================================
 &paciso
 ciso_init         = .false.     ! initial fractionation of bulk organic matter
-ciso_14           = .false.      ! include inorganic radiocarbon
+ciso_14           = .false.     ! include inorganic radiocarbon
 ciso_organic_14   = .false.     ! include organic radiocarbon
-lambda_14         = 3.8561e-12  ! corresponding to 1 year = 365.00 days
-delta_CO2_13      = -6.61       ! atmospheric d13C (permil), global-mean value
-big_delta_CO2_14(1)  = 0. ! atmospheric D14C (permil), northern hemisphere polewards of 30°N
-big_delta_CO2_14(2)  = 0. ! atmospheric D14C (permil), (sub) tropical zone 30°N - 30°S
-big_delta_CO2_14(3)  = 0. ! atmospheric D14C (permil), southern hemisphere polewards of 30°S
-atbox_spinup      = .false.
-cosmic_14_init    = 2.0
+lambda_14         = 3.8561e-12  ! radiocarbon decay constant [1/s] (1 year = 365.00 days)
+delta_CO2_13      = -6.61       ! atmospheric d13C, global mean [permil]
+big_delta_CO2_14(1)  = 0. ! atmospheric D14C north of 30°N [permil]
+big_delta_CO2_14(2)  = 0. ! atmospheric D14C between 30°N and 30°S [permil]
+big_delta_CO2_14(3)  = 0. ! atmospheric D14C south of 30°S [permil]
+atbox_spinup      = .false.     ! spin-up mode of the atmospheric 14C box
+cosmic_14_init    = 2.0         ! initial cosmogenic 14C production [atoms/(s cm²)]
 /
-
-

--- a/config/bin_3p3z2d/namelist.tra
+++ b/config/bin_3p3z2d/namelist.tra
@@ -1,9 +1,37 @@
+! ============================================================================
+! ============ Namelist file for FESOM2 tracer configuration =================
+! ============================================================================
+! This file contains configuration for ocean tracers (temperature, salinity,
+! and passive tracers):
+! - Tracer list and advection/diffusion schemes
+! - Initial conditions (3D ocean and 2D sea ice)
+! - Biharmonic diffusion options
+! - Vertical diffusion and time stepping
+! - Physical parameterizations (mixing, restoring)
+! ============================================================================
+
+! ============================================================================
+! TRACER ARRAY ALLOCATION
+! ============================================================================
 &tracer_listsize
-num_tracers=100 !number of tracers to allocate. shallbe large or equal to the number of streams in &nml_list
+num_tracers = 100         ! number of tracers to allocate (must be ≥ actual number of tracers)
 /
 
+! ============================================================================
+! TRACER LIST AND ADVECTION SCHEMES
+! ============================================================================
+! Format: ID, horizontal_advection, vertical_advection, horizontal_diffusion, Kh_factor, Kv_factor
+! Advection schemes: 'MFCT' (Multidimensional FCT), 'UPW1' (1st-order upwind), 'QR4C' (4th-order)
+! Diffusion schemes: 'FCT' (Flux-Corrected Transport), 'NON' (none)
+! Order switches   : hor./vert. Ord.=1.0 --> 4th order, =0.0 --> 3rd order, =0.5 --> mixed 3rd&4th order
+! ============================================================================
+! nml_tracer_list =
+! idx, hor. Adv, vert. Adv., use FCT, hor.Ord., vert. Ord. 
+! 1  , 'MFCT'  , 'QR4C'    , 'FCT ' , 1.      , 1.        ,   ! temperature
+! 2  , 'MFCT'  , 'QR4C'    , 'FCT ' , 1.      , 1.        ,   ! salinity
+!101 , 'UPW1'  , 'UPW1'    , 'NON ' , 0.      , 0.            ! example passive tracer
 &tracer_list
-nml_tracer_list =  
+nml_tracer_list =
 1  ,   'MFCT',       'QR4C',       'FCT ',        1.,          1., 
 2  ,   'MFCT',       'QR4C',       'FCT ',        1.,          1.,
 1001,  'MFCT',       'QR4C',       'FCT ',        1.,          1.,
@@ -43,49 +71,81 @@ nml_tracer_list =
 !101, 'UPW1',       'UPW1',       'NON ',        0.,          0.
 /
 
-&tracer_init3d                            ! initial conditions for tracers
-n_ic3d   = 8                              ! number of tracers to initialize
-idlist   = 1019, 1022, 1018, 1003, 1002, 1001, 2, 1 ! their IDs (0 is temperature, 1 is salinity, etc.). The reading order is defined here!
-filelist = 'fe_pisces_opa_eq_init_3D_changed_name.nc', 'woa18_all_o00_01_mmol_fesom2.nc', 'woa13_all_i00_01_fesom2.nc', 'GLODAPv2.2016b.TAlk_fesom2_mmol_fix_z_Fillvalue.nc', 'GLODAPv2.2016b.TCO2_fesom2_mmol_fix_z_Fillvalue.nc', 'woa13_all_n00_01_fesom2.nc', 'phc3.0_winter.nc', 'phc3.0_winter.nc'  ! list of files in ClimateDataPath to read (one file per tracer), same order as idlist
-varlist  = 'Fe', 'oxygen_mmol', 'i_an', 'TAlk_mmol', 'TCO2_mmol', 'n_an', 'salt', 'temp'                 ! variables to read from specified files
-t_insitu = .true.                         ! if T is insitu it will be converted to potential after reading it
+! ============================================================================
+! 3D TRACER INITIAL CONDITIONS (OCEAN)
+! ============================================================================
+&tracer_init3d
+n_ic3d   = 8  ! number of 3D tracers to initialize from files
+idlist   = 1019, 1022, 1018, 1003, 1002, 1001, 2, 1 ! tracer IDs to initialize (1=temperature, 2=salinity)
+filelist = 'fe_pisces_opa_eq_init_3D_changed_name.nc', 'woa18_all_o00_01_mmol_fesom2.nc', 'woa13_all_i00_01_fesom2.nc', 'GLODAPv2.2016b.TAlk_fesom2_mmol_fix_z_Fillvalue.nc', 'GLODAPv2.2016b.TCO2_fesom2_mmol_fix_z_Fillvalue.nc', 'woa13_all_n00_01_fesom2.nc', 'phc3.0_winter.nc', 'phc3.0_winter.nc' ! netCDF files in ClimateDataPath (one per tracer)
+varlist  = 'Fe', 'oxygen_mmol', 'i_an', 'TAlk_mmol', 'TCO2_mmol', 'n_an', 'salt', 'temp' ! variable names in the netCDF files
+t_insitu = .true.                                  ! if true, convert in-situ temperature to potential temperature
 /
 
-&tracer_init2d                                      ! initial conditions for 2D tracers (sea ice)
-n_ic2d   = 3                                        ! number of tracers to initialize
-idlist   = 1, 2, 3                                  ! their IDs (0 is a_ice, 1 is m_ice, 3 m_snow). The reading order is defined here!
-filelist = 'a_ice.nc', 'm_ice.nc', 'm_snow.nc' ! list of files in ClimateDataPath to read (one file per tracer), same order as idlist
-varlist  = 'a_ice', 'm_ice', 'm_snow'                 ! variables to read from specified files
-ini_ice_from_file=.false.
+! ============================================================================
+! 2D TRACER INITIAL CONDITIONS (SEA ICE)
+! ============================================================================
+&tracer_init2d
+n_ic2d            = 3                                    ! number of 2D tracers to initialize from files
+idlist            = 1, 2, 3                              ! tracer IDs (1=ice concentration, 2=ice thickness, 3=snow thickness)
+filelist          = 'a_ice.nc', 'm_ice.nc', 'm_snow.nc'  ! netCDF files in ClimateDataPath
+varlist           = 'a_ice', 'm_ice', 'm_snow'           ! variable names in the netCDF files
+ini_ice_from_file = .false.                              ! enable initialization from files (false = use default values)
 /
 
+! ============================================================================
+! TRACER GENERAL SETTINGS
+! ============================================================================
 &tracer_general
-! bharmonic diffusion for tracers. We recommend to use this option in very high resolution runs (Redi is generally off there).
-smooth_bh_tra =.false.     ! use biharmonic diffusion (filter implementation) for tracers
-gamma0_tra    = 0.0005     ! gammaX_tra are analogous to those in the dynamical part
-gamma1_tra    = 0.0125
-gamma2_tra    = 0.
-i_vert_diff   =.true.
+! --- Biharmonic Diffusion ---
+! Recommended for very high resolution runs (where Redi is typically disabled)
+smooth_bh_tra = .false.       ! enable biharmonic diffusion (filter implementation) for tracers
+gamma0_tra    = 0.0005        ! background biharmonic diffusion coefficient [dimensionless]
+gamma1_tra    = 0.0125        ! flow-aware biharmonic diffusion coefficient [dimensionless]
+gamma2_tra    = 0.            ! additional biharmonic diffusion coefficient [dimensionless]
+
+! --- Vertical Diffusion and Time Stepping ---
+i_vert_diff   = .true.        ! use implicit vertical diffusion (recommended for stability)
 /
 
+! ============================================================================
+! TRACER PHYSICS AND PARAMETERIZATIONS
+! ============================================================================
 &tracer_phys
-use_momix     = .true.     ! switch on/off  !Monin-Obukhov -> TB04 mixing
-momix_lat     = -50.0      ! latitidinal treshhold for TB04, =90 --> global
-momix_kv      = 0.01       ! PP/KPP, mixing coefficient within MO length
-use_instabmix = .true.     ! enhance convection in case of instable stratification
-instabmix_kv  = 0.1
-use_windmix   = .false.    ! enhance mixing trough wind only for PP mixing (for stability)
-windmix_kv    = 1.e-3
-windmix_nl    = 2
-diff_sh_limit=5.0e-3       ! for KPP, max diff due to shear instability
-Kv0_const=.true.
-double_diffusion=.false.   ! for KPP,dd switch
-K_ver=1.0e-5
-K_hor=3000.
-surf_relax_T=0.0
-surf_relax_S=1.929e-06   ! 50m/300days 6.43e-07! m/s 10./(180.*86400.)
-balance_salt_water =.true. ! balance virtual-salt or freshwater flux or not
-clim_relax=0.0	           ! 1/s, geometrical information has to be supplied
-ref_sss_local=.true.
-ref_sss=34.
+! --- Monin-Obukhov Mixing (TB04) ---
+use_momix          = .true.            ! enable Monin-Obukhov mixing (Timmermann & Beckmann 2004)
+momix_lat          = -50.0             ! latitude threshold for TB04 [degrees] (90 = global, -50 = south of 50°S)
+momix_kv           = 0.01              ! mixing coefficient within MO length [m²/s]
+
+! --- Convective Instability Mixing ---
+use_instabmix      = .true.            ! enhance mixing for unstable stratification (convection)
+instabmix_kv       = 0.1               ! mixing coefficient for unstable stratification [m²/s]
+
+! --- Wind Mixing (PP scheme only) ---
+use_windmix        = .false.           ! enhance near-surface mixing by wind (for PP mixing stability)
+windmix_kv         = 1.e-3             ! wind mixing coefficient [m²/s]
+windmix_nl         = 2                 ! number of surface layers for wind mixing
+
+! --- Shear Instability (KPP) ---
+diff_sh_limit      = 5.0e-3            ! maximum diffusivity due to shear instability [m²/s] (for KPP)
+
+! --- Background Diffusivity ---
+Kv0_const          = .true.            ! use constant background vertical diffusivity
+K_ver              = 1.0e-5            ! background vertical diffusivity [m²/s]
+K_hor              = 3000.             ! background horizontal diffusivity [m²/s]
+
+! --- Double Diffusion (KPP) ---
+double_diffusion   = .false.           ! enable double diffusion parameterization (for KPP)
+
+! --- Surface Restoring ---
+surf_relax_T       = 0.0               ! surface temperature restoring coefficient [m/s] (0 = disabled)
+surf_relax_S       = 1.929e-06         ! surface salinity restoring coefficient [m/s]
+balance_salt_water = .true.            ! balance virtual salt flux with freshwater flux
+
+! --- Climatology Restoring ---
+clim_relax         = 0.0               ! 3D climatology restoring coefficient [1/s] (0 = disabled)
+
+! --- Reference Salinity ---
+ref_sss_local      = .true.            ! use local reference SSS (true) or global constant (false)
+ref_sss            = 34.               ! global reference salinity [psu] (if ref_sss_local=false)
 /

--- a/config/bin_4p3z2d/namelist.config
+++ b/config/bin_4p3z2d/namelist.config
@@ -1,76 +1,133 @@
-! This is the namelist file for model general configuration
+! ============================================================================
+! ============ Namelist file for FESOM2 general configuration ================
+! ============================================================================
+! This file contains the main configuration parameters for FESOM2, including:
+! - Model identification and run settings
+! - Time stepping and simulation duration
+! - Initial time/date settings
+! - File paths for mesh, forcing, and output
+! - Restart and logging configuration
+! - Vertical coordinate system (ALE)
+! - Grid geometry and rotation
+! - Calendar settings
+! - Model components (ice, cavities, etc.)
+! - Parallel decomposition
+! - Iceberg settings
+! ============================================================================
 
+! ============================================================================
+! RUN IDENTIFICATION
+! ============================================================================
 &modelname
-runid='fesom'
+runid = 'fesom'        ! run identifier (used in output filenames)
 /
 
+! ============================================================================
+! TIME STEPPING AND RUN LENGTH
+! ============================================================================
 &timestep
-step_per_day=32 !96 !96 !72 !72 !45 !72 !96
-run_length= 1 !62 !62 !62 !28
-run_length_unit='y' ! y, m, d, s
+step_per_day      = 32         ! number of time steps per day (determines dt = 86400/step_per_day seconds)
+                                ! common values: 32 (45min), 48 (30min), 72 (20min), 96 (15min), 192 (7min 30sec), 
+                                ! 216 (6min 40sec), 240 (6min), 288 (5min), 360 (4min), 720 (2min), 1440 (1min), 2880 (30sec)
+run_length        = 1          ! total length of simulation run
+run_length_unit   = 'y'        ! unit for run_length: 'y' (years), 'm' (months), 'd' (days), 's' (steps)
 /
 
-&clockinit              ! the model starts at
-timenew=0.0
-daynew=1
-yearnew=1958
+! ============================================================================
+! INITIAL TIME/DATE SETTINGS
+! ============================================================================
+&clockinit
+timenew = 0.0                  ! initial time within the day [seconds] (0.0 = midnight)
+daynew  = 1                    ! initial day of the month (1-31)
+yearnew = 1958                 ! initial year
 /
 
+! ============================================================================
+! MESH, INITIALIZATION & OUTPUT PATHS
+! ============================================================================
 &paths
-MeshPath='/albedo/work/projects/p_recompdaf/frbunsen/FESOM2/meshes/core2/'
-ClimateDataPath='/albedo/work/projects/MarESys/ogurses/input/corrected_input/'
-ResultPath='/albedo/work/user/...'
+MeshPath         = '/albedo/work/projects/p_recompdaf/frbunsen/FESOM2/meshes/core2/' ! path to mesh files (nod2d.out, elem2d.out, etc.)
+ClimateDataPath  = '/albedo/work/projects/MarESys/ogurses/input/corrected_input/' ! path to initial conditions (temperature, salinity)
+ResultPath       = '/albedo/work/user/...'  ! path for output files and fesom.clock file
 /
 
+! ============================================================================
+! RESTART AND LOGGING CONFIGURATION
+! ============================================================================
 &restart_log
-restart_length=1            ! --> do netcdf restart ( only required for d,h,s cases, y, m take 1)
-restart_length_unit='y'     !output period: y, d, h, s, off
-raw_restart_length=1        ! --> do core dump restart
-raw_restart_length_unit='off' ! e.g. y, d, h, s, off
-bin_restart_length=1        ! --> do derived type binary restart 
-bin_restart_length_unit='off' ! e.g. y, d, h, s, off
-logfile_outfreq=960         !in logfile info. output frequency, # steps
+restart_length          = 1        ! frequency for netCDF restart files (required for d,h,s; y,m use 1)
+restart_length_unit     = 'y'      ! unit: 'y' (years), 'm' (months), 'd' (days), 'h' (hours), 's' (steps), 'off' (disabled)
+raw_restart_length      = 1        ! frequency for raw core dump restart files
+raw_restart_length_unit = 'off'    ! unit: 'y', 'm', 'd', 'h', 's', 'off'
+bin_restart_length      = 1        ! frequency for binary derived type restart files
+bin_restart_length_unit = 'off'    ! unit: 'y', 'm', 'd', 'h', 's', 'off'
+logfile_outfreq         = 960      ! log file output frequency [number of time steps]
 /
 
+! ============================================================================
+! VERTICAL COORDINATE SYSTEM (ALE - Arbitrary Lagrangian-Eulerian)
+! ============================================================================
 &ale_def
-which_ALE='zstar'       ! 'linfs','zlevel', 'zstar'
-use_partial_cell=.true.
+which_ALE          = 'zstar'     ! vertical coordinate type:
+                                  !   'linfs'  = linear free surface
+                                  !   'zlevel' = z-level (fixed depth levels)
+                                  !   'zstar'  = z-star (terrain-following with SSH scaling)
+use_partial_cell   = .true.      ! use partial bottom cells for better topography representation (not recommended)
 /
 
+! ============================================================================
+! GRID GEOMETRY AND ROTATION
+! ============================================================================
 &geometry
-cartesian=.false.
-fplane=.false.
-cyclic_length=360       ![degree]
-rotated_grid=.true.     !option only valid for coupled model case now
-force_rotation=.true.
-alphaEuler=50.          ![degree] Euler angles, convention:
-betaEuler=15.           ![degree] first around z, then around new x,
-gammaEuler=-90.         ![degree] then around new z.
+cartesian       = .false.        ! use Cartesian coordinates (false = spherical Earth)
+fplane          = .false.        ! use f-plane approximation (constant Coriolis parameter)
+cyclic_length   = 360            ! length of cyclic domain [degrees] (360 = global)
+rotated_grid    = .true.         ! use rotated grid (typically for coupled models to avoid pole singularity)
+force_rotation  = .true.         ! force grid rotation even if not coupled
+alphaEuler      = 50.            ! first Euler angle (rotation around z-axis) [degrees]
+betaEuler       = 15.            ! second Euler angle (rotation around new x-axis) [degrees]
+gammaEuler      = -90.           ! third Euler angle (rotation around new z-axis) [degrees]
+                                  ! Euler angle convention: rotate first around z, then around new x, then around new z
 /
 
+! ============================================================================
+! CALENDAR SETTINGS
+! ============================================================================
 &calendar
-include_fleapyear=.false.
+include_fleapyear = .false.      ! include leap years in calendar (false = 365-day year, true = 365/366-day year)
 /
 
+! ============================================================================
+! MODEL COMPONENTS AND FEATURES
+! ============================================================================
 &run_config
-use_ice=.true.                  ! ocean+ice
-use_cavity=.false.              !
-use_cavity_partial_cell=.false. 
-use_floatice = .false.
-use_sw_pene=.true.
-flag_debug=.false.
-use_transit=.false.
+use_ice                  = .true.        ! enable sea ice model
+use_cavity               = .false.       ! enable ice shelf cavities
+use_cavity_partial_cell  = .false.       ! use partial cells in ice shelf cavities (not recommended)
+use_floatice             = .false.       ! enable floating ice (icebergs)
+use_sw_pene              = .true.        ! enable shortwave radiation penetration into ocean
+flag_debug               = .false.       ! enable debug output (verbose logging)
+use_transit              = .false.       ! enable transient tracer module (CFCs, SF6, etc.)
 /
 
+! ============================================================================
+! PARALLEL DECOMPOSITION (DOMAIN PARTITIONING)
+! ============================================================================
 &machine
-n_levels=2
-n_part= 12, 36          ! 432 number of partitions on each hierarchy level
+n_levels = 2             ! number of hierarchy levels for domain decomposition
+n_part   = 12, 36        ! number of partitions at each level (total CPUs = product of n_part)
+                         ! example: 2 x 128 = 256 MPI tasks
+                         ! adjust based on mesh size and available compute resources
+                         ! maximum scaling reached at ~300 FESOM2 2D nodes per CPU (see first line in nod2d.out for number of 2D nodes)
 /
 
+! ============================================================================
+! ICEBERG SETTINGS
+! ============================================================================
 &icebergs
-use_icesheet_coupling=.false.
-ib_num=1
-use_icebergs=.false.
-steps_per_ib_step=8
-ib_async_mode=0
+use_icesheet_coupling = .false.  ! enable ice sheet model
+ib_num                = 1        ! number of iceberg classes
+use_icebergs          = .false.  ! enable iceberg module
+steps_per_ib_step     = 8        ! ocean time steps per iceberg time step (iceberg subcycling)
+ib_async_mode         = 0        ! iceberg asynchronous mode (0=synchronous, 1=asynchronous)
 /

--- a/config/bin_4p3z2d/namelist.dyn
+++ b/config/bin_4p3z2d/namelist.dyn
@@ -1,24 +1,56 @@
+! ============================================================================
+! ========== Namelist file for FESOM2 momentum dynamics ======================
+! ============================================================================
+! This file contains configuration for momentum equations and dynamics:
+! - Horizontal viscosity schemes and parameters
+! - Momentum advection options
+! - Free-slip vs no-slip boundary conditions
+! - Vertical velocity splitting
+! - Split-explicit barotropic subcycling
+! - Energy diagnostics
+! ============================================================================
+
+! ============================================================================
+! HORIZONTAL VISCOSITY
+! ============================================================================
 &dynamics_visc
-visc_gamma0  = 0.003 ! [m/s],   backgroung viscosity= gamma0*len, it should be as small a s possible (keep it < 0.01 m/s).
-visc_gamma1  = 0.1   ! [nodim], for computation of the flow aware viscosity
-visc_gamma2  = 0.285 ! [s/m],   is only used in easy backscatter option
-visc_easybsreturn= 1.5
+! --- Biharmonic Viscosity Coefficients ---
+visc_gamma0        = 0.003       ! background viscosity coefficient [m/s]
+                                 ! viscosity = gamma0 × element_length
+                                 ! keep < 0.01 m/s for numerical stability
+visc_gamma1        = 0.1         ! flow-aware viscosity coefficient [dimensionless]
+visc_gamma2        = 0.285       ! additional viscosity coefficient [s/m]
+                                 ! only used for easy backscatter (opt_visc=5) and dynamic backscatter (opt_visc=8)
+visc_easybsreturn  = 1.5         ! energy return parameter for easy backscatter [dimensionless]
 
-opt_visc     = 5          
-! 5=Kinematic (easy) Backscatter
-! 6=Biharmonic flow aware (viscosity depends on velocity Laplacian)
-! 7=Biharmonic flow aware (viscosity depends on velocity differences)
-! 8=Dynamic Backscatter
+! --- Viscosity Scheme Selection ---
+opt_visc           = 5           ! horizontal viscosity scheme:
+                                 !   5 = Kinematic (easy) Backscatter
+                                 !   6 = Biharmonic flow-aware (depends on velocity Laplacian)
+                                 !   7 = Biharmonic flow-aware (depends on velocity differences)
+                                 !       + optional Laplacian when visc_gamma0_h or visc_gamma1_h > 0
+                                 !   8 = Dynamic Backscatter
 
-use_ivertvisc= .true.  
+! --- Vertical Viscosity ---
+use_ivertvisc      = .true.      ! use implicit vertical viscosity (recommended for stability)
 /
 
+! ============================================================================
+! GENERAL DYNAMICS SETTINGS
+! ============================================================================
 &dynamics_general
-momadv_opt   = 2       ! option for momentum advection in moment only =2
-use_freeslip = .false. ! Switch on free slip
-use_wsplit   = .false. ! Switch for implicite/explicte splitting of vert. velocity
-wsplit_maxcfl= 1.0     ! maximum allowed CFL criteria in vertical (0.5 < w_max_cfl < 1.) 
-                       ! in older FESOM it used to be w_exp_max=1.e-3
-ldiag_KE=.false.       ! activates energy diagnostics
+! --- Momentum Advection ---
+momadv_opt         = 2           ! momentum advection option (only 2 is currently supported)
+
+! --- Boundary Conditions ---
+use_freeslip       = .false.     ! enable free-slip lateral boundary conditions (false = no-slip)
+
+! --- Vertical Velocity Splitting ---
+use_wsplit         = .false.     ! enable implicit/explicit splitting of vertical velocity
+wsplit_maxcfl      = 1.0         ! maximum allowed vertical CFL criterion (range: 0.5-1.0)
+                                 ! in older FESOM versions this was w_exp_max=1.e-3
+
+! --- Energy Diagnostics ---
+ldiag_KE           = .false.     ! enable kinetic energy diagnostics (requires additional computation)
 /
 

--- a/config/bin_4p3z2d/namelist.forcing
+++ b/config/bin_4p3z2d/namelist.forcing
@@ -1,80 +1,154 @@
-! This is the namelist file for forcing
+! ============================================================================
+! ============= Namelist file for FESOM2 atmospheric forcing ================
+! ============================================================================
+! This file contains configuration for atmospheric forcing and surface boundary
+! conditions, including:
+! - Bulk formulae exchange coefficients (heat, momentum, moisture)
+! - Bulk formulae options and reference heights
+! - Land ice freshwater forcing
+! - Age tracer configuration
+! - Surface forcing data files and variables
+! - Runoff and salinity restoring
+! - Chlorophyll data for shortwave penetration
+! ============================================================================
+! ----------------------------------------------------------------------------
+! File names below are relative to ForcingDataPath in namelist.config. A name
+! starting with '/' is used as given, which is how files outside the forcing
+! tree (for example the Sweeney chlorophyll climatology) are pointed at.
+! ----------------------------------------------------------------------------
 
+! ============================================================================
+! BULK FORMULAE EXCHANGE COEFFICIENTS
+! ============================================================================
+! These coefficients control the turbulent exchange of heat, moisture, and
+! momentum between the atmosphere and ocean/ice surfaces.
+! ============================================================================
 &forcing_exchange_coeff
-Ce_atm_oce=0.00175 ! exchange coeff. of latent heat over open water
-Ch_atm_oce=0.00175 ! exchange coeff. of sensible heat over open water
-Cd_atm_oce=0.001  ! drag coefficient between atmosphere and water
-Ce_atm_ice=0.00175 ! exchange coeff. of latent heat over ice
-Ch_atm_ice=0.00175 ! exchange coeff. of sensible heat over ice
-Cd_atm_ice=0.0012  ! drag coefficient between atmosphere and ice 
-Swind     =0.0     ! parameterization for coupled current feedback
+Ce_atm_oce = 0.00175    ! exchange coefficient of latent heat over open water (dimensionless)
+Ch_atm_oce = 0.00175    ! exchange coefficient of sensible heat over open water (dimensionless)
+Cd_atm_oce = 0.001      ! drag coefficient between atmosphere and water (dimensionless)
+Ce_atm_ice = 0.00175    ! exchange coefficient of latent heat over ice (dimensionless)
+Ch_atm_ice = 0.00175    ! exchange coefficient of sensible heat over ice (dimensionless)
+Cd_atm_ice = 0.0012     ! drag coefficient between atmosphere and ice (dimensionless)
+Swind       = 0.0       ! parameterization for coupled current feedback (0.0 = disabled)
+                        ! non-zero values reduce wind stress based on ocean surface currents
 /
 
+! ============================================================================
+! BULK FORMULAE OPTIONS
+! ============================================================================
+! Configuration for bulk formulae calculations (turbulent fluxes).
+! Reference heights must match the forcing data specifications.
+! ============================================================================
 &forcing_bulk
-AOMIP_drag_coeff=.false.
-ncar_bulk_formulae=.true.
-ncar_bulk_z_wind=10.0 ! height at which wind forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-ncar_bulk_z_tair=10.0 ! height at which temp forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-ncar_bulk_z_shum=10.0 ! height at which humi forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-
+AOMIP_drag_coeff  = .false.  ! use AOMIP drag coefficient formulation (false = use standard)
+ncar_bulk_formulae = .true.  ! use NCAR bulk formulae (Large & Yeager 2004, 2009)
+ncar_bulk_z_wind   = 10.0    ! reference height for wind forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_tair   = 10.0    ! reference height for air temperature forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_shum   = 10.0    ! reference height for specific humidity forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
 /
 
+! ============================================================================
+! LAND ICE FRESHWATER FORCING
+! ============================================================================
+! Configuration for freshwater input from land ice (glaciers, ice sheets).
+! Requires use_landice_water=.true. in namelist.config to enable output.
+! ============================================================================
 &land_ice
-use_landice_water=.false.
-landice_start_mon=5
-landice_end_mon=10
-fwf_path='./mesh/'
-
+use_landice_water = .false.  ! enable land ice freshwater forcing
+landice_start_mon = 5        ! start month for land ice forcing (1-12)
+landice_end_mon   = 10       ! end month for land ice forcing (1-12)
+fwf_path          = './mesh/'    ! path to land ice freshwater flux data files
 /
 
+! ============================================================================
+! AGE TRACER CONFIGURATION
+! ============================================================================
+! Configuration for passive age tracer (tracks water mass age).
+! Requires use_age_tracer=.true. in namelist.config to enable output.
+! ============================================================================
 &age_tracer
-use_age_tracer=.false.
-use_age_mask=.false.
-age_tracer_path='./mesh/'
-age_start_year=2000
-
+use_age_tracer    = .false.  ! enable age tracer computation
+use_age_mask      = .false.  ! use spatial mask for age tracer initialization
+age_tracer_path   = './mesh/'    ! path to age tracer mask file (if use_age_mask=.true.)
+age_start_year    = 2000     ! year to start age tracer (tracer age = 0 at this year)
 /
 
+! ============================================================================
+! SURFACE BOUNDARY CONDITION (FORCING DATA)
+! ============================================================================
+! Specification of atmospheric forcing data files and variables.
+! File paths are relative to the run directory.
+! ============================================================================
 &nam_sbc
-   nm_xwind_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/uas.clim61'        ! name of file with winds, if nm_sbc=2
-   nm_ywind_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/vas.clim61'        ! name of file with winds, if nm_sbc=2
-   nm_xstre_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/uas.clim61'        ! name of file with winds, if nm_sbc=2
-   nm_ystre_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/vas.clim61'        ! name of file with winds, if nm_sbc=2
-   nm_humi_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/huss.clim61'        ! name of file with humidity
-   nm_qsr_file   = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/rsds.clim61'    ! name of file with solar heat
-   nm_qlw_file   = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/rlds.clim61'    ! name of file with Long wave
-   nm_tair_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/tas.clim61'        ! name of file with 2m air temperature
+   ! --- Forcing file paths ---
+   nm_xwind_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/uas.clim61' ! name of file with zonal wind speeds
+   nm_ywind_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/vas.clim61' ! name of file with meridional wind speeds
+   nm_xstre_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/uas.clim61' ! name of file with zonal wind stress
+   nm_ystre_file = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/vas.clim61' ! name of file with meridional wind stress
+   nm_humi_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/huss.clim61' ! name of file with air humidity
+   nm_qsr_file   = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/rsds.clim61' ! name of file with short wave radiation
+   nm_qlw_file   = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/rlds.clim61' ! name of file with long wave radiation
+   nm_tair_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/tas.clim61' ! name of file with 2m air temperature
    nm_prec_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/prra.clim61' ! name of file with total precipitation
-   nm_snow_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/prsn.clim61' ! name of file with snow  precipitation
+   nm_snow_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/prsn.clim61' ! name of file with snow precipitation
    nm_mslp_file  = '/albedo/work/projects/MarESys/FROM-OLLIE/forcing_JRA55-do-v1.4.0_clim61/psl.clim61'         ! air_pressure_at_sea_level
-   nm_xwind_var  = 'uas'   ! name of variable in file with wind
-   nm_ywind_var  = 'vas'   ! name of variable in file with wind
-   nm_xstre_var  = 'uas'   ! name of variable in file with wind
-   nm_ystre_var  = 'vas'   ! name of variable in file with wind
-   nm_humi_var   = 'huss'  ! name of variable in file with humidity
-   nm_qsr_var    = 'rsds'  ! name of variable in file with solar heat
-   nm_qlw_var    = 'rlds'  ! name of variable in file with Long wave
-   nm_tair_var   = 'tas'   ! name of variable in file with 2m air temperature
-   nm_prec_var   = 'prra'  ! name of variable in file with total precipitation
-   nm_snow_var   = 'prsn'  ! name of variable in file with total precipitation
-   nm_mslp_var   = 'psl'   ! name of variable in file with air_pressure_at_sea_level
-   nm_nc_iyear   = 1900
-   nm_nc_imm     = 1            ! initial month of time axis in netCDF 
-   nm_nc_idd     = 1            ! initial day of time axis in netCDF
-   nm_nc_freq    = 1            ! data points per day (i.e. 86400 if the time axis is in seconds)
-   nm_nc_tmid    = 0            ! 1 if the time stamps are given at the mid points of the netcdf file, 0 otherwise (i.e. 1 in CORE1, CORE2; 0 in JRA55)
-   y_perpetual=.true.
-   l_xwind=.true. l_ywind=.true. l_xstre=.false. l_ystre=.false. l_humi=.true. l_qsr=.true. l_qlw=.true. l_tair=.true. l_prec=.true. l_mslp=.true. l_cloud=.false. l_snow=.true.
-   nm_runoff_file      ='/albedo/pool/FESOM/forcing/CORE2/runoff.nc'
-   runoff_data_source ='CORE2'	!Dai09, CORE2
-   !runoff_data_source ='Dai09'  !Dai09, CORE2, JRA55
-   !runoff_climatology =.true.
-   sss_data_source    ='CORE2'
-   nm_sss_data_file   ='/albedo/pool/FESOM/forcing/CORE2/PHC2_salx.nc'
-   chl_data_source    ='None' !'Sweeney' monthly chlorophyll climatology or 'NONE' for constant chl_const (below). Make use_sw_pene=.TRUE. in namelist.config!
-   nm_chl_data_file   ='/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/Sweeney/Sweeney_2005.nc'
-   chl_const          = 0.1
-   use_runoff_mapper  = .FALSE.
-   runoff_basins_file = 'runoff_maps_regular.nc'
-   runoff_radius      = 500000.
+
+   ! --- Variable names in netCDF forcing files ---
+   nm_xwind_var  = 'uas'      ! name of variable in file with zonal wind
+   nm_ywind_var  = 'vas'      ! name of variable in file with meridional wind
+   nm_xstre_var  = 'uas'      ! name of variable in file with zonal wind stress
+   nm_ystre_var  = 'vas'      ! name of variable in file with meridional wind stress
+   nm_humi_var   = 'huss'     ! name of variable in file with humidity
+   nm_qsr_var    = 'rsds'     ! name of variable in file with solar heat
+   nm_qlw_var    = 'rlds'     ! name of variable in file with long wave
+   nm_tair_var   = 'tas'      ! name of variable in file with 2m air temperature
+   nm_prec_var   = 'prra'     ! name of variable in file with total precipitation
+   nm_snow_var   = 'prsn'     ! name of variable in file with snow precipitation
+   nm_mslp_var   = 'psl'      ! name of variable in file with air_pressure_at_sea_level
+
+   ! --- Time axis configuration in forcing files ---
+   nm_nc_iyear   = 1900       ! initial year of forcing data time axis (note, not the first year in the file!)
+   nm_nc_imm     = 1          ! initial month of forcing data time axis (1-12)
+   nm_nc_idd     = 1          ! initial day of forcing data time axis (1-31)
+   nm_nc_freq    = 1          ! divisor converting the time axis of the forcing files to days (1 = days, 24 = hours, 86400 = seconds)
+   nm_nc_tmid    = 0          ! time stamp position: 1=mid-point, 0=start of interval
+   y_perpetual   = .true.     ! use perpetual year forcing (repeat single year)
+
+   ! --- Enable/disable individual forcing fields ---
+   l_xwind       = .true.     ! use zonal wind forcing
+   l_ystre=.false.
+   l_ywind       = .true.     ! use meridional wind forcing
+   l_humi        = .true.     ! use specific humidity forcing
+   l_qsr         = .true.     ! use shortwave radiation forcing
+   l_qlw         = .true.     ! use longwave radiation forcing
+   l_tair        = .true.     ! use air temperature forcing
+   l_xstre=.false.
+   l_prec        = .true.     ! use precipitation forcing
+   l_mslp        = .true.     ! use mean sea level pressure forcing
+   l_cloud       = .false.    ! use cloud cover forcing
+   l_snow        = .true.     ! use snow precipitation forcing
+
+   ! --- Runoff configuration ---
+   runoff_data_source = 'CORE2'       ! runoff data source: 'Dai09', 'JRA55', 'CORE1', 'CORE2' or 'NONE'
+   nm_runoff_file     = '/albedo/pool/FESOM/forcing/CORE2/runoff.nc' ! CORE2 monthly climatology with runoff_climatology=.true.
+   !nm_runoff_file     = 'friver.'  ! Dai09/JRA55 with runoff_climatology=.false.: prefix, year and '.nc' are appended (friver.1958.nc).
+
+   ! --- Sea surface salinity restoring ---
+   sss_data_source  = 'CORE2'  ! SSS restoring data source: 'CORE2', 'WOA', or 'NONE'
+   nm_sss_data_file = '/albedo/pool/FESOM/forcing/CORE2/PHC2_salx.nc' ! path to SSS restoring data file, e.g. PHC2_salx.nc
+
+   ! --- Chlorophyll data for shortwave penetration ---
+   chl_data_source  = 'None'      ! chlorophyll data source: 'Sweeney' (monthly climatology) or 'None' (constant)
+                               ! requires use_sw_pene=.true. in namelist.config
+   nm_chl_data_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/Sweeney/Sweeney_2005.nc' ! chlorophyll data file (if Sweeney)
+   chl_const        = 0.1      ! constant chlorophyll concentration [mg/m³] (if chl_data_source='None')
+
+   ! --- Runoff mapper (distributes runoff over coastal area) ---
+   use_runoff_mapper  = .false.  ! enable runoff mapper (spreads runoff spatially)
+   runoff_basins_file = 'runoff_maps_regular.nc' ! runoff basin mapping file
+   runoff_radius      = 500000.  ! radius for runoff spreading [m] (if use_runoff_mapper=.true.)
 /

--- a/config/bin_4p3z2d/namelist.ice
+++ b/config/bin_4p3z2d/namelist.ice
@@ -1,31 +1,76 @@
-! Ice namelist
+! ============================================================================
+! ============== Namelist file for FESOM2 sea ice model =====================
+! ============================================================================
+! This file contains configuration for sea ice dynamics and thermodynamics:
+! - EVP (Elastic-Viscous-Plastic) rheology options
+! - Ice strength and deformation parameters
+! - Ocean-ice drag
+! - Ice thermodynamics and thickness distribution
+! - Albedo parameterizations
+! ============================================================================
+
+! ============================================================================
+! SEA ICE DYNAMICS
+! ============================================================================
 &ice_dyn
-whichEVP=0             ! 0=standart; 1=mEVP; 2=aEVP
-Pstar=30000.0          ! [N/m^2]
-ellipse=2.0
-c_pressure=20.0        ! ice concentration parameter used in ice strength computation
-delta_min=1.0e-11      ! [s^(-1)]
-evp_rheol_steps=120    ! number of EVP subcycles
-alpha_evp=250          ! constant that control numerical stability of mEVP. Adjust with resolution. 
-beta_evp=250           ! constant that control numerical stability of mEVP. Adjust with resolution.
-c_aevp=0.15            ! a tuning constant in aEVP. Adjust with resolution.
-Cd_oce_ice=0.0055      ! drag coef. oce - ice 
-ice_gamma_fct=0.5      ! smoothing parameter
-ice_diff=0.0           ! diffusion to stabilize
-theta_io=0.0           ! rotation angle
-ice_ave_steps=1        ! ice step=ice_ave_steps*oce_step
+! --- EVP Rheology Options ---
+whichEVP       = 0              ! EVP solver type:
+                                !   0 = standard EVP
+                                !   1 = modified EVP (mEVP)
+                                !   2 = adaptive EVP (aEVP)
+
+! --- Ice Strength Parameters ---
+Pstar          = 30000.0        ! ice strength parameter [N/m²] (typical: 20000-30000)
+ellipse        = 2.0            ! aspect ratio of yield curve ellipse (dimensionless)
+c_pressure     = 20.0           ! ice concentration parameter for strength computation (dimensionless)
+
+! --- Ice Deformation ---
+delta_min      = 1.0e-11        ! minimum strain rate for viscosity regularization [s⁻¹]
+
+! --- EVP Subcycling ---
+evp_rheol_steps = 120           ! number of EVP subcycles per ice time step
+
+! --- mEVP Stability Parameters (for whichEVP=1) ---
+alpha_evp      = 250            ! mEVP stability constant (adjust with resolution)
+beta_evp       = 250            ! mEVP stability constant (adjust with resolution)
+
+! --- aEVP Tuning (for whichEVP=2) ---
+c_aevp         = 0.15           ! aEVP tuning constant (adjust with resolution)
+
+! --- Ocean-Ice Coupling ---
+Cd_oce_ice     = 0.0055         ! drag coefficient between ocean and ice (dimensionless, typical: 0.0055)
+
+! --- Numerical Stabilization ---
+ice_gamma_fct  = 0.5            ! smoothing parameter for ice dynamics (0.0-1.0)
+ice_diff       = 0.0            ! artificial diffusion for numerical stability [m²/s]
+theta_io       = 0.0            ! rotation angle for ice-ocean stress [degrees]
+
+! --- Time Stepping ---
+ice_ave_steps  = 1              ! ice time step = ice_ave_steps × ocean time step
 /
 
+! ============================================================================
+! SEA ICE THERMODYNAMICS
+! ============================================================================
 &ice_therm
-Sice=4.0               ! Ice salinity 3.2--5.0 ppt.
-h0=.5                  ! Lead closing parameter [m] 
-emiss_ice=0.97         ! Emissivity of Snow/Ice,
-emiss_wat=0.97         ! Emissivity of open water
-albsn=0.81             ! Albedo: frozen snow
-albsnm=0.77            !         melting snow
-albi=0.7               !         frozen ice
-albim=0.68             !         melting ice
-albw=0.1               !         open water
-con=2.1656             ! Thermal conductivities: ice; W/m/K
-consn=0.31             !                         snow
+! --- Ice Properties ---
+Sice           = 4.0            ! bulk ice salinity [ppt] (typical range: 3.2-5.0)
+
+! --- Lead Closing Parameters ---
+h0             = 0.5            ! lead closing parameter for Northern Hemisphere [m]
+
+! --- Emissivity (Longwave Radiation) ---
+emiss_ice      = 0.97           ! emissivity of snow/ice surface (dimensionless, 0-1)
+emiss_wat      = 0.97           ! emissivity of open water (dimensionless, 0-1)
+
+! --- Albedo (Shortwave Radiation) ---
+albsn             = 0.81           ! albedo of frozen snow (dimensionless, 0-1)
+albsnm            = 0.77           ! albedo of melting snow (dimensionless, 0-1)
+albi              = 0.7            ! albedo of frozen ice (dimensionless, 0-1)
+albim             = 0.68           ! albedo of melting ice (dimensionless, 0-1)
+albw              = 0.1            ! albedo of open water (dimensionless, 0-1)
+
+! --- Thermal Conductivity ---
+con            = 2.1656         ! thermal conductivity of ice [W/m/K]
+consn          = 0.31           ! thermal conductivity of snow [W/m/K]
 /

--- a/config/bin_4p3z2d/namelist.icepack
+++ b/config/bin_4p3z2d/namelist.icepack
@@ -1,4 +1,23 @@
-&env_nml                    ! In the original release these variables are defined in the icepack.settings
+! ============================================================================
+! =============== Namelist file for FESOM2 Icepack sea ice ===================
+! ============================================================================
+! This file contains configuration for the Icepack column physics package,
+! used when FESOM2 is built with Icepack (see docs/icepack_in_fesom.rst):
+! - Tracer array sizes and switches
+! - Ice thickness distribution and thermodynamics
+! - Shortwave radiation and albedo
+! - Melt ponds
+! - Surface forcing options
+! - Ridging and ice strength
+! - Icepack output variables
+! ============================================================================
+
+! ============================================================================
+! ENVIRONMENT (ARRAY SIZES)
+! ============================================================================
+! In the original Icepack release these are set in icepack.settings.
+! ============================================================================
+&env_nml
     nicecat   = 5           ! number of ice thickness categories
     nfsdcat   = 1           ! number of floe size categories
     nicelyr   = 4           ! number of vertical layers in the ice
@@ -6,110 +25,160 @@
     ntraero   = 0           ! number of aerosol tracers (up to max_aero in ice_domain_size.F90)
     trzaero   = 0           ! number of z aerosol tracers (up to max_aero = 6)
     tralg     = 0           ! number of algal tracers (up to max_algae = 3)
-    trdoc     = 0           ! number of dissolve organic carbon (up to max_doc = 3)
-    trdic     = 0           ! number of dissolve inorganic carbon (up to max_dic = 1)
-    trdon     = 0           ! number of dissolve organic nitrogen (up to max_don = 1)
-    trfed     = 0           ! number of dissolved iron tracers (up to max_fe  = 2)
-    trfep     = 0           ! number of particulate iron tracers (up to max_fe  = 2)
+    trdoc     = 0           ! number of dissolved organic carbon tracers (up to max_doc = 3)
+    trdic     = 0           ! number of dissolved inorganic carbon tracers (up to max_dic = 1)
+    trdon     = 0           ! number of dissolved organic nitrogen tracers (up to max_don = 1)
+    trfed     = 0           ! number of dissolved iron tracers (up to max_fe = 2)
+    trfep     = 0           ! number of particulate iron tracers (up to max_fe = 2)
     nbgclyr   = 0           ! number of zbgc layers
-    trbgcz    = 0           ! set to 1 for zbgc tracers (needs TRBGCS = 0 and TRBRI = 1)
-    trzs      = 0           ! set to 1 for zsalinity tracer (needs TRBRI = 1)
+    trbgcz    = 0           ! set to 1 for zbgc tracers (needs trbgcs = 0 and trbri = 1)
+    trzs      = 0           ! set to 1 for zsalinity tracer (needs trbri = 1)
     trbri     = 0           ! set to 1 for brine height tracer
     trage     = 0           ! set to 1 for ice age tracer
     trfy      = 0           ! set to 1 for first-year ice area tracer
     trlvl     = 0           ! set to 1 for level and deformed ice tracers
     trpnd     = 0           ! set to 1 for melt pond tracers
-    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs TRBGCZ = 0)
+    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs trbgcz = 0)
     ndtd      = 1           ! dynamic time steps per thermodynamic time step
 /
 
+! ============================================================================
+! ICE THICKNESS CATEGORIES
+! ============================================================================
 &grid_nml
-    kcatbound    = 1
+    kcatbound    = 1        ! category boundary formula:
+                            !   -1 = single category (column configurations, nicecat = 1)
+                            !    0 = old formula, 1 = new formula with round numbers
+                            !    2 = WMO standard categories (nicecat = 5, 6 or 7 only)
+                            !    3 = asymptotic scheme
 /
 
+! ============================================================================
+! TRACER SWITCHES
+! ============================================================================
+! Any melt pond scheme with calc_Tsfc = .true. needs shortwave = 'dEdd'.
+! ============================================================================
 &tracer_nml
-    tr_iage      = .false.
-    tr_FY        = .false.
-    tr_lvl       = .false.
-    tr_pond_cesm = .false.
-    tr_pond_topo = .false.
-    tr_pond_lvl  = .false.
-    tr_aero      = .false.
-    tr_fsd       = .false.
+    tr_iage      = .false.  ! ice age tracer
+    tr_FY        = .false.  ! first-year ice area tracer
+    tr_lvl       = .false.  ! level (undeformed) ice area and volume tracers
+    tr_pond_cesm = .false.  ! CESM melt pond scheme
+    tr_pond_topo = .false.  ! topographic melt pond scheme
+    tr_pond_lvl  = .false.  ! level-ice melt pond scheme (needs tr_lvl, forces hs0 = 0)
+    tr_aero      = .false.  ! aerosol tracers (needs shortwave = 'dEdd')
+    tr_fsd       = .false.  ! floe size distribution
 /
 
+! ============================================================================
+! THERMODYNAMICS
+! ============================================================================
 &thermo_nml
-    kitd              = 1
-    ktherm            = 1
-    conduct           = 'bubbly'
-    a_rapid_mode      =  0.5e-3
-    Rac_rapid_mode    =    10.0
-    aspect_rapid_mode =     1.0
-    dSdt_slow_mode    = -5.0e-8
-    phi_c_slow_mode   =    0.05
-    phi_i_mushy       =    0.85
-    ksno              = 0.3
+! --- Thickness Distribution and Thermodynamics Scheme ---
+    kitd              = 1           ! ice thickness distribution: 0 = delta function, 1 = linear remapping
+    ktherm            = 1           ! thermodynamics: 1 = Bitz & Lipscomb (1999), 2 = mushy layer
+                                    ! ktherm = 1 expects tfrz_option = 'linear_salt',
+                                    ! ktherm = 2 expects tfrz_option = 'mushy' and calc_Tsfc = .true.
+    conduct           = 'bubbly'    ! ice thermal conductivity (ktherm = 1):
+                                    !   'MU71' = Maykut & Untersteiner (1971), 'bubbly' = Pringle et al. (2007)
+
+! --- Mushy Layer Brine Drainage (ktherm = 2) ---
+    a_rapid_mode      =  0.5e-3     ! brine channel diameter [m]
+    Rac_rapid_mode    =    10.0     ! critical Rayleigh number for rapid drainage
+    aspect_rapid_mode =     1.0     ! brine convection aspect ratio
+    dSdt_slow_mode    = -5.0e-8     ! slow drainage strength parameter [m/(s K)]
+    phi_c_slow_mode   =    0.05     ! critical liquid fraction for slow drainage
+    phi_i_mushy       =    0.85     ! solid fraction at the lower ice boundary
+
+! --- Snow ---
+    ksno              = 0.3         ! thermal conductivity of snow [W/(m K)]
 /
 
+! ============================================================================
+! SHORTWAVE RADIATION AND ALBEDO
+! ============================================================================
 &shortwave_nml
-    shortwave       = 'ccsm3'
-    albedo_type     = 'ccsm3'
-    albicev         = 0.78
-    albicei         = 0.36
-    albsnowv        = 0.98
-    albsnowi        = 0.70
-    albocn          = 0.1
-    ahmax           = 0.3
-    R_ice           = 0.
-    R_pnd           = 0.
-    R_snw           = 1.5
-    dT_mlt          = 1.5
-    rsnw_mlt        = 1500.
-    kalg            = 0.6
+! --- Scheme Selection ---
+    shortwave       = 'ccsm3'   ! shortwave scheme: 'ccsm3' (bulk albedo) or 'dEdd' (Delta-Eddington)
+    albedo_type     = 'ccsm3'   ! albedo parameterization with shortwave = 'ccsm3': 'ccsm3' or 'constant'
+
+! --- Bulk Albedos (shortwave = 'ccsm3') ---
+    albicev         = 0.78      ! visible albedo of thick bare ice
+    albicei         = 0.36      ! near-infrared albedo of thick bare ice
+    albsnowv        = 0.98      ! visible albedo of cold snow
+    albsnowi        = 0.70      ! near-infrared albedo of cold snow
+    albocn          = 0.1       ! ocean albedo
+    ahmax           = 0.3       ! ice thickness above which the albedo is constant [m]
+
+! --- Delta-Eddington Tuning (shortwave = 'dEdd') ---
+    R_ice           = 0.        ! sea ice albedo tuning [standard deviations]
+    R_pnd           = 0.        ! melt pond albedo tuning [standard deviations]
+    R_snw           = 1.5       ! snow grain radius tuning [standard deviations]
+    dT_mlt          = 1.5       ! temperature change that gives rsnw_mlt [deg C]
+    rsnw_mlt        = 1500.     ! maximum melting snow grain radius [micrometres]
+    kalg            = 0.6       ! absorption coefficient for algae
 /
 
+! ============================================================================
+! MELT PONDS
+! ============================================================================
 &ponds_nml
-    hp1             = 0.01
-    hs0             = 0.
-    hs1             = 0.03
-    dpscale         = 1.e-3
-    frzpnd          = 'hlid'
-    rfracmin        = 0.15
-    rfracmax        = 1.
-    pndaspect       = 0.8
+    hp1             = 0.01      ! critical parameter for pond ice thickness [m]
+    hs0             = 0.        ! snow depth for transition to bare sea ice [m]
+    hs1             = 0.03      ! snow depth for transition to pond ice [m] (tr_pond_lvl)
+    dpscale         = 1.e-3     ! time scale for flushing in permeable ice (not used with tr_pond_cesm)
+    frzpnd          = 'hlid'    ! pond refreezing: 'cesm' or 'hlid' (Stefan refreezing with a pond ice lid)
+    rfracmin        = 0.15      ! minimum fraction of melt water added to ponds
+    rfracmax        = 1.        ! maximum fraction of melt water added to ponds
+    pndaspect       = 0.8       ! aspect ratio of pond changes (depth:area)
 /
 
+! ============================================================================
+! SURFACE FORCING OPTIONS
+! ============================================================================
 &forcing_nml
-    formdrag        = .false.
-    atmbndy         = 'default'
-    calc_strair     = .true.
-    calc_Tsfc       = .true.
-    highfreq        = .false.
-    natmiter        = 5
-    ustar_min       = 0.0005
-    emissivity      = 0.95
-    fbot_xfer_type  = 'constant'
-    update_ocn_f    = .false.
-    l_mpond_fresh   = .false.
-    tfrz_option     = 'linear_salt'
-    oceanmixed_ice  = .true.
-    wave_spec_type  = 'none'
+! --- Atmosphere-Ice Exchange ---
+    formdrag        = .false.       ! calculate form drag (needs calc_strair and tr_lvl, not atmbndy = 'constant')
+    atmbndy         = 'default'     ! atmospheric boundary layer: 'default' (stability dependent) or 'constant'
+    calc_strair     = .true.        ! calculate the wind stress in Icepack instead of reading it
+    calc_Tsfc       = .true.        ! calculate the surface temperature in Icepack instead of reading it
+    highfreq        = .false.       ! high-frequency atmosphere-ice coupling (Roberts et al. 2015)
+    natmiter        = 5             ! number of iterations for the atmospheric boundary layer fluxes
+    emissivity      = 0.95          ! emissivity of snow and ice
+
+! --- Ice-Ocean Exchange ---
+    ustar_min       = 0.0005        ! minimum friction velocity for the ice-ocean heat flux [m/s]
+    fbot_xfer_type  = 'constant'    ! ice-ocean heat transfer coefficient: 'constant' or 'Cdn_ocn' (needs formdrag)
+    update_ocn_f    = .false.       ! include frazil ice fluxes in the ocean flux fields
+    l_mpond_fresh   = .false.       ! retain (topo) pond water until the ponds drain
+    tfrz_option     = 'linear_salt' ! seawater freezing temperature: 'minus1p8', 'linear_salt' or 'mushy'
+    oceanmixed_ice  = .true.        ! active ocean mixed layer calculation in Icepack
+
+! --- Waves ---
+    wave_spec_type  = 'none'        ! wave spectrum for the floe size distribution: 'none', 'constant' or 'random'
 /
 
+! ============================================================================
+! RIDGING AND ICE STRENGTH
+! ============================================================================
 &dynamics_nml
-    kstrength       = 1
-    krdg_partic     = 1
-    krdg_redist     = 1
-    mu_rdg          = 3
-    Cf              = 17.
-    P_star          = 27000.
-    C_star          = 20.
+    kstrength       = 1         ! ice strength formulation: 0 = Hibler (1979), 1 = Rothrock (1975)
+    krdg_partic     = 1         ! ridging participation function: 0 = Thorndike et al. (1975), 1 = exponential
+    krdg_redist     = 1         ! ridging redistribution function: 0 = Hibler (1980), 1 = exponential
+    mu_rdg          = 3         ! e-folding scale of ridged ice [m^0.5] (krdg_redist = 1)
+    Cf              = 17.       ! ratio of ridging work to change in potential energy (kstrength = 1)
+    P_star          = 27000.    ! ice strength parameter [N/m²] (kstrength = 0)
+    C_star          = 20.       ! ice strength decay constant [dimensionless] (kstrength = 0)
 /
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!!!!!!!!!                Icepack output namelist                    !!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
+! ============================================================================
+! ICEPACK OUTPUT VARIABLES
+! ============================================================================
+! Format: 'variable_id', frequency, unit, precision
+!   frequency  = output frequency (integer)
+!   unit       = 'y' (yearly), 'm' (monthly), 'd' (daily), 'h' (hourly), 's' (steps)
+!   precision  = 4 (single precision) or 8 (double precision)
+! Remove the leading '!' to enable a variable.
+! ============================================================================
 &nml_list_icepack
 io_list_icepack =  'aicen     ',1, 'm', 4, ! Sea ice concentration
                    'vicen     ',1, 'm', 4, ! Volume per unit area of ice

--- a/config/bin_4p3z2d/namelist.icepack.cesm.ponds
+++ b/config/bin_4p3z2d/namelist.icepack.cesm.ponds
@@ -1,4 +1,23 @@
-&env_nml                    ! In the original release these variables are defined in the icepack.settings
+! ============================================================================
+! =============== Namelist file for FESOM2 Icepack sea ice ===================
+! ============================================================================
+! This file contains configuration for the Icepack column physics package,
+! used when FESOM2 is built with Icepack (see docs/icepack_in_fesom.rst):
+! - Tracer array sizes and switches
+! - Ice thickness distribution and thermodynamics
+! - Shortwave radiation and albedo
+! - Melt ponds
+! - Surface forcing options
+! - Ridging and ice strength
+! - Icepack output variables
+! ============================================================================
+
+! ============================================================================
+! ENVIRONMENT (ARRAY SIZES)
+! ============================================================================
+! In the original Icepack release these are set in icepack.settings.
+! ============================================================================
+&env_nml
     nicecat   = 5           ! number of ice thickness categories
     nfsdcat   = 1           ! number of floe size categories
     nicelyr   = 4           ! number of vertical layers in the ice
@@ -6,108 +25,156 @@
     ntraero   = 0           ! number of aerosol tracers (up to max_aero in ice_domain_size.F90)
     trzaero   = 0           ! number of z aerosol tracers (up to max_aero = 6)
     tralg     = 0           ! number of algal tracers (up to max_algae = 3)
-    trdoc     = 0           ! number of dissolve organic carbon (up to max_doc = 3)
-    trdic     = 0           ! number of dissolve inorganic carbon (up to max_dic = 1)
-    trdon     = 0           ! number of dissolve organic nitrogen (up to max_don = 1)
-    trfed     = 0           ! number of dissolved iron tracers (up to max_fe  = 2)
-    trfep     = 0           ! number of particulate iron tracers (up to max_fe  = 2)
+    trdoc     = 0           ! number of dissolved organic carbon tracers (up to max_doc = 3)
+    trdic     = 0           ! number of dissolved inorganic carbon tracers (up to max_dic = 1)
+    trdon     = 0           ! number of dissolved organic nitrogen tracers (up to max_don = 1)
+    trfed     = 0           ! number of dissolved iron tracers (up to max_fe = 2)
+    trfep     = 0           ! number of particulate iron tracers (up to max_fe = 2)
     nbgclyr   = 0           ! number of zbgc layers
-    trbgcz    = 0           ! set to 1 for zbgc tracers (needs TRBGCS = 0 and TRBRI = 1)
-    trzs      = 0           ! set to 1 for zsalinity tracer (needs TRBRI = 1)
+    trbgcz    = 0           ! set to 1 for zbgc tracers (needs trbgcs = 0 and trbri = 1)
+    trzs      = 0           ! set to 1 for zsalinity tracer (needs trbri = 1)
     trbri     = 0           ! set to 1 for brine height tracer
     trage     = 0           ! set to 1 for ice age tracer
     trfy      = 0           ! set to 1 for first-year ice area tracer
     trlvl     = 0           ! set to 1 for level and deformed ice tracers
     trpnd     = 1           ! set to 1 for melt pond tracers
-    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs TRBGCZ = 0)
+    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs trbgcz = 0)
     ndtd      = 1           ! dynamic time steps per thermodynamic time step
 /
 
+! ============================================================================
+! ICE THICKNESS CATEGORIES
+! ============================================================================
 &grid_nml
-    kcatbound    = 1
+    kcatbound    = 1        ! category boundary formula:
+                            !   -1 = single category (column configurations, nicecat = 1)
+                            !    0 = old formula, 1 = new formula with round numbers
+                            !    2 = WMO standard categories (nicecat = 5, 6 or 7 only)
+                            !    3 = asymptotic scheme
 /
 
+! ============================================================================
+! TRACER SWITCHES
+! ============================================================================
+! Any melt pond scheme with calc_Tsfc = .true. needs shortwave = 'dEdd'.
+! ============================================================================
 &tracer_nml
-    tr_iage      = .false.
-    tr_FY        = .false.
-    tr_lvl       = .false.
-    tr_pond_cesm = .true.
-    tr_pond_topo = .false.
-    tr_pond_lvl  = .false.
-    tr_aero      = .false.
-    tr_fsd       = .false.
+    tr_iage      = .false.  ! ice age tracer
+    tr_FY        = .false.  ! first-year ice area tracer
+    tr_lvl       = .false.  ! level (undeformed) ice area and volume tracers
+    tr_pond_cesm = .true.   ! CESM melt pond scheme
+    tr_pond_topo = .false.  ! topographic melt pond scheme
+    tr_pond_lvl  = .false.  ! level-ice melt pond scheme (needs tr_lvl, forces hs0 = 0)
+    tr_aero      = .false.  ! aerosol tracers (needs shortwave = 'dEdd')
+    tr_fsd       = .false.  ! floe size distribution
 /
 
+! ============================================================================
+! THERMODYNAMICS
+! ============================================================================
 &thermo_nml
-    kitd              = 1
-    ktherm            = 1
-    conduct           = 'bubbly'
-    a_rapid_mode      =  0.5e-3
-    Rac_rapid_mode    =    10.0
-    aspect_rapid_mode =     1.0
-    dSdt_slow_mode    = -5.0e-8
-    phi_c_slow_mode   =    0.05
-    phi_i_mushy       =    0.85
+! --- Thickness Distribution and Thermodynamics Scheme ---
+    kitd              = 1           ! ice thickness distribution: 0 = delta function, 1 = linear remapping
+    ktherm            = 1           ! thermodynamics: 1 = Bitz & Lipscomb (1999), 2 = mushy layer
+                                    ! ktherm = 1 expects tfrz_option = 'linear_salt',
+                                    ! ktherm = 2 expects tfrz_option = 'mushy' and calc_Tsfc = .true.
+    conduct           = 'bubbly'    ! ice thermal conductivity (ktherm = 1):
+                                    !   'MU71' = Maykut & Untersteiner (1971), 'bubbly' = Pringle et al. (2007)
+
+! --- Mushy Layer Brine Drainage (ktherm = 2) ---
+    a_rapid_mode      =  0.5e-3     ! brine channel diameter [m]
+    Rac_rapid_mode    =    10.0     ! critical Rayleigh number for rapid drainage
+    aspect_rapid_mode =     1.0     ! brine convection aspect ratio
+    dSdt_slow_mode    = -5.0e-8     ! slow drainage strength parameter [m/(s K)]
+    phi_c_slow_mode   =    0.05     ! critical liquid fraction for slow drainage
+    phi_i_mushy       =    0.85     ! solid fraction at the lower ice boundary
 /
 
+! ============================================================================
+! SHORTWAVE RADIATION AND ALBEDO
+! ============================================================================
 &shortwave_nml
-    shortwave       = 'dEdd'
-    albedo_type     = 'ccsm3'
-    albicev         = 0.78
-    albicei         = 0.36
-    albsnowv        = 0.98
-    albsnowi        = 0.70
-    ahmax           = 0.3
-    R_ice           = 0.
-    R_pnd           = 0.
-    R_snw           = 1.5
-    dT_mlt          = 1.5
-    rsnw_mlt        = 1500.
-    kalg            = 0.6
+! --- Scheme Selection ---
+    shortwave       = 'dEdd'    ! shortwave scheme: 'ccsm3' (bulk albedo) or 'dEdd' (Delta-Eddington)
+    albedo_type     = 'ccsm3'   ! albedo parameterization with shortwave = 'ccsm3': 'ccsm3' or 'constant'
+
+! --- Bulk Albedos (shortwave = 'ccsm3') ---
+    albicev         = 0.78      ! visible albedo of thick bare ice
+    albicei         = 0.36      ! near-infrared albedo of thick bare ice
+    albsnowv        = 0.98      ! visible albedo of cold snow
+    albsnowi        = 0.70      ! near-infrared albedo of cold snow
+    ahmax           = 0.3       ! ice thickness above which the albedo is constant [m]
+
+! --- Delta-Eddington Tuning (shortwave = 'dEdd') ---
+    R_ice           = 0.        ! sea ice albedo tuning [standard deviations]
+    R_pnd           = 0.        ! melt pond albedo tuning [standard deviations]
+    R_snw           = 1.5       ! snow grain radius tuning [standard deviations]
+    dT_mlt          = 1.5       ! temperature change that gives rsnw_mlt [deg C]
+    rsnw_mlt        = 1500.     ! maximum melting snow grain radius [micrometres]
+    kalg            = 0.6       ! absorption coefficient for algae
 /
 
+! ============================================================================
+! MELT PONDS
+! ============================================================================
 &ponds_nml
-    hp1             = 0.01
-    hs0             = 0.
-    hs1             = 0.03
-    dpscale         = 1.e-3
-    frzpnd          = 'hlid'
-    rfracmin        = 0.15
-    rfracmax        = 1.
-    pndaspect       = 0.8
+    hp1             = 0.01      ! critical parameter for pond ice thickness [m]
+    hs0             = 0.        ! snow depth for transition to bare sea ice [m]
+    hs1             = 0.03      ! snow depth for transition to pond ice [m] (tr_pond_lvl)
+    dpscale         = 1.e-3     ! time scale for flushing in permeable ice (not used with tr_pond_cesm)
+    frzpnd          = 'hlid'    ! pond refreezing: 'cesm' or 'hlid' (Stefan refreezing with a pond ice lid)
+    rfracmin        = 0.15      ! minimum fraction of melt water added to ponds
+    rfracmax        = 1.        ! maximum fraction of melt water added to ponds
+    pndaspect       = 0.8       ! aspect ratio of pond changes (depth:area)
 /
 
+! ============================================================================
+! SURFACE FORCING OPTIONS
+! ============================================================================
 &forcing_nml
-    formdrag        = .false.
-    atmbndy         = 'default'
-    calc_strair     = .true.
-    calc_Tsfc       = .true.
-    highfreq        = .false.
-    natmiter        = 5
-    ustar_min       = 0.0005
-    emissivity      = 0.95
-    fbot_xfer_type  = 'constant'
-    update_ocn_f    = .false.
-    l_mpond_fresh   = .false.
-    tfrz_option     = 'linear_salt'
-    oceanmixed_ice  = .true.
-    wave_spec_type  = 'none'
+! --- Atmosphere-Ice Exchange ---
+    formdrag        = .false.       ! calculate form drag (needs calc_strair and tr_lvl, not atmbndy = 'constant')
+    atmbndy         = 'default'     ! atmospheric boundary layer: 'default' (stability dependent) or 'constant'
+    calc_strair     = .true.        ! calculate the wind stress in Icepack instead of reading it
+    calc_Tsfc       = .true.        ! calculate the surface temperature in Icepack instead of reading it
+    highfreq        = .false.       ! high-frequency atmosphere-ice coupling (Roberts et al. 2015)
+    natmiter        = 5             ! number of iterations for the atmospheric boundary layer fluxes
+    emissivity      = 0.95          ! emissivity of snow and ice
+
+! --- Ice-Ocean Exchange ---
+    ustar_min       = 0.0005        ! minimum friction velocity for the ice-ocean heat flux [m/s]
+    fbot_xfer_type  = 'constant'    ! ice-ocean heat transfer coefficient: 'constant' or 'Cdn_ocn' (needs formdrag)
+    update_ocn_f    = .false.       ! include frazil ice fluxes in the ocean flux fields
+    l_mpond_fresh   = .false.       ! retain (topo) pond water until the ponds drain
+    tfrz_option     = 'linear_salt' ! seawater freezing temperature: 'minus1p8', 'linear_salt' or 'mushy'
+    oceanmixed_ice  = .true.        ! active ocean mixed layer calculation in Icepack
+
+! --- Waves ---
+    wave_spec_type  = 'none'        ! wave spectrum for the floe size distribution: 'none', 'constant' or 'random'
 /
 
+! ============================================================================
+! RIDGING AND ICE STRENGTH
+! ============================================================================
 &dynamics_nml
-    kstrength       = 1
-    krdg_partic     = 1
-    krdg_redist     = 1
-    mu_rdg          = 3
-    Cf              = 17.
-    P_star          = 27000.
-    C_star          = 20.
+    kstrength       = 1         ! ice strength formulation: 0 = Hibler (1979), 1 = Rothrock (1975)
+    krdg_partic     = 1         ! ridging participation function: 0 = Thorndike et al. (1975), 1 = exponential
+    krdg_redist     = 1         ! ridging redistribution function: 0 = Hibler (1980), 1 = exponential
+    mu_rdg          = 3         ! e-folding scale of ridged ice [m^0.5] (krdg_redist = 1)
+    Cf              = 17.       ! ratio of ridging work to change in potential energy (kstrength = 1)
+    P_star          = 27000.    ! ice strength parameter [N/m²] (kstrength = 0)
+    C_star          = 20.       ! ice strength decay constant [dimensionless] (kstrength = 0)
 /
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!!!!!!!!!                Icepack output namelist                    !!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
+! ============================================================================
+! ICEPACK OUTPUT VARIABLES
+! ============================================================================
+! Format: 'variable_id', frequency, unit, precision
+!   frequency  = output frequency (integer)
+!   unit       = 'y' (yearly), 'm' (monthly), 'd' (daily), 'h' (hourly), 's' (steps)
+!   precision  = 4 (single precision) or 8 (double precision)
+! Remove the leading '!' to enable a variable.
+! ============================================================================
 &nml_list_icepack
 io_list_icepack =  'aicen     ',1, 'm', 4, ! Sea ice concentration
                    'vicen     ',1, 'm', 4, ! Volume per unit area of ice

--- a/config/bin_4p3z2d/namelist.io
+++ b/config/bin_4p3z2d/namelist.io
@@ -1,26 +1,55 @@
+! ============================================================================
+! ============ Namelist file for FESOM2 output configuration =================
+! ============================================================================
+! This file contains configuration for model output and diagnostics:
+! - Diagnostic flags for optional output fields
+! - General output settings (compression, rotation)
+! - Output variable list with frequency and precision
+! - Complete catalog of all available output fields
+!
+! See the output catalog at the end of this file for all possible variables.
+! Some outputs require specific flags in &diag_list or other namelists.
+! ============================================================================
+
+! ============================================================================
+! DIAGNOSTIC FLAGS
+! ============================================================================
+! Enable/disable optional diagnostic computations and outputs.
+! Setting these to .true. enables additional output fields (see catalog below).
+! ============================================================================
 &diag_list
-ldiag_solver     =.false.
-lcurt_stress_surf=.false.
-ldiag_curl_vel3  =.false.
-ldiag_Ri         =.false.
-ldiag_turbflux   =.false.
-ldiag_salt3D     =.false.
-ldiag_dMOC       =.false.
-ldiag_DVD        =.false.
-ldiag_forc       =.false.
-ldiag_extflds    =.false.
+ldiag_solver      = .false.  ! enables solver diagnostics (convergence, iterations)
+lcurt_stress_surf = .false.  ! enables 'curl_surf' output (vorticity of surface stress)
+ldiag_curl_vel3   = .false.  ! enables 'curl_u' output (relative vorticity from 3D velocity)
+ldiag_Ri          = .false.  ! enables Richardson number diagnostics ('shear', 'Ri')
+ldiag_turbflux    = .false.  ! enables turbulent flux diagnostics ('KvdTdz', 'KvdSdz')
+ldiag_salt3D      = .false.  ! enables 3D salinity diagnostics
+ldiag_dMOC        = .false.  ! enables 'dMOC' output (density MOC diagnostics)
+ldiag_DVD         = .false.  ! enables 'DVD' output (Discrete Variance Decay diagnostics)
+ldiag_forc        = .false.  ! enables 'FORC' output (comprehensive forcing diagnostics)
+ldiag_extflds     = .false.  ! enables extended field diagnostics
 /
 
+! ============================================================================
+! GENERAL OUTPUT SETTINGS
+! ============================================================================
 &nml_general
-io_listsize    =150 !number of streams to allocate. shallbe large or equal to the number of streams in &nml_list
-vec_autorotate =.false.
+io_listsize       = 150      ! total number of streams to allocate. Shall be larger or equal to the number of streams in &nml_list (max. 150)
+vec_autorotate    = .false.  ! unrotate vector fields (velocities, winds) before writing to output files
 /
 
-! for sea ice related variables use_ice should be true, otherewise there will be no output
-! for 'curl_surf' to work lcurt_stress_surf must be .true. otherwise no output
-! for 'fer_C', 'bolus_u', 'bolus_v', 'bolus_w', 'fer_K' to work Fer_GM must be .true. otherwise no output
-! 'otracers' - all other tracers if applicable
-! for 'dMOC' to work ldiag_dMOC must be .true. otherwise no output
+! ============================================================================
+! OUTPUT VARIABLE LIST
+! ============================================================================
+! Format: 'variable_id', frequency, unit, precision
+!   frequency  = output frequency (integer)
+!   unit       = 'y' (yearly), 'm' (monthly), 'd' (daily), 'h' (hourly), 's' (steps)
+!   precision  = 4 (single precision) or 8 (double precision)
+!   Note: in a single-precision build (WP=4) a field requesting precision 8 is
+!   still honoured (written as NF_DOUBLE; means accumulated in real64), but its
+!   samples are single-precision-sourced. FESOM prints one summary line at
+!   startup listing such fields.
+! ============================================================================
 &nml_list
 io_list =  'sst       ',1, 'm', 4,
            'sss       ',1, 'm', 4,
@@ -136,3 +165,277 @@ io_list =  'sst       ',1, 'm', 4,
            'TCphot_phaeo',1, 'm', 4,                                                                 
            'TSi_assimDia',1, 'm', 4,                
 /
+
+! ============================================================================
+! COMPLETE CATALOG OF ALL POSSIBLE OUTPUT FIELDS
+! ============================================================================
+! Below is a comprehensive list of all valid io_list IDs available in FESOM2.
+! To enable any field, copy the line to the &nml_list section above.
+! NOTE: Some fields require specific flags to be enabled (see comments).
+! ============================================================================
+
+! --- 2D OCEAN SURFACE FIELDS ---
+! 'sst       ',1, 'm', 4,  ! sea surface temperature [C]
+! 'sss       ',1, 'm', 4,  ! sea surface salinity [psu]
+! 'ssh       ',1, 'm', 4,  ! sea surface elevation [m]
+! 'vve_5     ',1, 'm', 4,  ! vertical velocity at 5th level [m/s]
+! 't_star    ',1, 'm', 4,  ! air temperature [C]
+! 'qsr       ',1, 'm', 4,  ! solar radiation [W/s^2]
+
+! --- 3D OCEAN FIELDS ---
+! 'temp      ',1, 'm', 4,  ! temperature [C]
+! 'salt      ',1, 'm', 8,  ! salinity [psu]
+! 'sigma0    ',1, 'm', 4,  ! potential density [kg/m3]
+! 'u         ',1, 'm', 4,  ! zonal velocity [m/s]
+! 'v         ',1, 'm', 4,  ! meridional velocity [m/s]
+! 'unod      ',1, 'm', 4,  ! zonal velocity at nodes [m/s]
+! 'vnod      ',1, 'm', 4,  ! meridional velocity at nodes [m/s]
+! 'w         ',1, 'm', 4,  ! vertical velocity [m/s]
+! 'otracers  ',1, 'm', 4,  ! all other tracers if applicable
+! 'age       ',1, 'm', 4,  ! water age tracer [year] (require use_age_tracer=.true.)
+
+! --- 2D SSH DIAGNOSTIC VARIABLES ---
+! 'ssh_rhs   ',1, 'm', 4,  ! ssh rhs [m/s]
+! 'ssh_rhs_old',1, 'm', 4, ! ssh rhs old [m/s]
+! 'd_eta     ',1, 'm', 4,  ! dssh from solver [m]
+! 'hbar      ',1, 'm', 4,  ! ssh n+0.5 tstep [m]
+! 'hbar_old  ',1, 'm', 4,  ! ssh n-0.5 tstep [m]
+! 'dhe       ',1, 'm', 4,  ! dhbar @ elem [m]
+
+! --- SEA ICE FIELDS (require use_ice=.true.) ---
+! 'uice      ',1, 'm', 4,  ! ice velocity x [m/s]
+! 'vice      ',1, 'm', 4,  ! ice velocity y [m/s]
+! 'a_ice     ',1, 'm', 4,  ! ice concentration [%]
+! 'm_ice     ',1, 'm', 4,  ! ice height per unit area [m]
+! 'thdgrice  ',1, 'm', 4,  ! thermodynamic growth rate ice [m/s]
+! 'thdgrarea ',1, 'm', 4,  ! thermodynamic growth rate ice concentration [frac/s]
+! 'dyngrarea' ,1, 'm', 4,  ! dynamic growth rate ice concentration [frac/s]
+! 'dyngrice  ',1, 'm', 4,  ! dynamic growth rate ice [m/s]
+! 'thdgrsn   ',1, 'm', 4,  ! thermodynamic growth rate snow [m/s]
+! 'dyngrsnw  ',1, 'm', 4,  ! dynamic growth rate snow [m/s] 
+! 'flice     ',1, 'm', 4,  ! flooding growth rate ice [m/s]
+! 'm_snow    ',1, 'm', 4,  ! snow height per unit area [m]
+! 'h_ice     ',1, 'm', 4,  ! ice thickness over ice-covered fraction [m]
+! 'h_snow    ',1, 'm', 4,  ! snow thickness over ice-covered fraction [m]
+! 'fw_ice    ',1, 'm', 4,  ! fresh water flux from ice ['m/s']
+! 'fw_snw    ',1, 'm', 4,  ! fresh water flux from snow ['m/s']
+
+! --- SEA ICE DEBUG VARIABLES (require use_ice=.true.) ---
+! 'strength_ice',1, 'm', 4,  ! ice strength [?]
+! 'inv_areamass',1, 'm', 4,  ! inv_areamass [?]
+! 'rhs_a     ',1, 'm', 4,  ! rhs_a [?]
+! 'rhs_m     ',1, 'm', 4,  ! rhs_m [?]
+! 'sgm11     ',1, 'm', 4,  ! sgm11 [?]
+! 'sgm12     ',1, 'm', 4,  ! sgm12 [?]
+! 'sgm22     ',1, 'm', 4,  ! sgm22 [?]
+! 'eps11     ',1, 'm', 4,  ! eps11 [?]
+! 'eps12     ',1, 'm', 4,  ! eps12 [?]
+! 'eps22     ',1, 'm', 4,  ! eps22 [?]
+! 'u_rhs_ice ',1, 'm', 4,  ! u_rhs_ice [?]
+! 'v_rhs_ice ',1, 'm', 4,  ! v_rhs_ice [?]
+! 'metric_fac',1, 'm', 4,  ! metric_fac [?]
+! 'elevat_ice',1, 'm', 4,  ! elevat_ice [?]
+! 'uwice     ',1, 'm', 4,  ! uwice [?]
+! 'vwice     ',1, 'm', 4,  ! vwice [?]
+! 'twice     ',1, 'm', 4,  ! twice [?]
+! 'swice     ',1, 'm', 4,  ! swice [?]
+
+! --- MIXED LAYER DEPTH ---
+! 'MLD1      ',1, 'm', 4,  ! Mixed Layer Depth [m] Large et al. 1997, bvfreq(nz, node) > db_max
+! 'MLD2      ',1, 'm', 4,  ! Mixed Layer Depth [m] Levitus treshold, rhopot(nz)-rhopot(1) > 0.125_WP kg/m
+! 'MLD3      ',1, 'm', 4,  ! Mixed Layer Depth [m] Griffies 2016 , rhopot(nz)-rhopot(1) > 0.03_WP kg/m
+
+! --- HEAT CONTENT (require ldiag_destine=.true.) ---
+! 'hc300m    ',1, 'm', 4,  ! Vertically integrated heat content upper 300m [J m**-2]
+! 'hc700m    ',1, 'm', 4,  ! Vertically integrated heat content upper 700m [J m**-2]
+! 'hc        ',1, 'm', 4,  ! Vertically integrated heat content total column [J m**-2]
+
+! --- WATER ISOTOPES IN SEA ICE (require lwiso=.true.) ---
+! 'h2o18_ice ',1, 'm', 4,  ! h2o18 concentration in sea ice [kmol/m**3]
+! 'hDo16_ice ',1, 'm', 4,  ! hDo16 concentration in sea ice [kmol/m**3]
+! 'h2o16_ice ',1, 'm', 4,  ! h2o16 concentration in sea ice [kmol/m**3]
+
+! --- FRESHWATER FLUX (require use_landice_water=.true.) ---
+! 'landice   ',1, 'm', 4,  ! freshwater flux [m/s]
+
+! --- SURFACE FORCING ---
+! 'tx_sur    ',1, 'm', 4,  ! zonal wind str. to ocean [N/m2]
+! 'ty_sur    ',1, 'm', 4,  ! meridional wind str. to ocean [N/m2]
+! 'curl_surf ',1, 'm', 4,  ! vorticity of the surface stress [none] (require lcurt_stress_surf=.true.)
+! 'fh        ',1, 'm', 4,  ! heat flux [W/m2]
+! 'fw        ',1, 'm', 4,  ! fresh water flux [m/s]
+! 'atmice_x  ',1, 'm', 4,  ! stress atmice x [N/m2]
+! 'atmice_y  ',1, 'm', 4,  ! stress atmice y [N/m2]
+! 'atmoce_x  ',1, 'm', 4,  ! stress atmoce x [N/m2]
+! 'atmoce_y  ',1, 'm', 4,  ! stress atmoce y [N/m2]
+! 'iceoce_x  ',1, 'm', 4,  ! stress iceoce x [N/m2]
+! 'iceoce_y  ',1, 'm', 4,  ! stress iceoce y [N/m2]
+! 'alpha     ',1, 'm', 4,  ! thermal expansion [none]
+! 'beta      ',1, 'm', 4,  ! saline contraction [none]
+! 'dens_flux ',1, 'm', 4,  ! density flux [kg/(m3*s)]
+! 'runoff    ',1, 'm', 4,  ! river runoff [m/s]
+! 'evap      ',1, 'm', 4,  ! evaporation [m/s]
+! 'prec      ',1, 'm', 4,  ! precipitation rain [m/s]
+! 'snow      ',1, 'm', 4,  ! precipitation snow [m/s]
+! 'tair      ',1, 'm', 4,  ! surface air temperature [°C]
+! 'shum      ',1, 'm', 4,  ! specific humidity []
+! 'swr       ',1, 'm', 4,  ! short wave radiation [W/m^2]
+! 'lwr       ',1, 'm', 4,  ! long wave radiation [W/m^2]
+! 'uwind     ',1, 'm', 4,  ! 10m zonal surface wind velocity [m/s]
+! 'vwind     ',1, 'm', 4,  ! 10m merid. surface wind velocity [m/s]
+! 'virtsalt  ',1, 'm', 4,  ! virtual salt flux [m/s*psu]
+! 'relaxsalt ',1, 'm', 4,  ! relaxation salt flux [m/s*psu]
+! 'realsalt  ',1, 'm', 4,  ! real salt flux from sea ice [m/s*psu]
+
+! --- KPP VERTICAL MIXING (require mix_scheme_nmb==1,17,3,37) ---
+! 'kpp_obldepth',1, 'm', 4, ! KPP ocean boundary layer depth [m]
+! 'kpp_sbuoyflx',1, 'm', 4, ! surface buoyancy flux [m2/s3]
+
+! --- RECOM 2D BIOGEOCHEMISTRY (require use_REcoM=.true. and __recom) ---
+! 'dpCO2s    ',1, 'm', 4,  ! Difference of oceanic pCO2 minus atmospheric pCO2 [uatm]
+! 'pCO2s     ',1, 'm', 4,  ! Partial pressure of oceanic CO2 [uatm]
+! 'CO2f      ',1, 'm', 4,  ! CO2-flux into the surface water [mmolC/m2/d]
+! 'O2f       ',1, 'm', 4,  ! O2-flux into the surface water [mmolO/m2/d]
+! 'Hp        ',1, 'm', 4,  ! Mean of H-plus ions in the surface water [mol/kg]
+! 'aFe       ',1, 'm', 4,  ! Atmospheric iron input [umolFe/m2/s]
+! 'aN        ',1, 'm', 4,  ! Atmospheric DIN input [mmolN/m2/s]
+! 'benN      ',1, 'm', 4,  ! Benthos Nitrogen [mmol]
+! 'benC      ',1, 'm', 4,  ! Benthos Carbon [mmol]
+! 'benSi     ',1, 'm', 4,  ! Benthos silicon [mmol]
+! 'benCalc   ',1, 'm', 4,  ! Benthos calcite [mmol]
+! 'NPPn      ',1, 'm', 4,  ! Mean NPP nanophytoplankton [mmolC/m2/d]
+! 'NPPd      ',1, 'm', 4,  ! Mean NPP diatoms [mmolC/m2/d]
+! 'GPPn      ',1, 'm', 4,  ! Mean GPP nanophytoplankton [mmolC/m2/d]
+! 'GPPd      ',1, 'm', 4,  ! Mean GPP diatoms [mmolC/m2/d]
+! 'NNAn      ',1, 'm', 4,  ! Net N-assimilation nanophytoplankton [mmolN/m2/d]
+! 'NNAd      ',1, 'm', 4,  ! Net N-assimilation diatoms [mmolN/m2/d]
+! 'Chldegn   ',1, 'm', 4,  ! Chlorophyll degradation nanophytoplankton [1/d]
+! 'Chldegd   ',1, 'm', 4,  ! Chlorophyll degradation diatoms [1/d]
+! 'NPPc      ',1, 'm', 4,  ! Mean NPP coccolithophores [mmolC/(m2*d)]
+! 'GPPc      ',1, 'm', 4,  ! Mean GPP coccolithophores [mmolC/m2/d]
+! 'NNAc      ',1, 'm', 4,  ! Net N-assimilation coccolithophores [mmolN/(m2*d)]
+! 'Chldegc   ',1, 'm', 4,  ! Chlorophyll degradation coccolithophores [1/d]
+
+! --- RECOM 3D BIOGEOCHEMISTRY (require use_REcoM=.true. and __recom) ---
+! 'PAR       ',1, 'm', 4,  ! PAR [W/m2]
+! 'respmeso  ',1, 'm', 4,  ! Respiration rate of mesozooplankton [mmolC/m2/d]
+! 'respmacro ',1, 'm', 4,  ! Respiration rate of macrozooplankton [mmolC/m2/d]
+! 'respmicro ',1, 'm', 4,  ! Respiration rate of microzooplankton [mmolC/m2/d]
+! 'calcdiss  ',1, 'm', 4,  ! Calcite dissolution [mmolC/m2/d]
+! 'calcif    ',1, 'm', 4,  ! Calcification [mmolC/m2/d]
+! 'aggn      ',1, 'm', 4,  ! Aggregation of small phytoplankton [mmolC/m2/d]
+! 'aggd      ',1, 'm', 4,  ! Aggregation of diatoms [mmolC/m2/d]
+! 'aggc      ',1, 'm', 4,  ! Aggregation of coccolithophores [mmolC/m2/d]
+! 'docexn    ',1, 'm', 4,  ! DOC excretion by small phytoplankton [mmolC/m2/d]
+! 'docexd    ',1, 'm', 4,  ! DOC excretion by diatoms [mmolC/m2/d]
+! 'docexc    ',1, 'm', 4,  ! DOC excretion by coccolithophores [mmolC/m2/d]
+! 'respn     ',1, 'm', 4,  ! Respiration by small phytoplankton [mmolC/m2/d]
+! 'respd     ',1, 'm', 4,  ! Respiration by diatoms [mmolC/m2/d]
+! 'respc     ',1, 'm', 4,  ! Respiration by coccolithophores [mmolC/(m2*d)]
+! 'NPPn3D    ',1, 'm', 4,  ! Net primary production of small phytoplankton [mmolC/(m3*d)]
+! 'NPPd3D    ',1, 'm', 4,  ! Net primary production of diatoms [mmolC/(m3*d)]
+! 'NPPc3D    ',1, 'm', 4,  ! Net primary production of coccolithophores [mmolC/(m3*d)]
+
+! --- WATER ISOTOPES IN OCEAN (require lwiso=.true.) ---
+! 'h2o18     ',1, 'm', 4,  ! h2o18 concentration [kmol/m**3]
+! 'hDo16     ',1, 'm', 4,  ! hDo16 concentration [kmol/m**3]
+! 'h2o16     ',1, 'm', 4,  ! h2o16 concentration [kmol/m**3]
+
+! --- NEUTRAL SLOPES ---
+! 'slopetap_x',1, 'm', 4,  ! neutral slope tapered X [none]
+! 'slopetap_y',1, 'm', 4,  ! neutral slope tapered Y [none]
+! 'slopetap_z',1, 'm', 4,  ! neutral slope tapered Z [none]
+! 'slope_x   ',1, 'm', 4,  ! neutral slope X [none]
+! 'slope_y   ',1, 'm', 4,  ! neutral slope Y [none]
+! 'slope_z   ',1, 'm', 4,  ! neutral slope Z [none]
+
+! --- MIXING AND DYNAMICS ---
+! 'N2        ',1, 'm', 4,  ! brunt väisälä [1/s2]
+! 'Kv        ',1, 'm', 4,  ! vertical diffusivity Kv [m2/s]
+! 'Av        ',1, 'm', 4,  ! vertical viscosity Av [m2/s]
+
+! --- VISCOSITY TENDENCIES (require dynamics%opt_visc==8) ---
+! 'u_dis_tend',1, 'm', 4,  ! horizontal velocity viscosity tendency [m/s]
+! 'v_dis_tend',1, 'm', 4,  ! meridional velocity viscosity tendency [m/s]
+! 'u_back_tend',1, 'm', 4, ! horizontal velocity backscatter tendency [m2/s2]
+! 'v_back_tend',1, 'm', 4, ! meridional velocity backscatter tendency [m2/s2]
+! 'u_total_tend',1, 'm', 4,! horizontal velocity total viscosity tendency [m/s]
+! 'v_total_tend',1, 'm', 4,! meridional velocity total viscosity tendency [m/s]
+
+! --- FERRARI/GM PARAMETERISATION (require Fer_GM=.true.) ---
+! 'bolus_u   ',1, 'm', 4,  ! GM bolus velocity U [m/s]
+! 'bolus_v   ',1, 'm', 4,  ! GM bolus velocity V [m/s]
+! 'bolus_w   ',1, 'm', 4,  ! GM bolus velocity W [m/s]
+! 'fer_K     ',1, 'm', 4,  ! GM, stirring diff. [m2/s]
+! 'fer_scal  ',1, 'm', 4,  ! GM surface scaling []
+! 'fer_C     ',1, 'm', 4,  ! GM, depth independent speed [m/s]
+! 'cfl_z     ',1, 'm', 4,  ! vertical CFL criteria [?]
+
+! --- DENSITY MOC DIAGNOSTICS (require ldiag_dMOC=.true.) ---
+! 'dMOC      ',1, 'm', 4,  ! fluxes for density MOC (multiple variables)
+
+! --- PRESSURE GRADIENT FORCE ---
+! 'pgf_x     ',1, 'm', 4,  ! zonal pressure gradient force [m/s^2]
+! 'pgf_y     ',1, 'm', 4,  ! meridional pressure gradient force [m/s^2]
+
+! --- ALE LAYER THICKNESS ---
+! 'hnode     ',1, 'm', 4,  ! vertice layer thickness [m]
+! 'hnode_new ',1, 'm', 4,  ! hnode_new [m]
+! 'helem     ',1, 'm', 4,  ! elemental layer thickness [m]
+
+! --- OIFS/IFS INTERFACE (require __oifs or __ifsinterface) ---
+! 'alb       ',1, 'm', 4,  ! ice albedo [none]
+! 'ist       ',1, 'm', 4,  ! ice surface temperature [K]
+! 'qsi       ',1, 'm', 4,  ! ice heat flux [W/m^2]
+! 'qso       ',1, 'm', 4,  ! oce heat flux [W/m^2]
+! 'enthalpy  ',1, 'm', 4,  ! enthalpy of fusion [W/m^2]
+! 'qcon      ',1, 'm', 4,  ! conductive heat flux [W/m^2]
+! 'qres      ',1, 'm', 4,  ! residual heat flux [W/m^2]
+! 'runoff_liquid',1, 'm', 4, ! liquid water runoff [m/s]
+! 'runoff_solid',1, 'm', 4, ! solid water runoff [m/s]
+
+! --- ICEBERG OUTPUTS (require use_icebergs=.true.) ---
+! 'icb       ',1, 'm', 4,  ! iceberg outputs (multiple variables)
+
+! --- TKE MIXING DIAGNOSTICS (require mix_scheme_nmb==5 or 56) ---
+! 'TKE       ',1, 'm', 4,  ! TKE diagnostics (multiple variables)
+
+! --- IDEMIX MIXING DIAGNOSTICS (require mod(mix_scheme_nmb,10)==6) ---
+! 'IDEMIX    ',1, 'm', 4,  ! IDEMIX diagnostics (multiple variables)
+
+! --- TIDAL MIXING DIAGNOSTICS (require mod(mix_scheme_nmb,10)==7) ---
+! 'TIDAL     ',1, 'm', 4,  ! TIDAL diagnostics (multiple variables)
+
+! --- FORCING DIAGNOSTICS (require ldiag_forc=.true.) ---
+! 'FORC      ',1, 'm', 4,  ! forcing diagnostics (multiple variables)
+
+! --- DISCRETE VARIANCE DECAY (require ldiag_DVD=.true.) ---
+! 'DVD       ',1, 'm', 4,  ! DVD diagnostics (multiple variables)
+
+! --- SPLIT-EXPLICIT SUBCYCLING (require dynamics%use_ssh_se_subcycl=.true.) ---
+! 'SPLIT-EXPL',1, 'm', 4,  ! split-explicit diagnostics (multiple variables)
+
+! --- SQUARED VELOCITIES (require ldiag_uvw_sqr=.true.) ---
+! 'UVW_SQR   ',1, 'm', 4,  ! squared velocities (u2, v2, w2)
+
+! --- TRACER GRADIENTS (require ldiag_trgrd_xyz=.true.) ---
+! 'TRGRD_XYZ ',1, 'm', 4,  ! horizontal and vertical tracer gradients
+
+! --- CMOR DIAGNOSTICS FOR CMIP6/CMIP7 (require ldiag_cmor=.true.) ---
+! 'tos       ',1, 'm', 8,  ! sea surface temperature [degC] (CMOR standard)
+! 'sos       ',1, 'm', 8,  ! sea surface salinity [psu] (CMOR standard)
+! 'pbo       ',1, 'm', 8,  ! sea water pressure at sea floor [Pa]
+! 'opottemptend',1, 'm', 8,! ocean potential temperature tendency [W/m^2]
+! 'volo      ',1, 'm', 8,  ! ocean volume [m^3] (global scalar)
+! 'soga      ',1, 'm', 8,  ! global mean sea water salinity [psu] (global scalar)
+! 'thetaoga  ',1, 'm', 8,  ! global mean sea water potential temperature [degC] (global scalar)
+! 'siarean   ',1, 'm', 8,  ! sea ice area Northern hemisphere [10^12 m^2] (global scalar)
+! 'siareas   ',1, 'm', 8,  ! sea ice area Southern hemisphere [10^12 m^2] (global scalar)
+! 'siextentn ',1, 'm', 8,  ! sea ice extent Northern hemisphere [10^12 m^2] (global scalar)
+! 'siextents ',1, 'm', 8,  ! sea ice extent Southern hemisphere [10^12 m^2] (global scalar)
+! 'sivoln    ',1, 'm', 8,  ! sea ice volume Northern hemisphere [10^9 m^3] (global scalar)
+! 'sivols    ',1, 'm', 8,  ! sea ice volume Southern hemisphere [10^9 m^3] (global scalar)
+
+! ============================================================================
+! END OF CATALOG
+! ============================================================================

--- a/config/bin_4p3z2d/namelist.oce
+++ b/config/bin_4p3z2d/namelist.oce
@@ -1,26 +1,105 @@
-! The namelist file for the finite-volume ocean model
+! ============================================================================
+! ============ Namelist file for FESOM2 ocean dynamics ======================
+! ============================================================================
+! This file contains configuration for ocean dynamics and parameterizations:
+! - Bottom drag and vertical viscosity
+! - Gent-McWilliams (GM) eddy parameterization
+! - Redi isopycnal diffusion
+! - Vertical mixing schemes (KPP, PP)
+! - Convection parameters
+! - Tidal forcing
+! ============================================================================
 
+! ============================================================================
+! OCEAN DYNAMICS AND PARAMETERIZATIONS
+! ============================================================================
 &oce_dyn
-C_d=0.0025             ! Bottom drag, nondimensional
-A_ver= 1.e-4	       ! Vertical viscosity, m^2/s
-scale_area=5.8e9       ! Visc. and diffus. are for an element with scale_area
-SPP=.false.                 ! Salt Plume Parameterization
-Fer_GM=.true.               ! to swith on/off GM after Ferrari et al. 2010
-K_GM_max     = 2000.0       ! max. GM thickness diffusivity (m2/s)
-K_GM_min     = 2.0          ! max. GM thickness diffusivity (m2/s)
-K_GM_bvref   = 2            ! def of bvref in ferreira scaling 0=srf,1=bot mld,2=mean over mld,3=weighted mean over mld
-K_GM_rampmax = -1.0         ! Resol >K_GM_rampmax[km] GM on
-K_GM_rampmin = -1.0         ! Resol <K_GM_rampmin[km] GM off, in between linear scaled down
-K_GM_resscalorder = 1
+! --- Basic ocean dynamics parameters ---
+C_d                = 0.0025  ! bottom drag coefficient (dimensionless, typical: 0.0025)
+A_ver              = 1.e-4   ! background vertical viscosity [m²/s]
+scale_area         = 5.8e9   ! reference element area for viscosity/diffusivity scaling [m²]
 
-scaling_Ferreira   =.false.  ! GM vertical scaling after Ferreira et al.(2005) (as also implemented by Qiang in FESOM 1.4)
-scaling_Rossby     =.false. ! GM is smoothly switched off according to Rossby radius (from 1. in coarse areas to 0. where resolution reaches 2 points/Rossby radius)
-scaling_resolution =.true.  ! GM is spatially scaled with resolution; A value of K_GM corresponds then to a resolution of 100km
-scaling_FESOM14    =.false.  ! special treatment of GM in the NH (as also implemented by Qiang in FESOM 1.4; it is zero within the boundary layer)
+! --- Salt Plume Parameterization ---
+SPP                = .false. ! enable Salt Plume Parameterization (for brine rejection under sea ice)
 
-Redi  =.true.
-visc_sh_limit=5.0e-3       ! for KPP, max visc due to shear instability
-mix_scheme='KPP'           ! vertical mixing scheme: KPP, PP 
-Ricr   = 0.3               ! critical bulk Richardson Number
-concv  = 1.6               ! constant for pure convection (eqn. 23) (Large 1.5-1.6; MOM default 1.8)
+! --- Gent-McWilliams (GM) Eddy Parameterization ---
+Fer_GM             = .true.  ! to swith on/off GM after Ferrari et al. 2010
+K_GM_max           = 2000.0  ! max. GM thickness diffusivity (m2/s)
+K_GM_min           = 2.0     ! min. GM thickness diffusivity (m2/s)
+K_GM_bvref         = 2       ! def of bvref in ferreira scaling 0=srf,1=bot mld,2=mean over mld,3=weighted mean over mld
+K_GM_rampmax       = -1.0    ! Resol >K_GM_rampmax[km] GM on
+K_GM_rampmin       = -1.0    ! Resol <K_GM_rampmin[km] GM off, in between linear scaled down
+K_GM_resscalorder  = 1       ! scaling order 1: resol scaling, 2: area scaling 
+
+! --- GM Scaling Options ---
+scaling_Ferreira   = .false. ! enable GM vertical scaling (Ferreira et al. 2005, as in FESOM 1.4)
+scaling_Rossby     = .false. ! scale GM with Rossby radius (1.0 in coarse regions, 0.0 at 2 points/Rossby radius)
+scaling_resolution = .true.  ! scale GM with horizontal resolution (K_GM corresponds to 100km resolution)
+scaling_FESOM14    = .false. ! use FESOM 1.4 GM treatment in Northern Hemisphere (zero within boundary layer)
+
+! --- Redi Isopycnal Diffusion ---
+Redi               = .true.  ! enable Redi isopycnal diffusion
+
+! --- Vertical Mixing Scheme ---
+visc_sh_limit      = 5.0e-3  ! maximum viscosity due to shear instability [m²/s] (for KPP)
+mix_scheme         = 'KPP'   ! vertical mixing scheme: 'KPP' (K-Profile Parameterization), 'PP' (Pacanowski-Philander), or 'cvmix_TKE' (Turbulent Kinetic Energy). For complete list of available shemes look at the oce_setup_step.F90. 
+
+! --- Convection Parameters ---
+Ricr               = 0.3     ! critical bulk Richardson number (for convection onset)
+concv              = 1.6     ! constant for pure convection (eq. 23 in Large et al.)
+                             ! typical values: Large 1.5-1.6, MOM default 1.8
 /
+
+! ===================================================================
+! Initial condition perturbation settings
+! ===================================================================
+! This section controls random perturbation of initial temperature
+! and salinity fields. Useful for ensemble modeling and uncertainty
+! quantification.
+!
+! lperturb       : Enable/disable perturbation (.true./.false.)
+! perturb_mode   : When to apply perturbations
+!                  'initial_only' - Apply only during initial runs (not restarts)
+!                  'first_step'   - Apply during first time step (initial or restart)
+! perturb_method : Type of random distribution
+!                  'uniform'   - Uniform distribution between [min_val, max_val]
+!                  'gaussian'  - Gaussian distribution with mean=min_val, std_dev=max_val
+! perturb_seed   : Random seed for reproducible perturbations
+!                  -1 = use system time (different each run)
+!                  >0 = use specified seed (reproducible)
+! temp_perturb   : Temperature perturbation parameters
+!                  For uniform: [min_val, max_val] in Kelvin
+!                  For gaussian: [mean(=0.0), std_dev] in Kelvin
+! salt_perturb   : Salinity perturbation parameters
+!                  For uniform: [min_val, max_val] in PSU
+!                  For gaussian: [mean(=0.0), std_dev] in PSU
+!
+! Example for ensemble forecasting with Gaussian perturbations:
+!&oce_perturb
+!lperturb       = .true.
+!perturb_mode   = 'first_step'
+!perturb_method = 'gaussian'
+!perturb_seed   = 12345
+!temp_perturb   = 0.0, 1.D-13
+!salt_perturb   = 0.0, 2.D-13
+!/
+!
+! Example for sensitivity study with uniform perturbations:
+!&oce_perturb
+!lperturb       = .true.
+!perturb_mode   = 'initial_only'
+!perturb_method = 'uniform'
+!perturb_seed   = -1
+!temp_perturb   = -1.D-12, 1.D-12
+!salt_perturb   = -2.D-12, 2.D-12
+!/
+
+! Default behavior (no perturbations):
+!&oce_perturb
+!lperturb       = .false.
+!perturb_mode   = 'initial_only'
+!perturb_method = 'uniform'
+!perturb_seed   = -1
+!temp_perturb   = 0.0, 0.0
+!salt_perturb   = 0.0, 0.0
+!/

--- a/config/bin_4p3z2d/namelist.recom
+++ b/config/bin_4p3z2d/namelist.recom
@@ -1,92 +1,150 @@
-! This is the namelist file for recom
+! ============================================================================
+! ============ Namelist file for FESOM2 REcoM biogeochemistry ================
+! ============================================================================
+! This file contains configuration for the REcoM biogeochemical model:
+! - Surface boundary condition input files
+! - Model switches, tracer counts and sinking
+! - Phytoplankton, zooplankton and detritus parameters
+! - Carbonate chemistry, iron, calcite and benthos
+! - Ballasting and carbon isotopes
+!
+! Phytoplankton parameters come in sets: no suffix = small phytoplankton,
+! _d = diatoms, _c = coccolithophores, _p = Phaeocystis (where present).
+! Zooplankton: first = mesozooplankton, second (suffix 2) = macrozooplankton,
+! third (suffix 3) = microzooplankton.
+! ============================================================================
 
+! ============================================================================
+! SURFACE BOUNDARY CONDITION FILES
+! ============================================================================
+! Relative names of the dust, aeolian nitrogen and CO2 files are taken from
+! ClimateDataPath; the river and erosion files are used as given.
+! ============================================================================
 &nam_rsbc
-fe_data_source        ='Albani'
-nm_fe_data_file       ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/DustClimMonthlyAlbani.nc'
-nm_aen_data_file      ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/AeolianNitrogenDep.nc'
-nm_river_data_file    ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/RiverineInput.nc'
-nm_erosion_data_file  ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/ErosionInput.nc'
-nm_co2_data_file      ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/MonthlyAtmCO2_gcb2023.nc'
+fe_data_source        = 'Albani'    ! 'Albani' reads nm_fe_data_file; any other value switches the Albani dust input off
+nm_fe_data_file       = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/DustClimMonthlyAlbani.nc'
+                                    ! monthly dust deposition climatology (Albani)
+nm_aen_data_file      = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/AeolianNitrogenDep.nc'
+                                    ! aeolian nitrogen deposition (useAeolianN)
+nm_river_data_file    = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/RiverineInput.nc'
+                                    ! riverine nutrient input (useRivers)
+nm_erosion_data_file  = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/ErosionInput.nc'
+                                    ! input from erosion (useErosion)
+nm_co2_data_file      = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/MonthlyAtmCO2_gcb2023.nc'
+                                    ! atmospheric CO2 time series, read when constant_CO2 = .false.
 /
 
+! ============================================================================
+! TRACER SET
+! ============================================================================
+! bgc_num in &pavariables is checked against these switches at startup.
+! ============================================================================
 &parecomsetup
-enable_3zoo2det = .true.
-enable_coccos = .true.
+enable_3zoo2det       = .true.      ! three zooplankton groups and two detritus classes instead of one each
+enable_coccos         = .true.      ! coccolithophore and Phaeocystis tracers
 /
 
+! ============================================================================
+! MODEL SWITCHES, TRACER COUNTS AND SINKING
+! ============================================================================
 &pavariables
-use_REcoM             =.true.
-REcoM_restart         =.true.
+! --- Main Switches ---
+use_REcoM             = .true.      ! switch REcoM on
+REcoM_restart         = .true.      ! read the REcoM tracers from the restart (false = initialize from climatology)
+recom_debug           = .false.     ! extra REcoM debug output
+Diags                 = .true.      ! compute REcoM diagnostics
 
-bgc_num               = 37 !33 !30 !22 !33 !24 !38
-diags3d_num           = 31          ! Number of diagnostic 3d tracers to be saved
-bgc_base_num          = 22          ! standard tracers
-VDet                  = 20.d0       ! Sinking velocity, constant through the water column and positive downwards
-VDet_zoo2             = 200.d0      ! Sinking velocity, constant through the water column
-VPhy                  = 0.d0        !!! If the number of sinking velocities are different from 3, code needs to be changed !!!
-VDia                  = 0.d0
-VCocco	       	      = 0.d0      
+! --- Tracer Counts ---
+bgc_num               = 37          ! number of REcoM tracers, checked at startup against enable_3zoo2det and enable_coccos
+diags3d_num           = 31          ! number of 3D diagnostic tracers to be saved
+bgc_base_num          = 22          ! number of standard (base) BGC tracers
+benthos_num           = 4           ! number of benthic BGC tracers: 8 with ciso = .true., otherwise 4
+Nmocsy                = 1           ! length of the vector passed to mocsy (always 1 for REcoM)
+biostep               = 1           ! number of biology steps per ocean time step
+
+! --- Sinking ---
+VDet                  = 20.d0       ! sinking velocity of small detritus [m/day], positive downwards
+VDet_zoo2             = 200.d0      ! sinking velocity of large detritus [m/day]
+VPhy                  = 0.d0        ! sinking velocity of small phytoplankton [m/day]
+VDia                  = 0.d0        ! sinking velocity of diatoms [m/day]
+VCocco                = 0.d0        ! sinking velocity of coccolithophores [m/day]
 VPhaeo                = 0.d0 
-allow_var_sinking     = .true.   
-biostep               = 1           ! Number of times biology should be stepped forward for each time step		 
-REcoM_Geider_limiter  = .false.     ! Decides what routine should be used to calculate limiters in sms
-REcoM_Grazing_Variable_Preference = .true. ! Decides if grazing should have preference for phyN or DiaN 
-Grazing_detritus      = .true.
+allow_var_sinking     = .true.      ! detritus sinking speed increases with depth (Vdet_a in &pasinking)
+
+! --- Process Options ---
+REcoM_Geider_limiter  = .false.     ! selects the routine that calculates the limiters in the sources-minus-sinks
+REcoM_Grazing_Variable_Preference = .true. ! grazing preferences weighted by prey abundance
+Grazing_detritus      = .true.      ! zooplankton also graze on detritus
 !TIRPS                 = .false.    ! Temperature induced reduction in photosynthesis for phytoplankton
-het_resp_noredfield   = .true.    ! Decides respiratation of copepod group
-diatom_mucus          = .true.    ! Decides nutrient limitation effect on aggregation
-O2dep_remin           = .true.    ! O2remin Add option for O2 dependency of organic matter remineralization
-use_ballasting        = .true.    ! BALL
-use_density_scaling   = .true.    ! BALL
-use_viscosity_scaling = .true.    ! BALL
-OmegaC_diss           = .true.    ! DISS Use OmegaC from Mocsy to compute calcite dissolution (after Aumont et al. 2015 and Gehlen et al. 2007)
-CO2lim                = .true.    ! CO2 dependence of growth and calcification
-Diags                 = .true.
-constant_CO2          = .true.
-UseFeDust             = .true.      ! Turns dust input of iron off when set to.false.
-UseDustClim           = .true.
-UseDustClimAlbani     = .true.     ! Use Albani dustclim field (If it is false Mahowald will be used)
-use_photodamage       = .true.      ! use Alvarez et al (2018) for chlorophyll degradation
-HetRespFlux_plus      = .true.      !MB More stable computation of zooplankton respiration fluxes adding a small number to HetN
+het_resp_noredfield   = .true.      ! respiration formulation of the first zooplankton (copepods)
+diatom_mucus          = .true.      ! nutrient limitation enhances diatom aggregation
+O2dep_remin           = .true.      ! oxygen-dependent remineralization of organic matter (k_o2_remin)
+use_photodamage       = .true.      ! light-dependent chlorophyll degradation after Alvarez et al. (2018)
+HetRespFlux_plus      = .true.      ! more stable zooplankton respiration flux (not used by the current code)
+CO2lim                = .true.      ! CO2 dependence of growth and calcification (&paco2lim)
+OmegaC_diss           = .true.      ! calcite dissolution from the mocsy saturation state OmegaC
+                                    ! (Aumont et al. 2015, Gehlen et al. 2007); set calc_diss_guts = 0 when .false.
+
+! --- Ballasting ---
+use_ballasting        = .true.      ! mineral ballasting of detritus sinking (&paballasting)
+use_density_scaling   = .true.      ! scale sinking with seawater density (ballasting)
+use_viscosity_scaling = .true.      ! scale sinking with seawater viscosity (ballasting)
+
+! --- External Sources ---
+UseFeDust             = .true.      ! iron input from dust (not used by the current code, see fe_data_source)
+UseDustClim           = .true.      ! dust deposition climatology (not used by the current code)
+UseDustClimAlbani     = .true.      ! Albani dust climatology, otherwise Mahowald (not used by the current code)
+useRivers             = .false.     ! riverine nutrient input (nm_river_data_file)
+useRivFe              = .false.     ! riverine iron source
+useErosion            = .false.     ! input from erosion (nm_erosion_data_file)
+NitrogenSS            = .false.     ! external nitrogen sources and sinks (riverine, aeolian and denitrification)
+useAeolianN           = .false.     ! aeolian nitrogen deposition (nm_aen_data_file)
 REcoMDataPath         = '/albedo/work/projects/MarESys/ogurses/input/mesh_CORE2_finaltopo_mean/'
-restore_alkalinity    = .true.
-useRivers             = .false.
-useRivFe              = .false.      ! When set to true, riverine Fe source is activated
-useErosion            = .false.
-NitrogenSS            = .false.     ! When set to true, external sources and sinks of nitrogen are activated (Riverine, aeolian and denitrification)
-useAeolianN           = .false.      ! When set to true, aeolian nitrogen deposition is activated
-firstyearoffesomcycle = 1958        ! The first year of the actual physical forcing (e.g. JRA-55) used
-lastyearoffesomcycle  = 2024        ! Last year of the actual physical forcing used
-numofCO2cycles        = 1           ! Number of cycles of the forcing planned 
-currentCO2cycle       = 1           ! Which CO2 cycle we are currently running
-DIC_PI                = .true.
-Nmocsy                = 1           ! Length of the vector that is passed to mocsy (always one for recom)
-recom_debug           =.false.
-ciso                  =.false.     ! Main switch to enable/disable carbon isotopes (13|14C)
-benthos_num           = 4          ! number of benthic BGC tracers -> 8 if (ciso == .true.) otherwise -> 4
-use_MEDUSA            = .false.      ! Main switch for the sediment model MEDUSA
-sedflx_num            = 0           ! if 0: no file from MEDUSA is read but default sediment
-bottflx_num           = 4           ! if ciso&ciso_14: =8; if .not.ciso_14: =6; no ciso: =4
-use_atbox             = .false.
-add_loopback          = .false.     ! add loopback fluxes through rivers to the surface
-lb_tscale             = 1.0         ! /year: fraction of loopback fluxes yearly added to the surface
+                                    ! REcoM input directory (not used by the current code)
+
+! --- Carbon Chemistry and Atmospheric CO2 ---
+constant_CO2          = .true.      ! use CO2_for_spinup instead of the time series in nm_co2_data_file
+DIC_PI                = .true.      ! initialize DIC with the preindustrial GLODAP field
+restore_alkalinity    = .true.      ! restore surface alkalinity (surf_relax_Alk)
+use_atbox             = .false.     ! atmospheric box model for CO2
+firstyearoffesomcycle = 1958        ! first year of the physical forcing used (e.g. JRA55)
+lastyearoffesomcycle  = 2024        ! last year of the physical forcing used
+numofCO2cycles        = 1           ! number of forcing cycles planned
+currentCO2cycle       = 1           ! forcing cycle currently running
+
+! --- Carbon Isotopes and Sediment ---
+ciso                  = .false.     ! main switch for carbon isotopes (13C, 14C), see &paciso
+use_MEDUSA            = .false.     ! main switch for the sediment model MEDUSA
+sedflx_num            = 0           ! number of sediment fluxes read from MEDUSA (0 = none, default sediment)
+bottflx_num           = 4           ! number of bottom fluxes: 8 with ciso and ciso_14, 6 with ciso only, 4 without ciso
+add_loopback          = .false.     ! return loopback fluxes to the surface through rivers
+lb_tscale             = 1.0         ! fraction of the loopback fluxes added to the surface per year [1/year]
 /
 
+! ============================================================================
+! DEPTH-DEPENDENT SINKING
+! ============================================================================
 &pasinking
-Vdet_a                = 0.0288      ! [1/day]
-Vcalc                 = 0.0144      ! [1/day]
+Vdet_a                = 0.0288      ! increase of detritus sinking speed with depth [1/day] (allow_var_sinking)
+Vcalc                 = 0.0144      ! depth dependence of calcite dissolution [1/day]
 /
 
+! ============================================================================
+! INITIALIZATION
+! ============================================================================
 &painitialization_N
-cPhyN                 = 0.2d0
-cHetN                 = 0.2d0
-cZoo2N                = 0.2d0
+cPhyN                 = 0.2d0       ! initial small phytoplankton N (not used by the current code)
+cHetN                 = 0.2d0       ! initial first zooplankton N (not used by the current code)
+cZoo2N                = 0.2d0       ! initial second zooplankton N (not used by the current code)
 /
 
+! ============================================================================
+! TEMPERATURE DEPENDENCE
+! ============================================================================
 &paArrhenius
-recom_Tref            = 288.15d0    ! [K]
-C2K                   = 273.15d0    ! Conversion from degrees C to K
-Ae                    = 4500.d0     ! [K] Slope of the linear part of the Arrhenius function
+recom_Tref            = 288.15d0    ! reference temperature of the Arrhenius function [K]
+C2K                   = 273.15d0    ! conversion from degrees C to K
+Ae                    = 4500.d0     ! slope of the linear part of the Arrhenius function [K]
 Tmax_phaeo            = 16d0        ! [°C] For Blanchard temp fxn: maximum temperature
 Topt_phaeo            = 6.7982d0    ! [°C] For Blanchard temp fxn: optimum temperature
 uopt_phaeo            = 0.6903d0    ! [1/day] For Blanchard temp fxn: optimum growth rate
@@ -99,8 +157,9 @@ ord_cocco             = -0.2310d0   ! coccolitho ordonnée
 expon_cocco           = 0.0327d0    ! coccolitho exponent
 ord_phaeo             = -0.2310d0   ! phaeocystis ordonnée
 expon_phaeo           = 0.0327d0    ! phaeocystis exponent
-reminSi               = 0.02d0
-k_o2_remin            = 15.d0       ! NEW O2remin mmol m-3; Table 1 in Cram 2018 cites DeVries & Weber 2017 for a range of 0-30 mmol m-3
+reminSi               = 0.02d0      ! lower bound of the silica remineralization rate [1/day]
+k_o2_remin            = 15.d0       ! half-saturation O2 for O2-dependent remineralization [mmol/m3] (O2dep_remin)
+                                    ! Cram et al. (2018), Table 1, cite 0-30 mmol/m3 (DeVries & Weber 2017)
 !d1_d                  = 0.001d0     ! 42°C version
 !d2_d                  = 0.2d0       ! 42°C version
 !d1_phy                = 0.0016d0      ! 42°C version
@@ -109,296 +168,387 @@ k_o2_remin            = 15.d0       ! NEW O2remin mmol m-3; Table 1 in Cram 2018
 !d2_cocco              = 0.17d0      ! 42°C version
 /
 
+! ============================================================================
+! LIMITATION FUNCTIONS
+! ============================================================================
 &palimiter_function
-NMinSlope             = 50.d0 
-SiMinSlope            = 1000.d0
-NCmin                 = 0.04d0 !0.05d0
-NCmin_d               = 0.04d0 !0.05d0
-NCmin_c		      = 0.04d0      ! NEW
+! --- Limitation Function Slopes ---
+NMinSlope             = 50.d0       ! steepness of the nitrogen limitation function at the minimum quota
+SiMinSlope            = 1000.d0     ! steepness of the silicon limitation function at the minimum quota
+
+! --- Minimum Quotas ---
+NCmin                 = 0.04d0      ! minimum N:C quota, small phytoplankton [mmol N/mmol C]
+NCmin_d               = 0.04d0      ! minimum N:C quota, diatoms [mmol N/mmol C]
+NCmin_c               = 0.04d0      ! minimum N:C quota, coccolithophores [mmol N/mmol C]
 NCmin_p               = 0.04d0      ! NEW for Phaeocystis
-SiCmin                = 0.04d0
-k_Fe                  = 0.04d0
-k_Fe_d                = 0.12d0
-k_Fe_c		      = 0.09d0      ! NEW
+SiCmin                = 0.04d0      ! minimum Si:C quota, diatoms [mmol Si/mmol C]
+
+! --- Nutrient Half-Saturation ---
+k_Fe                  = 0.04d0      ! half-saturation constant for iron uptake, small phytoplankton [µmol Fe/m3]
+k_Fe_d                = 0.12d0      ! half-saturation constant for iron uptake, diatoms [µmol Fe/m3]
+k_Fe_c                = 0.09d0      ! half-saturation constant for iron uptake, coccolithophores [µmol Fe/m3]
 k_Fe_p                = 0.09d0      ! NEW for Phaeocystis (to be tuned)
-k_si                  = 4.d0
-P_cm                  = 3.0d0       ! [1/day]            Rate of C-specific photosynthesis 
-P_cm_d                = 3.5d0
-P_cm_c		      = 2.8d0	    ! NEW
+k_si                  = 4.d0        ! half-saturation constant for silicate uptake, diatoms [mmol Si/m3]
+
+! --- Maximum Photosynthesis ---
+P_cm                  = 3.0d0       ! maximum C-specific photosynthesis rate, small phytoplankton [1/day]
+P_cm_d                = 3.5d0       ! maximum C-specific photosynthesis rate, diatoms [1/day]
+P_cm_c                = 2.8d0       ! maximum C-specific photosynthesis rate, coccolithophores [1/day] (not used by the current code)
 P_cm_p                = 0.75d0       ! NEW for Phaeocystis (to be tuned)
 /
 
+! ============================================================================
+! LIGHT
+! ============================================================================
 &palight_calculations
-k_w                   = 0.04d0      ! [1/m]              Light attenuation coefficient
-a_chl                 = 0.03d0      ! [1/m * 1/(mg Chl)] Chlorophyll specific attenuation coefficients
+k_w                   = 0.04d0      ! light attenuation coefficient of water [1/m]
+a_chl                 = 0.03d0      ! chlorophyll-specific attenuation coefficient [1/m * 1/(mg Chl)]
 /
 
+! ============================================================================
+! PHOTOSYNTHESIS
+! ============================================================================
 &paphotosynthesis
-alfa                  = 0.15d0 !0.14d0	    ! [(mmol C*m2)/(mg Chl*W*day)]  ! NEW value for Phaeocystis
-alfa_d                = 0.19d0      ! An initial slope of the P-I curve
-alfa_c		      = 0.10d0      ! NEW
+alfa                  = 0.15d0      ! initial slope of the P-I curve, small phytoplankton [(mmol C m²)/(mg Chl W day)]
+alfa_d                = 0.19d0      ! initial slope of the P-I curve, diatoms [(mmol C m²)/(mg Chl W day)]
+alfa_c                = 0.10d0      ! initial slope of the P-I curve, coccolithophores [(mmol C m²)/(mg Chl W day)]
 alfa_p                = 0.17d0      ! NEW for Phaeocystis (to be tuned)
-parFrac               = 0.43d0
+parFrac               = 0.43d0      ! photosynthetically active fraction of the shortwave radiation
 /
 
+! ============================================================================
+! NUTRIENT ASSIMILATION
+! ============================================================================
 &paassimilation
-V_cm_fact             = 0.7d0       ! scaling factor for temperature dependent maximum of C-specific N-uptake
-V_cm_fact_d           = 0.7d0  
-V_cm_fact_c	      = 0.7d0       ! NEW
+! --- Nitrogen Uptake ---
+V_cm_fact             = 0.7d0       ! scaling of the temperature-dependent maximum C-specific N uptake, small phytoplankton
+V_cm_fact_d           = 0.7d0       ! scaling of the temperature-dependent maximum C-specific N uptake, diatoms
+V_cm_fact_c           = 0.7d0       ! scaling of the temperature-dependent maximum C-specific N uptake, coccolithophores
 V_cm_fact_p           = 0.7d0       ! NEW for Phaeocystis
-NMaxSlope             = 1000.d0     ! Max slope for limiting function
-SiMaxSlope            = 1000.d0
-NCmax                 = 0.2d0       ! [mmol N/mmol C] Maximum cell quota of nitrogen (N:C)
-NCmax_d               = 0.2d0
-NCmax_c		      = 0.15d0      ! NEW
+NMaxSlope             = 1000.d0     ! steepness of the limitation function at the maximum N quota
+NCmax                 = 0.2d0       ! maximum N:C quota, small phytoplankton [mmol N/mmol C]
+NCmax_d               = 0.2d0       ! maximum N:C quota, diatoms [mmol N/mmol C]
+NCmax_c               = 0.15d0      ! maximum N:C quota, coccolithophores [mmol N/mmol C]
 NCmax_p               = 0.15d0       ! NEW for Phaeocystis (to be tuned)
-SiCmax                = 0.8d0
-NCuptakeRatio         = 0.2d0       ! [mmol N/mmol C] Maximum uptake ratio of N:C
-NCUptakeRatio_d       = 0.2d0
-NCUptakeRatio_c	      = 0.2d0       ! NEW
+NCuptakeRatio         = 0.2d0       ! maximum N:C uptake ratio, small phytoplankton [mmol N/mmol C]
+NCUptakeRatio_d       = 0.2d0       ! maximum N:C uptake ratio, diatoms [mmol N/mmol C]
+NCUptakeRatio_c       = 0.2d0       ! maximum N:C uptake ratio, coccolithophores [mmol N/mmol C]
 NCUptakeRatio_p       = 0.2d0       ! NEW for Phaeocystis
-SiCUptakeRatio        = 0.2d0
-k_din                 = 0.55d0      ! [mmol N/m3] Half-saturation constant for nitrate uptake
-k_din_d               = 1.0d0
-k_din_c		      = 0.9d0       ! NEW
+k_din                 = 0.55d0      ! half-saturation constant for nitrate uptake, small phytoplankton [mmol N/m3]
+k_din_d               = 1.0d0       ! half-saturation constant for nitrate uptake, diatoms [mmol N/m3]
+k_din_c               = 0.9d0       ! half-saturation constant for nitrate uptake, coccolithophores [mmol N/m3]
 k_din_p               = 0.7d0      ! NEW for Phaeocystis (to be tuned)
-Chl2N_max             = 3.15d0      ! [mg CHL/mmol N] Maximum CHL a : N ratio = 0.3 gCHL gN^-1
-Chl2N_max_d           = 4.2d0
-Chl2N_max_c	      = 3.5d0       ! NEW
+
+! --- Silicon Uptake (Diatoms) ---
+SiMaxSlope            = 1000.d0     ! steepness of the limitation function at the maximum Si quota
+SiCmax                = 0.8d0       ! maximum Si:C quota [mmol Si/mmol C]
+SiCUptakeRatio        = 0.2d0       ! maximum Si:C uptake ratio [mmol Si/mmol C]
+
+! --- Chlorophyll ---
+Chl2N_max             = 3.15d0      ! maximum Chl:N ratio, small phytoplankton [mg Chl/mmol N]
+Chl2N_max_d           = 4.2d0       ! maximum Chl:N ratio, diatoms [mg Chl/mmol N]
+Chl2N_max_c           = 3.5d0       ! maximum Chl:N ratio, coccolithophores [mg Chl/mmol N]
 Chl2N_max_p           = 2.6d0       ! NEW for Phaeocystis
-res_phy               = 0.01d0      ! [1/day] Maintenance respiration rate constant
-res_phy_d             = 0.01d0
-res_phy_c	      = 0.01d0      ! NEW
+
+! --- Respiration ---
+res_phy               = 0.01d0      ! maintenance respiration rate, small phytoplankton [1/day]
+res_phy_d             = 0.01d0      ! maintenance respiration rate, diatoms [1/day]
+res_phy_c             = 0.01d0      ! maintenance respiration rate, coccolithophores [1/day]
 res_phy_p             = 0.01d0      ! NEW for phaeocystis
-biosynth              = 2.33d0      ! [mmol C/mmol N] Cost of biosynthesis
-biosynthSi            = 0.d0
+biosynth              = 2.33d0      ! cost of biosynthesis [mmol C/mmol N]
+biosynthSi            = 0.d0        ! cost of silica biosynthesis [mmol C/mmol Si]
 /
 
+! ============================================================================
+! IRON CHEMISTRY
+! ============================================================================
 &pairon_chem
-totalligand           = 1.d0        ! [mumol/m3] order 1. Total free ligand
-ligandStabConst       = 100.d0      ! [m3/mumol] order 100. Ligand-free iron stability constant
+totalligand           = 1.d0        ! total free ligand [µmol/m3] (order 1)
+ligandStabConst       = 100.d0      ! ligand-free iron stability constant [m3/µmol] (order 100)
 /
 
+! ============================================================================
+! FIRST ZOOPLANKTON (MESOZOOPLANKTON)
+! ============================================================================
 &pazooplankton
-graz_max              = 0.31d0       ! [mmol N/(m3 * day)] Maximum grazing loss parameter 
-epsilonr              = 0.09d0      ! [(mmol N)2 /m6] Half saturation constant for grazing loss 
-res_het               = 0.028d0      ! [1/day] Respiration by heterotrophs and mortality (loss to detritus)
-Redfield              = 6.625       ! [mmol C/mmol N] Redfield ratio of C:N = 106:16
-loss_het              = 0.04d0      ! [1/day] Temperature dependent N degradation of extracellular organic N (EON)
-pzDia                 = 1.0d0 !0.5d0       ! Maximum diatom preference ! NEW value for Phaeocystis
-sDiaNsq               = 0.d0
-pzPhy                 = 0.5d0 !0.04d0 !0.25d0 !1.0d0       ! Maximum nano-phytoplankton preference (NEW: 3/12) ! NEW value for Phaeocystis
-sPhyNsq               = 0.d0
-pzCocco		      = 0.666d0  !0.4d0   ! NEW (8/12) ! NEW value for Phaeocystis
-sCoccoNsq	      = 0.d0        ! NEW
+graz_max              = 0.31d0      ! maximum grazing rate [mmol N/(m3 day)]
+epsilonr              = 0.09d0      ! half-saturation constant for grazing [(mmol N)^2/m^6]
+res_het               = 0.028d0     ! respiration and mortality (loss to detritus) [1/day]
+Redfield              = 6.625       ! Redfield C:N ratio (106:16) [mmol C/mmol N]
+loss_het              = 0.04d0      ! temperature-dependent N degradation of extracellular organic N (EON) [1/day]
+tiny_het              = 1.d-5       ! small number for a more stable HetRespFlux; may exceed tiny since HetRespFlux ~ HetC^2
+
+! --- Prey Preferences ---
+pzDia                 = 1.0d0       ! maximum diatom preference
+sDiaNsq               = 0.d0        ! not used by the current code
+pzPhy                 = 0.5d0       ! maximum small phytoplankton preference
+sPhyNsq               = 0.d0        ! not used by the current code
+pzCocco               = 0.666d0     ! maximum coccolithophore preference
+sCoccoNsq             = 0.d0        ! not used by the current code
 pzPhaeo               = 0.5d0       ! NEW for Phaeocystis
 sPhaeoNsq             = 0.d0        ! NEW for Phaeocystis
-pzMicZoo              = 1.0d0       ! NEW 3Zoo Maximum nano-phytoplankton preference
-sMicZooNsq            = 0.d0        ! NEW 3Zoo
-tiny_het              = 1.d-5       ! for more stable computation of HetRespFlux (_plus). Value can be > tiny because HetRespFlux ~ hetC**2.
+pzMicZoo              = 1.0d0       ! maximum microzooplankton preference
+sMicZooNsq            = 0.d0        ! not used by the current code
 /
 
+! ============================================================================
+! SECOND ZOOPLANKTON (MACROZOOPLANKTON)
+! ============================================================================
 &pasecondzooplankton
-graz_max2      = 0.25d0 !0.1d0              ! [mmol N/(m3 * day)] Maximum grazing loss parameter   ! NEW value for Phaeocystis                                                                                     
-epsilon2       = 0.0144d0           ! [(mmol N)2 /m6] Half saturation constant for grazing loss                                                                              
-res_zoo2       = 0.0107d0           ! [1/day] Respiration by heterotrophs and mortality (loss to detritus)                                                            
-loss_zoo2      = 0.003d0            ! [1/day] Temperature dependent N degradation of extracellular organic N (EON)
-fecal_rate_n      = 0.104d0         ! [1/day] Temperature dependent N degradation of \
-fecal_rate_c      = 0.236d0  
-fecal_rate_n_mes = 0.25d0           ! NEW 3Zoo
-fecal_rate_c_mes = 0.32d0           ! NEW 3Zoo                                                          
-pzDia2         = 1.5d0  !1.0d0     ! Maximum diatom preference ! NEW value for Phaeocystis
-sDiaNsq2       = 0.d0
-pzPhy2         = 0.5d0  !0.07d0    ! Maximum diatom preference ! NEW value for Phaeocystis
-sPhyNsq2       = 0.d0
-pzCocco2       = 0.5d0  !0.7d0        ! NEW ! NEW value for Phaeocystis
-sCoccoNsq2     = 0.d0		    ! NEW
+graz_max2             = 0.25d0      ! maximum grazing rate [mmol N/(m3 day)]
+epsilon2              = 0.0144d0    ! half-saturation constant for grazing [(mmol N)^2/m^6]
+res_zoo2              = 0.0107d0    ! respiration and mortality (loss to detritus) [1/day]
+loss_zoo2             = 0.003d0     ! temperature-dependent N degradation of extracellular organic N (EON) [1/day]
+
+! --- Fecal Pellets ---
+fecal_rate_n          = 0.104d0     ! fraction of the grazed nitrogen egested as fecal pellets
+fecal_rate_c          = 0.236d0     ! fraction of the grazed carbon egested as fecal pellets
+fecal_rate_n_mes      = 0.25d0      ! as fecal_rate_n, for the first zooplankton (mesozooplankton)
+fecal_rate_c_mes      = 0.32d0      ! as fecal_rate_c, for the first zooplankton (mesozooplankton)
+
+! --- Prey Preferences ---
+pzDia2                = 1.5d0       ! maximum diatom preference
+sDiaNsq2              = 0.d0        ! not used by the current code
+pzPhy2                = 0.5d0       ! maximum small phytoplankton preference
+sPhyNsq2              = 0.d0        ! not used by the current code
+pzCocco2              = 0.5d0       ! maximum coccolithophore preference
+sCoccoNsq2            = 0.d0        ! not used by the current code
 pzPhaeo2       = 0.5d0              ! NEW for Phaeocystis
 sPhaeoNsq2     = 0.d0               ! NEW for Phaeocystis
-pzHet          = 1.5d0 !0.8d0       ! Maximum diatom preference                                                                                                               
-sHetNsq        = 0.d0
-pzMicZoo2      = 1.0d0              ! NEW 3Zoo Maximum nano-phytoplankton preference
-sMicZooNsq2    = 0.d0   
-t1_zoo2        = 28145.d0           ! Krill temp. function constant1                                                                                                       
-t2_zoo2        = 272.5d0            ! Krill temp. function constant2                                                                                                         
-t3_zoo2        = 105234.d0          ! Krill temp. function constant3                                                                                                      
-t4_zoo2        = 274.15d0           ! Krill temp. function constant3
+pzHet                 = 1.5d0       ! maximum preference for the first zooplankton
+sHetNsq               = 0.d0        ! not used by the current code
+pzMicZoo2             = 1.0d0       ! maximum microzooplankton preference
+sMicZooNsq2           = 0.d0        ! not used by the current code
+
+! --- Temperature Function (Krill) ---
+t1_zoo2               = 28145.d0    ! krill temperature function constant 1
+t2_zoo2               = 272.5d0     ! krill temperature function constant 2
+t3_zoo2               = 105234.d0   ! krill temperature function constant 3
+t4_zoo2               = 274.15d0    ! krill temperature function constant 4
 /
 
+! ============================================================================
+! THIRD ZOOPLANKTON (MICROZOOPLANKTON)
+! ============================================================================
 &pathirdzooplankton
-graz_max3      = 0.36d0 !0.46d0             ! NEW 3Zoo [mmol N/(m3 * day)] Maximum grazing loss parameter ! NEW value for Phaeocystis
-epsilon3       = 0.64d0             ! NEW 3Zoo [(mmol N)2 /m6] Half saturation constant for grazing loss
-loss_miczoo    = 0.01d0             ! NEW 3Zoo [1/day] Temperature dependent N degradation of extracellular organic N (EON)
-res_miczoo     = 0.01d0 !0.02d0            ! NEW 3Zoo [1/day] Respiration by heterotrophs and mortality (loss to detritus)  ! NEW value for Phaeocystis
-pzDia3         = 0.5d0  !0.04d0     ! NEW 3Zoo Maximum diatom preference ! NEW value for Phaeocystis
-sDiaNsq3       = 0.d0               ! NEW 3Zoo
-pzPhy3         = 1.0d0 !0.07d0 ! NEW 3Zoo Maximum nano-phytoplankton preference ! NEW value for Phaeocystis
-sPhyNsq3       = 0.d0               ! NEW 3Zoo
-pzCocco3       = 0.5d0 !0.7d0               ! NEW 3Zoo Maximum coccolithophore preference ! ATTENTION: This value needs to be tuned; I start with zero preference! ! NEW value for Phaeocystis
-sCoccoNsq3     = 0.d0               ! NEW 3Zoo
+graz_max3             = 0.36d0      ! maximum grazing rate [mmol N/(m3 day)]
+epsilon3              = 0.64d0      ! half-saturation constant for grazing [(mmol N)^2/m^6]
+loss_miczoo           = 0.01d0      ! temperature-dependent N degradation of extracellular organic N (EON) [1/day]
+res_miczoo            = 0.01d0      ! respiration and mortality (loss to detritus) [1/day]
+
+! --- Prey Preferences ---
+pzDia3                = 0.5d0       ! maximum diatom preference
+sDiaNsq3              = 0.d0        ! not used by the current code
+pzPhy3                = 1.0d0       ! maximum small phytoplankton preference
+sPhyNsq3              = 0.d0        ! not used by the current code
+pzCocco3              = 0.5d0       ! maximum coccolithophore preference (still to be tuned)
+sCoccoNsq3            = 0.d0        ! not used by the current code
 pzPhaeo3       = 0.25d0              ! NEW for Phaeocystis
 sPhaeoNsq3     = 0.d0               ! NEW for Phaeocystis
 /
 
+! ============================================================================
+! GRAZING ON DETRITUS
+! ============================================================================
 &pagrazingdetritus
-pzDet         = 0.5d0           ! Maximum small detritus prefence by first zooplankton
-sDetNsq       = 0.d0
-pzDetZ2       = 0.5d0         ! Maximum large detritus preference by first zooplankton                                 
-sDetZ2Nsq     = 0.d0
-pzDet2         = 0.5d0           ! Maximum small detritus prefence by second zooplankton                               
-sDetNsq2       = 0.d0
-pzDetZ22       = 0.5d0           ! Maximum large detritus preference by second zooplankton
-sDetZ2Nsq2     = 0.d0
+pzDet                 = 0.5d0       ! maximum small detritus preference, first zooplankton
+sDetNsq               = 0.d0        ! not used by the current code
+pzDetZ2               = 0.5d0       ! maximum large detritus preference, first zooplankton
+sDetZ2Nsq             = 0.d0        ! not used by the current code
+pzDet2                = 0.5d0       ! maximum small detritus preference, second zooplankton
+sDetNsq2              = 0.d0        ! not used by the current code
+pzDetZ22              = 0.5d0       ! maximum large detritus preference, second zooplankton
+sDetZ2Nsq2            = 0.d0        ! not used by the current code
 /
 
+! ============================================================================
+! AGGREGATION
+! ============================================================================
 &paaggregation
-agg_PD                = 0.165d0     ! [m3/(mmol N * day)] Maximum aggregation loss parameter for DetN
-agg_PP                = 0.015d0     ! [m3/(mmol N * day)] Maximum aggregation loss parameter for PhyN and DiaN (plankton)
+agg_PD                = 0.165d0     ! maximum aggregation loss parameter for detritus [m3/(mmol N day)]
+agg_PP                = 0.015d0     ! maximum aggregation loss parameter for phytoplankton [m3/(mmol N day)]
 /
 
+! ============================================================================
+! DISSOLVED ORGANIC MATTER
+! ============================================================================
 &padin_rho_N
-rho_N                 = 0.11d0      ! [1/day] Temperature dependent N degradation of extracellular organic N (EON) (Remineralization of DON)
+rho_N                 = 0.11d0      ! temperature-dependent remineralization of DON (degradation of EON) [1/day]
 /
 
 &padic_rho_C1
-rho_C1                = 0.1d0       ! [1/day] Temperature dependent C degradation of extracellular organic C (EOC)
+rho_C1                = 0.1d0       ! temperature-dependent degradation of extracellular organic C (EOC) [1/day]
 /
 
+! ============================================================================
+! PHYTOPLANKTON LOSSES
+! ============================================================================
 &paphytoplankton_N
-lossN                 = 0.05d0      ! [1/day] Phytoplankton loss of organic N compounds
-lossN_d               = 0.05d0
-lossN_c		      = 0.05d0      ! NEW
+lossN                 = 0.05d0      ! loss of organic N compounds, small phytoplankton [1/day]
+lossN_d               = 0.05d0      ! loss of organic N compounds, diatoms [1/day]
+lossN_c               = 0.05d0      ! loss of organic N compounds, coccolithophores [1/day]
 lossN_p               = 0.05d0      ! NEW for Phaeocystis
 /
 
 &paphytoplankton_C
-lossC                 = 0.10d0      ! [1/day] Phytoplankton loss of carbon 
-lossC_d               = 0.10d0
-lossC_c		      = 0.10d0      ! NEW
+lossC                 = 0.10d0      ! loss of carbon, small phytoplankton [1/day]
+lossC_d               = 0.10d0      ! loss of carbon, diatoms [1/day]
+lossC_c               = 0.10d0      ! loss of carbon, coccolithophores [1/day]
 lossC_p               = 0.10d0      ! NEW for Phaeocystis
 /
 
 &paphytoplankton_ChlA
-deg_Chl               = 0.15d0 !0.25d0 !0.2d0   ! NEW value for Phaeocystis   ! [1/day]
-deg_Chl_d             = 0.2d0 ! 0.15d0 ! NEW value for Phaeocystis
-deg_Chl_c	      = 0.2d0       ! NEW (has been 0.5)
+deg_Chl               = 0.15d0      ! chlorophyll degradation rate, small phytoplankton [1/day]
+deg_Chl_d             = 0.2d0       ! chlorophyll degradation rate, diatoms [1/day]
+deg_Chl_c             = 0.2d0       ! chlorophyll degradation rate, coccolithophores [1/day]
 deg_Chl_p             = 0.15d0       ! NEW for Phaeocystis
-
 /
 
+! ============================================================================
+! DETRITUS
+! ============================================================================
 &padetritus_N
-gfin                  = 0.3d0         ! NEW 3Zoo [] Grazing efficiency (fraction of grazing flux into zooplankton pool)
-grazEff2              = 0.8d0         ! [] Grazing efficiency (fraction of grazing flux into second zooplankton pool)
-grazEff3              = 0.8d0         ! NEW 3Zoo [] Grazing efficiency (fraction of grazing flux into microzooplankton pool)
-reminN                = 0.165d0       ! [1/day] Temperature dependent remineralisation rate of detritus	
+gfin                  = 0.3d0       ! grazing efficiency of the first zooplankton (fraction of the grazing flux it retains)
+grazEff2              = 0.8d0       ! grazing efficiency of the second zooplankton
+grazEff3              = 0.8d0       ! grazing efficiency of the microzooplankton
+reminN                = 0.165d0     ! temperature-dependent remineralization rate of detrital N [1/day]
 /
 
 &padetritus_C
-reminC                = 0.15d0      ! [1/day] Temperature dependent remineralisation rate of detritus
-rho_c2                = 0.1d0       ! [1/day] Temperature dependent C degradation of TEP-C
+reminC                = 0.15d0      ! temperature-dependent remineralization rate of detrital C [1/day]
+rho_c2                = 0.1d0       ! temperature-dependent degradation of TEP-C [1/day]
 /
 
+! ============================================================================
+! ZOOPLANKTON EXCRETION
+! ============================================================================
 &paheterotrophs
-lossN_z               = 0.1d0
-lossC_z               = 0.1d0
+lossN_z               = 0.1d0       ! DON excretion by the first zooplankton [1/day]
+lossC_z               = 0.1d0       ! DOC excretion by the first zooplankton [1/day]
 /
 
 &paseczooloss
-lossN_z2              = 0.02d0
-lossC_z2              = 0.02d0
+lossN_z2              = 0.02d0      ! DON excretion by the second zooplankton [1/day]
+lossC_z2              = 0.02d0      ! DOC excretion by the second zooplankton [1/day]
 /
 
 &pathirdzooloss
-lossN_z3              = 0.05d0       ! NEW 3Zoo
-lossC_z3              = 0.05d0       ! NEW 3Zoo 
+lossN_z3              = 0.05d0      ! DON excretion by the microzooplankton [1/day]
+lossC_z3              = 0.05d0      ! DOC excretion by the microzooplankton [1/day]
 /
 
-&paco2lim                    ! NEW
-Cunits         = 976.5625    ! Conversion factor between [mol/m3] (model) and [umol/kg] (function): (1000 * 1000) / 1024                                                                                                                      
-a_co2_phy      = 1.162e+00   ! [dimensionless]
-a_co2_dia      = 1.040e+00   ! [dimensionless]
-a_co2_cocco    = 1.109e+00   ! [dimensionless]
+! ============================================================================
+! CO2 DEPENDENCE OF GROWTH AND CALCIFICATION (CO2lim)
+! ============================================================================
+! Response = a*HCO3/(b + HCO3) - exp(-c*CO2) - d*10**(-pH), with HCO3 and
+! CO2 converted by Cunits; one set per phytoplankton group and calcification.
+! ============================================================================
+&paco2lim
+Cunits         = 976.5625    ! conversion between [mol/m3] (model) and [umol/kg] (function): (1000 * 1000) / 1024
+a_co2_phy      = 1.162e+00   ! HCO3 response coefficient a, small phytoplankton [dimensionless]
+a_co2_dia      = 1.040e+00   ! HCO3 response coefficient a, diatoms [dimensionless]
+a_co2_cocco    = 1.109e+00   ! HCO3 response coefficient a, coccolithophores [dimensionless]
 a_co2_phaeo    = 1.162e+00   ! [dimensionless] Phaeocystis
-a_co2_calc     = 1.102e+00   ! [dimensionless]
-b_co2_phy      = 4.888e+01   ! [mol/kg]
-b_co2_dia      = 2.890e+01   ! [mol/kg]
-b_co2_cocco    = 3.767e+01   ! [mol/kg]
+a_co2_calc     = 1.102e+00   ! HCO3 response coefficient a, calcification [dimensionless]
+b_co2_phy      = 4.888e+01   ! HCO3 half-saturation b, small phytoplankton [mol/kg]
+b_co2_dia      = 2.890e+01   ! HCO3 half-saturation b, diatoms [mol/kg]
+b_co2_cocco    = 3.767e+01   ! HCO3 half-saturation b, coccolithophores [mol/kg]
 b_co2_phaeo    = 4.888e+01   ! [mol/kg] Phaeocystis
-b_co2_calc     = 4.238e+01   ! [mol/kg]
-c_co2_phy      = 2.255e-01   ! [kg/mol]
-c_co2_dia      = 8.778e-01   ! [kg/mol]
-c_co2_cocco    = 3.912e-01   ! [kg/mol]
+b_co2_calc     = 4.238e+01   ! HCO3 half-saturation b, calcification [mol/kg]
+c_co2_phy      = 2.255e-01   ! CO2 inhibition coefficient c, small phytoplankton [kg/mol]
+c_co2_dia      = 8.778e-01   ! CO2 inhibition coefficient c, diatoms [kg/mol]
+c_co2_cocco    = 3.912e-01   ! CO2 inhibition coefficient c, coccolithophores [kg/mol]
 c_co2_phaeo    = 2.255e-01   ! [kg/mol] Phaeocystis
-c_co2_calc     = 7.079e-01   ! [kg/mol] 
-d_co2_phy      = 1.023e+07   ! [kg/mol]
-d_co2_dia      = 2.640e+06   ! [kg/mol]
-d_co2_cocco    = 9.450e+06   ! [kg/mol]
+c_co2_calc     = 7.079e-01   ! CO2 inhibition coefficient c, calcification [kg/mol]
+d_co2_phy      = 1.023e+07   ! H+ inhibition coefficient d, small phytoplankton [kg/mol]
+d_co2_dia      = 2.640e+06   ! H+ inhibition coefficient d, diatoms [kg/mol]
+d_co2_cocco    = 9.450e+06   ! H+ inhibition coefficient d, coccolithophores [kg/mol]
 d_co2_phaeo    = 1.023e+07   ! [kg/mol] Phaeocystis
-d_co2_calc     = 1.343e+07   ! [kg/mol]
+d_co2_calc     = 1.343e+07   ! H+ inhibition coefficient d, calcification [kg/mol]
 /
 
+! ============================================================================
+! IRON
+! ============================================================================
 &pairon
-Fe2N                  = 0.033d0     ! Fe2C * 6.625
-Fe2N_benthos          = 0.15d0      ! test, default was 0.14 Fe2C_benthos * 6.625 - will have to be tuned. [umol/m2/day]
-kScavFe               = 0.07d0
-dust_sol              = 0.02d0      ! Dissolution of Dust for bioavaliable
-RiverFeConc           = 100
+Fe2N                  = 0.033d0     ! Fe:N ratio of organic matter (Fe2C * 6.625)
+Fe2N_benthos          = 0.15d0      ! Fe:N ratio of the benthic iron release (Fe2C_benthos * 6.625; was 0.14, still to be tuned)
+kScavFe               = 0.07d0      ! scavenging rate of free iron onto detritus
+dust_sol              = 0.02d0      ! soluble (bioavailable) fraction of dust iron
+RiverFeConc           = 100         ! mean dissolved iron concentration in rivers (useRivFe)
 /
 
+! ============================================================================
+! CALCITE
+! ============================================================================
 &pacalc
-calc_prod_ratio       = 0.02
-calc_diss_guts        = 0.5d0 !0.0d0
-calc_diss_rate        = 0.005714d0  ! 20.d0/3500.d0
-calc_diss_rate2       = 0.005714d0
-calc_diss_omegac      = 0.197d0     ! NEW DISS Value from Aumont et al. 2015, will be used with OmegaC_diss flag
-calc_diss_exp         = 1.d0        ! NEW DISS Exponent in the dissolution rate of calcite, will be used with OmegaC_diss flag
+calc_prod_ratio       = 0.02        ! calcite production as a fraction of small phytoplankton carbon fixation
+calc_diss_guts        = 0.5d0       ! calcite dissolution in zooplankton guts (set to 0 when OmegaC_diss = .false.)
+calc_diss_rate        = 0.005714    ! calcite dissolution rate (20/3500) [1/day]
+calc_diss_rate2       = 0.005714d0  ! calcite dissolution rate of large detritus, scaled by its sinking speed / 20
+calc_diss_omegac      = 0.197d0     ! value from Aumont et al. (2015), used with OmegaC_diss
+calc_diss_exp         = 1.d0        ! exponent of the calcite dissolution rate, used with OmegaC_diss
 /
 
+! ============================================================================
+! BENTHOS
+! ============================================================================
 &pabenthos_decay_rate
-decayRateBenN         = 0.005d0
-decayRateBenC         = 0.005d0
-decayRateBenSi        = 0.005d0
+decayRateBenN         = 0.005d0     ! decay rate of benthic nitrogen [1/day]
+decayRateBenC         = 0.005d0     ! decay rate of benthic carbon [1/day]
+decayRateBenSi        = 0.005d0     ! decay rate of benthic silicon [1/day]
 q_NC_Denit            = 0.86d0      ! N:C quota of the denitrification process
 /
 
+! ============================================================================
+! AIR-SEA CO2 FLUX
+! ============================================================================
 &paco2_flux_param
-permil                = 0.000000976 ! 1.e-3/1024.5d0              ! Converting DIC from [mmol/m3] to [mol/kg]
-permeg                = 1.e-6                       ! [atm/uatm] Changes units from uatm to atm
+permil                = 0.000000976 ! converts DIC from [mmol/m3] to [mol/kg] (1.e-3/1024.5)
+permeg                = 1.e-6       ! converts uatm to atm [atm/uatm]
 !X1                    = exp(-5.d0*log(10.d0))       ! Lowest ph-value = 7.7 (phlo)
 !X2                    = exp(-9.d0*log(10.d0))       ! Highest ph-value = 9.5 (phhi)
-Xacc                  = 1.e-12                      ! Accuracy for ph-iteration (phacc)
-CO2_for_spinup        = 278.d0                      ! [uatm] Atmospheric partial pressure of CO2
+Xacc                  = 1.e-12      ! accuracy of the pH iteration
+CO2_for_spinup        = 278.d0      ! atmospheric pCO2 used with constant_CO2 = .true. [uatm]
 /
 
+! ============================================================================
+! ALKALINITY RESTORING
+! ============================================================================
 &paalkalinity_restoring
-surf_relax_Alk      = 3.2e-07 !10.d0/31536000.d0
+surf_relax_Alk        = 3.2e-07     ! surface alkalinity restoring velocity, 10 m per year [m/s] (restore_alkalinity)
 /
 
+! ============================================================================
+! BALLASTING (use_ballasting, see Cram et al. 2018)
+! ============================================================================
 &paballasting
-rho_POC              = 1033.d0   ! kg m-3; density of POC (see Table 1 in Cram et al., 2018)
-rho_PON              = 1033.d0   ! kg m-3; density of PON (see Table 1 in Cram et al., 2018)
-rho_CaCO3            = 2830.d0   ! kg m-3; density of CaCO3 (see Table 1 in Cram et al., 2018) 
-rho_opal             = 2090.d0   ! kg m-3; density of Opal (see Table 1 in Cram et al., 2018)
-rho_ref_part         = 1230.d0   ! kg m-3; reference particle density (see Cram et al., 2018)
-rho_ref_water        = 1027.d0   ! kg m-3; reference seawater density (see Cram et al., 2018)
-visc_ref_water       = 0.00158d0 ! kg m-1 s-1; reference seawater viscosity, at Temp=4 degC (see Cram et al., 2018)
-w_ref1               = 5.d0     ! m s-1; reference sinking velocity of small detritus
-w_ref2               = 200.d0    ! m s-1; reference sinking velocity of large detritus
-depth_scaling1       = 0.01d0 !5d0   ! s-1; factor to increase sinking speed of det1 with depth, set to 0 if not wanted
-depth_scaling2       = 0.d0      ! s-1; factor to increase sinking speed of det2 with depth, set to 0 if not wanted
-max_sinking_velocity = 250.d0    ! d-1; for numerical stability, set a maximum possible sinking velocity here (applies to both detritus classes)
+rho_POC              = 1033.d0   ! density of POC [kg/m3] (Cram et al. 2018, Table 1)
+rho_PON              = 1033.d0   ! density of PON [kg/m3] (Cram et al. 2018, Table 1)
+rho_CaCO3            = 2830.d0   ! density of CaCO3 [kg/m3] (Cram et al. 2018, Table 1)
+rho_opal             = 2090.d0   ! density of opal [kg/m3] (Cram et al. 2018, Table 1)
+rho_ref_part         = 1230.d0   ! reference particle density [kg/m3]
+rho_ref_water        = 1027.d0   ! reference seawater density [kg/m3]
+visc_ref_water       = 0.00158d0 ! reference seawater viscosity at 4 degC [kg/(m s)]
+w_ref1               = 5.d0      ! reference sinking velocity of small detritus [m/day]
+w_ref2               = 200.d0    ! reference sinking velocity of large detritus [m/day]
+depth_scaling1       = 0.01d0    ! increase of small detritus sinking speed with depth [1/day], 0 = off
+depth_scaling2       = 0.d0      ! increase of large detritus sinking speed with depth [1/day], 0 = off
+max_sinking_velocity = 250.d0    ! upper limit of the sinking speed for numerical stability [m/day], both detritus classes
 /
 
+! ============================================================================
+! CARBON ISOTOPES (ciso)
+! ============================================================================
 &paciso
 ciso_init         = .false.     ! initial fractionation of bulk organic matter
-ciso_14           = .false.      ! include inorganic radiocarbon
+ciso_14           = .false.     ! include inorganic radiocarbon
 ciso_organic_14   = .false.     ! include organic radiocarbon
-lambda_14         = 3.8561e-12  ! corresponding to 1 year = 365.00 days
-delta_CO2_13      = -6.61       ! atmospheric d13C (permil), global-mean value
-big_delta_CO2_14(1)  = 0. ! atmospheric D14C (permil), northern hemisphere polewards of 30°N
-big_delta_CO2_14(2)  = 0. ! atmospheric D14C (permil), (sub) tropical zone 30°N - 30°S
-big_delta_CO2_14(3)  = 0. ! atmospheric D14C (permil), southern hemisphere polewards of 30°S
-atbox_spinup      = .false.
-cosmic_14_init    = 2.0
+lambda_14         = 3.8561e-12  ! radiocarbon decay constant [1/s] (1 year = 365.00 days)
+delta_CO2_13      = -6.61       ! atmospheric d13C, global mean [permil]
+big_delta_CO2_14(1)  = 0. ! atmospheric D14C north of 30°N [permil]
+big_delta_CO2_14(2)  = 0. ! atmospheric D14C between 30°N and 30°S [permil]
+big_delta_CO2_14(3)  = 0. ! atmospheric D14C south of 30°S [permil]
+atbox_spinup      = .false.     ! spin-up mode of the atmospheric 14C box
+cosmic_14_init    = 2.0         ! initial cosmogenic 14C production [atoms/(s cm²)]
 /
-

--- a/config/bin_4p3z2d/namelist.tra
+++ b/config/bin_4p3z2d/namelist.tra
@@ -1,9 +1,37 @@
+! ============================================================================
+! ============ Namelist file for FESOM2 tracer configuration =================
+! ============================================================================
+! This file contains configuration for ocean tracers (temperature, salinity,
+! and passive tracers):
+! - Tracer list and advection/diffusion schemes
+! - Initial conditions (3D ocean and 2D sea ice)
+! - Biharmonic diffusion options
+! - Vertical diffusion and time stepping
+! - Physical parameterizations (mixing, restoring)
+! ============================================================================
+
+! ============================================================================
+! TRACER ARRAY ALLOCATION
+! ============================================================================
 &tracer_listsize
-num_tracers=100 !number of tracers to allocate. shallbe large or equal to the number of streams in &nml_list
+num_tracers = 100         ! number of tracers to allocate (must be ≥ actual number of tracers)
 /
 
+! ============================================================================
+! TRACER LIST AND ADVECTION SCHEMES
+! ============================================================================
+! Format: ID, horizontal_advection, vertical_advection, horizontal_diffusion, Kh_factor, Kv_factor
+! Advection schemes: 'MFCT' (Multidimensional FCT), 'UPW1' (1st-order upwind), 'QR4C' (4th-order)
+! Diffusion schemes: 'FCT' (Flux-Corrected Transport), 'NON' (none)
+! Order switches   : hor./vert. Ord.=1.0 --> 4th order, =0.0 --> 3rd order, =0.5 --> mixed 3rd&4th order
+! ============================================================================
+! nml_tracer_list =
+! idx, hor. Adv, vert. Adv., use FCT, hor.Ord., vert. Ord. 
+! 1  , 'MFCT'  , 'QR4C'    , 'FCT ' , 1.      , 1.        ,   ! temperature
+! 2  , 'MFCT'  , 'QR4C'    , 'FCT ' , 1.      , 1.        ,   ! salinity
+!101 , 'UPW1'  , 'UPW1'    , 'NON ' , 0.      , 0.            ! example passive tracer
 &tracer_list
-nml_tracer_list =  
+nml_tracer_list =
 1  ,   'MFCT',       'QR4C',       'FCT ',        1.,          1., 
 2  ,   'MFCT',       'QR4C',       'FCT ',        1.,          1.,
 1001,  'MFCT',       'QR4C',       'FCT ',        1.,          1.,
@@ -46,49 +74,81 @@ nml_tracer_list =
 !101, 'UPW1',       'UPW1',       'NON ',        0.,          0.
 /
 
-&tracer_init3d                            ! initial conditions for tracers
-n_ic3d   = 8                              ! number of tracers to initialize
-idlist   = 1019, 1022, 1018, 1003, 1002, 1001, 2, 1 ! their IDs (0 is temperature, 1 is salinity, etc.). The reading order is defined here!
-filelist = 'fe_pisces_opa_eq_init_3D_changed_name.nc', 'woa18_all_o00_01_mmol_fesom2.nc', 'woa13_all_i00_01_fesom2.nc', 'GLODAPv2.2016b.TAlk_fesom2_mmol_fix_z_Fillvalue.nc', 'GLODAPv2.2016b.TCO2_fesom2_mmol_fix_z_Fillvalue.nc', 'woa13_all_n00_01_fesom2.nc', 'phc3.0_winter.nc', 'phc3.0_winter.nc'  ! list of files in ClimateDataPath to read (one file per tracer), same order as idlist
-varlist  = 'Fe', 'oxygen_mmol', 'i_an', 'TAlk_mmol', 'TCO2_mmol', 'n_an', 'salt', 'temp'                 ! variables to read from specified files
-t_insitu = .true.                         ! if T is insitu it will be converted to potential after reading it
+! ============================================================================
+! 3D TRACER INITIAL CONDITIONS (OCEAN)
+! ============================================================================
+&tracer_init3d
+n_ic3d   = 8  ! number of 3D tracers to initialize from files
+idlist   = 1019, 1022, 1018, 1003, 1002, 1001, 2, 1 ! tracer IDs to initialize (1=temperature, 2=salinity)
+filelist = 'fe_pisces_opa_eq_init_3D_changed_name.nc', 'woa18_all_o00_01_mmol_fesom2.nc', 'woa13_all_i00_01_fesom2.nc', 'GLODAPv2.2016b.TAlk_fesom2_mmol_fix_z_Fillvalue.nc', 'GLODAPv2.2016b.TCO2_fesom2_mmol_fix_z_Fillvalue.nc', 'woa13_all_n00_01_fesom2.nc', 'phc3.0_winter.nc', 'phc3.0_winter.nc' ! netCDF files in ClimateDataPath (one per tracer)
+varlist  = 'Fe', 'oxygen_mmol', 'i_an', 'TAlk_mmol', 'TCO2_mmol', 'n_an', 'salt', 'temp' ! variable names in the netCDF files
+t_insitu = .true.                                  ! if true, convert in-situ temperature to potential temperature
 /
 
-&tracer_init2d                                      ! initial conditions for 2D tracers (sea ice)
-n_ic2d   = 3                                        ! number of tracers to initialize
-idlist   = 1, 2, 3                                  ! their IDs (0 is a_ice, 1 is m_ice, 3 m_snow). The reading order is defined here!
-filelist = 'a_ice.nc', 'm_ice.nc', 'm_snow.nc' ! list of files in ClimateDataPath to read (one file per tracer), same order as idlist
-varlist  = 'a_ice', 'm_ice', 'm_snow'                 ! variables to read from specified files
-ini_ice_from_file=.false.
+! ============================================================================
+! 2D TRACER INITIAL CONDITIONS (SEA ICE)
+! ============================================================================
+&tracer_init2d
+n_ic2d            = 3                                    ! number of 2D tracers to initialize from files
+idlist            = 1, 2, 3                              ! tracer IDs (1=ice concentration, 2=ice thickness, 3=snow thickness)
+filelist          = 'a_ice.nc', 'm_ice.nc', 'm_snow.nc'  ! netCDF files in ClimateDataPath
+varlist           = 'a_ice', 'm_ice', 'm_snow'           ! variable names in the netCDF files
+ini_ice_from_file = .false.                              ! enable initialization from files (false = use default values)
 /
 
+! ============================================================================
+! TRACER GENERAL SETTINGS
+! ============================================================================
 &tracer_general
-! bharmonic diffusion for tracers. We recommend to use this option in very high resolution runs (Redi is generally off there).
-smooth_bh_tra =.false.     ! use biharmonic diffusion (filter implementation) for tracers
-gamma0_tra    = 0.0005     ! gammaX_tra are analogous to those in the dynamical part
-gamma1_tra    = 0.0125
-gamma2_tra    = 0.
-i_vert_diff   =.true.
+! --- Biharmonic Diffusion ---
+! Recommended for very high resolution runs (where Redi is typically disabled)
+smooth_bh_tra = .false.       ! enable biharmonic diffusion (filter implementation) for tracers
+gamma0_tra    = 0.0005        ! background biharmonic diffusion coefficient [dimensionless]
+gamma1_tra    = 0.0125        ! flow-aware biharmonic diffusion coefficient [dimensionless]
+gamma2_tra    = 0.            ! additional biharmonic diffusion coefficient [dimensionless]
+
+! --- Vertical Diffusion and Time Stepping ---
+i_vert_diff   = .true.        ! use implicit vertical diffusion (recommended for stability)
 /
 
+! ============================================================================
+! TRACER PHYSICS AND PARAMETERIZATIONS
+! ============================================================================
 &tracer_phys
-use_momix     = .true.     ! switch on/off  !Monin-Obukhov -> TB04 mixing
-momix_lat     = -50.0      ! latitidinal treshhold for TB04, =90 --> global
-momix_kv      = 0.01       ! PP/KPP, mixing coefficient within MO length
-use_instabmix = .true.     ! enhance convection in case of instable stratification
-instabmix_kv  = 0.1
-use_windmix   = .false.    ! enhance mixing trough wind only for PP mixing (for stability)
-windmix_kv    = 1.e-3
-windmix_nl    = 2
-diff_sh_limit=5.0e-3       ! for KPP, max diff due to shear instability
-Kv0_const=.true.
-double_diffusion=.false.   ! for KPP,dd switch
-K_ver=1.0e-5
-K_hor=3000.
-surf_relax_T=0.0
-surf_relax_S=1.929e-06   ! 50m/300days 6.43e-07! m/s 10./(180.*86400.)
-balance_salt_water =.true. ! balance virtual-salt or freshwater flux or not
-clim_relax=0.0	           ! 1/s, geometrical information has to be supplied
-ref_sss_local=.true.
-ref_sss=34.
+! --- Monin-Obukhov Mixing (TB04) ---
+use_momix          = .true.            ! enable Monin-Obukhov mixing (Timmermann & Beckmann 2004)
+momix_lat          = -50.0             ! latitude threshold for TB04 [degrees] (90 = global, -50 = south of 50°S)
+momix_kv           = 0.01              ! mixing coefficient within MO length [m²/s]
+
+! --- Convective Instability Mixing ---
+use_instabmix      = .true.            ! enhance mixing for unstable stratification (convection)
+instabmix_kv       = 0.1               ! mixing coefficient for unstable stratification [m²/s]
+
+! --- Wind Mixing (PP scheme only) ---
+use_windmix        = .false.           ! enhance near-surface mixing by wind (for PP mixing stability)
+windmix_kv         = 1.e-3             ! wind mixing coefficient [m²/s]
+windmix_nl         = 2                 ! number of surface layers for wind mixing
+
+! --- Shear Instability (KPP) ---
+diff_sh_limit      = 5.0e-3            ! maximum diffusivity due to shear instability [m²/s] (for KPP)
+
+! --- Background Diffusivity ---
+Kv0_const          = .true.            ! use constant background vertical diffusivity
+K_ver              = 1.0e-5            ! background vertical diffusivity [m²/s]
+K_hor              = 3000.             ! background horizontal diffusivity [m²/s]
+
+! --- Double Diffusion (KPP) ---
+double_diffusion   = .false.           ! enable double diffusion parameterization (for KPP)
+
+! --- Surface Restoring ---
+surf_relax_T       = 0.0               ! surface temperature restoring coefficient [m/s] (0 = disabled)
+surf_relax_S       = 1.929e-06         ! surface salinity restoring coefficient [m/s]
+balance_salt_water = .true.            ! balance virtual salt flux with freshwater flux
+
+! --- Climatology Restoring ---
+clim_relax         = 0.0               ! 3D climatology restoring coefficient [1/s] (0 = disabled)
+
+! --- Reference Salinity ---
+ref_sss_local      = .true.            ! use local reference SSS (true) or global constant (false)
+ref_sss            = 34.               ! global reference salinity [psu] (if ref_sss_local=false)
 /

--- a/config/namelist.config.toy_dbgyre
+++ b/config/namelist.config.toy_dbgyre
@@ -39,16 +39,16 @@ run_length_unit   = 'd'        ! unit for run_length: 'y' (years), 'm' (months),
 &clockinit
 timenew = 0.0                  ! initial time within the day [seconds] (0.0 = midnight)
 daynew  = 1                    ! initial day of the month (1-31)
-yearnew = 1900                 ! initial year
+yearnew = 1900  ! initial year
 /
 
 ! ============================================================================
 ! MESH, INITIALIZATION & OUTPUT PATHS
 ! ============================================================================
 &paths
-MeshPath         = ''                                           ! path to mesh files (nod2d.out, elem2d.out, etc.)
-ClimateDataPath  = '/pool/data/AWICM/FESOM2/INITIAL/phc3.0/'    ! path to initial conditions (temperature, salinity)
-ResultPath       = '../results_tmp/'                            ! path for output files and fesom.clock file
+MeshPath         = ''  ! path to mesh files (nod2d.out, elem2d.out, etc.)
+ClimateDataPath  = '/pool/data/AWICM/FESOM2/INITIAL/phc3.0/'          ! path to initial conditions (temperature, salinity)
+ResultPath       = '../results_tmp/'  ! path for output files and fesom.clock file
 /
 
 ! ============================================================================
@@ -69,9 +69,9 @@ logfile_outfreq         = 72       ! log file output frequency [number of time s
 ! ============================================================================
 &ale_def
 which_ALE          = 'linfs'     ! vertical coordinate type:
-                                 !   'linfs'  = linear free surface
-                                 !   'zlevel' = z-level (fixed depth levels)
-                                 !   'zstar'  = z-star (terrain-following with SSH scaling)
+                                  !   'linfs'  = linear free surface
+                                  !   'zlevel' = z-level (fixed depth levels)
+                                  !   'zstar'  = z-star (terrain-following with SSH scaling)
 use_partial_cell   = .false.     ! use partial bottom cells for better topography representation (not recommended)
 /
 
@@ -87,14 +87,14 @@ force_rotation  = .false.        ! force grid rotation even if not coupled
 alphaEuler      = 0.             ! first Euler angle (rotation around z-axis) [degrees]
 betaEuler       = 0.             ! second Euler angle (rotation around new x-axis) [degrees]
 gammaEuler      = 0.             ! third Euler angle (rotation around new z-axis) [degrees]
-                                 ! Euler angle convention: rotate first around z, then around new x, then around new z
+                                  ! Euler angle convention: rotate first around z, then around new x, then around new z
 /
 
 ! ============================================================================
 ! CALENDAR SETTINGS
 ! ============================================================================
 &calendar
-include_fleapyear = .false.       ! include leap years in calendar (false = 365-day year, true = 365/366-day year)
+include_fleapyear = .false.      ! include leap years in calendar (false = 365-day year, true = 365/366-day year)
 /
 
 ! ============================================================================
@@ -133,4 +133,3 @@ use_icebergs          = .false.  ! enable iceberg module
 steps_per_ib_step     = 8        ! ocean time steps per iceberg time step (iceberg subcycling)
 ib_async_mode         = 0        ! iceberg asynchronous mode (0=synchronous, 1=asynchronous)
 /
-

--- a/config/namelist.config.toy_neverworld2
+++ b/config/namelist.config.toy_neverworld2
@@ -39,16 +39,16 @@ run_length_unit   = 'd'        ! unit for run_length: 'y' (years), 'm' (months),
 &clockinit
 timenew = 0.0                  ! initial time within the day [seconds] (0.0 = midnight)
 daynew  = 1                    ! initial day of the month (1-31)
-yearnew = 1900                 ! initial year
+yearnew = 1900  ! initial year
 /
 
 ! ============================================================================
 ! MESH, INITIALIZATION & OUTPUT PATHS
 ! ============================================================================
 &paths
-MeshPath         = ''                                           ! path to mesh files (nod2d.out, elem2d.out, etc.)
-ClimateDataPath  = '/pool/data/AWICM/FESOM2/INITIAL/phc3.0/'    ! path to initial conditions (temperature, salinity)
-ResultPath       = '../results_tmp/'                            ! path for output files and fesom.clock file
+MeshPath         = ''  ! path to mesh files (nod2d.out, elem2d.out, etc.)
+ClimateDataPath  = '/pool/data/AWICM/FESOM2/INITIAL/phc3.0/'          ! path to initial conditions (temperature, salinity)
+ResultPath       = '../results_tmp/'  ! path for output files and fesom.clock file
 /
 
 ! ============================================================================
@@ -61,7 +61,7 @@ raw_restart_length      = 1        ! frequency for raw core dump restart files
 raw_restart_length_unit = 'off'    ! unit: 'y', 'm', 'd', 'h', 's', 'off'
 bin_restart_length      = 1        ! frequency for binary derived type restart files
 bin_restart_length_unit = 'off'    ! unit: 'y', 'm', 'd', 'h', 's', 'off'
-logfile_outfreq         = 450       ! log file output frequency [number of time steps]
+logfile_outfreq         = 450      ! log file output frequency [number of time steps]
 /
 
 ! ============================================================================
@@ -69,9 +69,9 @@ logfile_outfreq         = 450       ! log file output frequency [number of time 
 ! ============================================================================
 &ale_def
 which_ALE          = 'linfs'     ! vertical coordinate type:
-                                 !   'linfs'  = linear free surface
-                                 !   'zlevel' = z-level (fixed depth levels)
-                                 !   'zstar'  = z-star (terrain-following with SSH scaling)
+                                  !   'linfs'  = linear free surface
+                                  !   'zlevel' = z-level (fixed depth levels)
+                                  !   'zstar'  = z-star (terrain-following with SSH scaling)
 use_partial_cell   = .false.     ! use partial bottom cells for better topography representation (not recommended)
 /
 
@@ -87,14 +87,14 @@ force_rotation  = .false.        ! force grid rotation even if not coupled
 alphaEuler      = 0.             ! first Euler angle (rotation around z-axis) [degrees]
 betaEuler       = 0.             ! second Euler angle (rotation around new x-axis) [degrees]
 gammaEuler      = 0.             ! third Euler angle (rotation around new z-axis) [degrees]
-                                 ! Euler angle convention: rotate first around z, then around new x, then around new z
+                                  ! Euler angle convention: rotate first around z, then around new x, then around new z
 /
 
 ! ============================================================================
 ! CALENDAR SETTINGS
 ! ============================================================================
 &calendar
-include_fleapyear = .false.       ! include leap years in calendar (false = 365-day year, true = 365/366-day year)
+include_fleapyear = .false.      ! include leap years in calendar (false = 365-day year, true = 365/366-day year)
 /
 
 ! ============================================================================
@@ -105,7 +105,7 @@ use_ice                  = .false.       ! enable sea ice model
 use_cavity               = .false.       ! enable ice shelf cavities
 use_cavity_partial_cell  = .false.       ! use partial cells in ice shelf cavities (not recommended)
 use_floatice             = .false.       ! enable floating ice (icebergs)
-use_sw_pene              = .false.        ! enable shortwave radiation penetration into ocean
+use_sw_pene              = .false.       ! enable shortwave radiation penetration into ocean
 flag_debug               = .false.       ! enable debug output (verbose logging)
 use_transit              = .false.       ! enable transient tracer module (CFCs, SF6, etc.)
 toy_ocean                = .true.        ! enable toy configuration
@@ -133,4 +133,3 @@ use_icebergs          = .false.  ! enable iceberg module
 steps_per_ib_step     = 8        ! ocean time steps per iceberg time step (iceberg subcycling)
 ib_async_mode         = 0        ! iceberg asynchronous mode (0=synchronous, 1=asynchronous)
 /
-

--- a/config/namelist.config.toy_soufflet
+++ b/config/namelist.config.toy_soufflet
@@ -27,8 +27,8 @@ runid = 'fesom'        ! run identifier (used in output filenames)
 ! ============================================================================
 &timestep
 step_per_day      = 72         ! number of time steps per day (determines dt = 86400/step_per_day seconds)
-                               ! common values: 32 (45min), 48 (30min), 72 (20min), 96 (15min), 192 (7min 30sec), 
-                               ! 216 (6min 40sec), 240 (6min), 288 (5min), 360 (4min), 720 (2min), 1440 (1min), 2880 (30sec)
+                                ! common values: 32 (45min), 48 (30min), 72 (20min), 96 (15min), 192 (7min 30sec), 
+                                ! 216 (6min 40sec), 240 (6min), 288 (5min), 360 (4min), 720 (2min), 1440 (1min), 2880 (30sec)
 run_length        = 10         ! total length of simulation run
 run_length_unit   = 'd'        ! unit for run_length: 'y' (years), 'm' (months), 'd' (days), 's' (steps)
 /
@@ -46,9 +46,9 @@ yearnew = 1958                 ! initial year
 ! MESH, INITIALIZATION & OUTPUT PATHS
 ! ============================================================================
 &paths
-MeshPath         = '/albedo/home/pscholz/fesom2/test/meshes/soufflet/'   ! path to mesh files (nod2d.out, elem2d.out, etc.)
-ClimateDataPath  = '/albedo/work/projects/p_fesom/FROM-OLLIE/FESOM2/hydrography/phc3.0/'          ! path to initial conditions (temperature, salinity)
-ResultPath       = '../result_tmp/'               ! path for output files and fesom.clock file
+MeshPath         = '/albedo/home/pscholz/fesom2/test/meshes/soufflet/' ! path to mesh files (nod2d.out, elem2d.out, etc.)
+ClimateDataPath  = '/albedo/work/projects/p_fesom/FROM-OLLIE/FESOM2/hydrography/phc3.0/' ! path to initial conditions (temperature, salinity)
+ResultPath       = '../result_tmp/'  ! path for output files and fesom.clock file
 /
 
 ! ============================================================================
@@ -69,9 +69,9 @@ logfile_outfreq         = 72       ! log file output frequency [number of time s
 ! ============================================================================
 &ale_def
 which_ALE          = 'linfs'     ! vertical coordinate type:
-                                 !   'linfs'  = linear free surface
-                                 !   'zlevel' = z-level (fixed depth levels)
-                                 !   'zstar'  = z-star (terrain-following with SSH scaling)
+                                  !   'linfs'  = linear free surface
+                                  !   'zlevel' = z-level (fixed depth levels)
+                                  !   'zstar'  = z-star (terrain-following with SSH scaling)
 use_partial_cell   = .false.     ! use partial bottom cells for better topography representation (not recommended)
 /
 
@@ -87,14 +87,14 @@ force_rotation  = .false.        ! force grid rotation even if not coupled
 alphaEuler      = 50.            ! first Euler angle (rotation around z-axis) [degrees]
 betaEuler       = 15.            ! second Euler angle (rotation around new x-axis) [degrees]
 gammaEuler      = -90.           ! third Euler angle (rotation around new z-axis) [degrees]
-                                 ! Euler angle convention: rotate first around z, then around new x, then around new z
+                                  ! Euler angle convention: rotate first around z, then around new x, then around new z
 /
 
 ! ============================================================================
 ! CALENDAR SETTINGS
 ! ============================================================================
 &calendar
-include_fleapyear = .false.       ! include leap years in calendar (false = 365-day year, true = 365/366-day year)
+include_fleapyear = .false.      ! include leap years in calendar (false = 365-day year, true = 365/366-day year)
 /
 
 ! ============================================================================
@@ -133,4 +133,3 @@ use_icebergs          = .false.  ! enable iceberg module
 steps_per_ib_step     = 8        ! ocean time steps per iceberg time step (iceberg subcycling)
 ib_async_mode         = 0        ! iceberg asynchronous mode (0=synchronous, 1=asynchronous)
 /
-

--- a/config/namelist.dyn.toy_dbgyre
+++ b/config/namelist.dyn.toy_dbgyre
@@ -14,7 +14,7 @@
 ! HORIZONTAL VISCOSITY
 ! ============================================================================
 &dynamics_visc
-! --- Viscosity Coefficients ---
+! --- Biharmonic Viscosity Coefficients ---
 visc_gamma0        = 0.005       ! background viscosity coefficient [m/s]
                                  ! viscosity = gamma0 × element_length
                                  ! keep < 0.01 m/s for numerical stability
@@ -28,6 +28,7 @@ opt_visc           = 5           ! horizontal viscosity scheme:
                                  !   5 = Kinematic (easy) Backscatter
                                  !   6 = Biharmonic flow-aware (depends on velocity Laplacian)
                                  !   7 = Biharmonic flow-aware (depends on velocity differences)
+                                 !       + optional Laplacian when visc_gamma0_h or visc_gamma1_h > 0
                                  !   8 = Dynamic Backscatter
 check_opt_visc     = .false.     ! check if opt_visc=5 is valid based on resolution/Rossby radius ratio
 

--- a/config/namelist.dyn.toy_neverworld2
+++ b/config/namelist.dyn.toy_neverworld2
@@ -14,7 +14,7 @@
 ! HORIZONTAL VISCOSITY
 ! ============================================================================
 &dynamics_visc
-! --- Viscosity Coefficients ---
+! --- Biharmonic Viscosity Coefficients ---
 visc_gamma0        = 0.005       ! background viscosity coefficient [m/s]
                                  ! viscosity = gamma0 × element_length
                                  ! keep < 0.01 m/s for numerical stability
@@ -28,6 +28,7 @@ opt_visc           = 5           ! horizontal viscosity scheme:
                                  !   5 = Kinematic (easy) Backscatter
                                  !   6 = Biharmonic flow-aware (depends on velocity Laplacian)
                                  !   7 = Biharmonic flow-aware (depends on velocity differences)
+                                 !       + optional Laplacian when visc_gamma0_h or visc_gamma1_h > 0
                                  !   8 = Dynamic Backscatter
 check_opt_visc     = .false.     ! check if opt_visc=5 is valid based on resolution/Rossby radius ratio
 

--- a/config/namelist.forcing
+++ b/config/namelist.forcing
@@ -97,23 +97,23 @@ age_start_year    = 2000     ! year to start age tracer (tracer age = 0 at this 
    nm_snow_file  = 'prsn.'       ! name of file with snow precipitation
 
    ! --- Variable names in netCDF forcing files ---
-   nm_xwind_var  = 'uas'      ! name of variable in file with wind
-   nm_ywind_var  = 'vas'      ! name of variable in file with wind
-   nm_xstre_var  = 'uas'      ! name of variable in file with wind
-   nm_ystre_var  = 'vas'      ! name of variable in file with wind
+   nm_xwind_var  = 'uas'      ! name of variable in file with zonal wind
+   nm_ywind_var  = 'vas'      ! name of variable in file with meridional wind
+   nm_xstre_var  = 'uas'      ! name of variable in file with zonal wind stress
+   nm_ystre_var  = 'vas'      ! name of variable in file with meridional wind stress
    nm_humi_var   = 'huss'     ! name of variable in file with humidity
    nm_qsr_var    = 'rsds'     ! name of variable in file with solar heat
    nm_qlw_var    = 'rlds'     ! name of variable in file with long wave
    nm_tair_var   = 'tas'      ! name of variable in file with 2m air temperature
    nm_prec_var   = 'prra'     ! name of variable in file with total precipitation
-   nm_snow_var   = 'prsn'     ! name of variable in file with total precipitation
+   nm_snow_var   = 'prsn'     ! name of variable in file with snow precipitation
    nm_mslp_var   = 'psl'      ! name of variable in file with air_pressure_at_sea_level
 
    ! --- Time axis configuration in forcing files ---
    nm_nc_iyear   = 1900       ! initial year of forcing data time axis (note, not the first year in the file!)
    nm_nc_imm     = 1          ! initial month of forcing data time axis (1-12)
    nm_nc_idd     = 1          ! initial day of forcing data time axis (1-31)
-   nm_nc_freq    = 1          ! do not touch! (number of data points per day (1=daily, 4=6-hourly, etc.))
+   nm_nc_freq    = 1          ! divisor converting the time axis of the forcing files to days (1 = days, 24 = hours, 86400 = seconds)
    nm_nc_tmid    = 0          ! time stamp position: 1=mid-point, 0=start of interval
    y_perpetual   = .false.    ! use perpetual year forcing (repeat single year)
 

--- a/config/namelist.forcing.CORE2
+++ b/config/namelist.forcing.CORE2
@@ -1,87 +1,149 @@
-! This is the namelist file for forcing
-!
-! File names below are relative to ForcingDataPath in namelist.config, which
-! for this setup should point at the CORE2 forcing directory. A name starting
-! with '/' is used as given.
+! ============================================================================
+! ============= Namelist file for FESOM2 atmospheric forcing ================
+! ============================================================================
+! This file contains configuration for atmospheric forcing and surface boundary
+! conditions, including:
+! - Bulk formulae exchange coefficients (heat, momentum, moisture)
+! - Bulk formulae options and reference heights
+! - Land ice freshwater forcing
+! - Age tracer configuration
+! - Surface forcing data files and variables
+! - Runoff and salinity restoring
+! - Chlorophyll data for shortwave penetration
+! For this setup ForcingDataPath should point at the CORE2 forcing directory.
+! ============================================================================
+! ----------------------------------------------------------------------------
+! File names below are relative to ForcingDataPath in namelist.config. A name
+! starting with '/' is used as given, which is how files outside the forcing
+! tree (for example the Sweeney chlorophyll climatology) are pointed at.
+! ----------------------------------------------------------------------------
 
+! ============================================================================
+! BULK FORMULAE EXCHANGE COEFFICIENTS
+! ============================================================================
+! These coefficients control the turbulent exchange of heat, moisture, and
+! momentum between the atmosphere and ocean/ice surfaces.
+! ============================================================================
 &forcing_exchange_coeff
-Ce_atm_oce=0.00175 ! exchange coeff. of latent heat over open water
-Ch_atm_oce=0.00175 ! exchange coeff. of sensible heat over open water
-Cd_atm_oce=0.001  ! drag coefficient between atmosphere and water
-Ce_atm_ice=0.00175 ! exchange coeff. of latent heat over ice
-Ch_atm_ice=0.00175 ! exchange coeff. of sensible heat over ice
-Cd_atm_ice=0.0012  ! drag coefficient between atmosphere and ice 
-Swind     =0.0     ! parameterization for coupled current feedback
+Ce_atm_oce = 0.00175    ! exchange coefficient of latent heat over open water (dimensionless)
+Ch_atm_oce = 0.00175    ! exchange coefficient of sensible heat over open water (dimensionless)
+Cd_atm_oce = 0.001      ! drag coefficient between atmosphere and water (dimensionless)
+Ce_atm_ice = 0.00175    ! exchange coefficient of latent heat over ice (dimensionless)
+Ch_atm_ice = 0.00175    ! exchange coefficient of sensible heat over ice (dimensionless)
+Cd_atm_ice = 0.0012     ! drag coefficient between atmosphere and ice (dimensionless)
+Swind       = 0.0       ! parameterization for coupled current feedback (0.0 = disabled)
+                        ! non-zero values reduce wind stress based on ocean surface currents
 /
 
+! ============================================================================
+! BULK FORMULAE OPTIONS
+! ============================================================================
+! Configuration for bulk formulae calculations (turbulent fluxes).
+! Reference heights must match the forcing data specifications.
+! ============================================================================
 &forcing_bulk
-AOMIP_drag_coeff=.false.
-ncar_bulk_formulae=.true.
-ncar_bulk_z_wind=10.0 ! height at which wind forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-ncar_bulk_z_tair=10.0 ! height at which temp forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-ncar_bulk_z_shum=10.0 ! height at which humi forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-
+AOMIP_drag_coeff  = .false.  ! use AOMIP drag coefficient formulation (false = use standard)
+ncar_bulk_formulae = .true.  ! use NCAR bulk formulae (Large & Yeager 2004, 2009)
+ncar_bulk_z_wind   = 10.0    ! reference height for wind forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_tair   = 10.0    ! reference height for air temperature forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_shum   = 10.0    ! reference height for specific humidity forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
 /
 
+! ============================================================================
+! LAND ICE FRESHWATER FORCING
+! ============================================================================
+! Configuration for freshwater input from land ice (glaciers, ice sheets).
+! Requires use_landice_water=.true. in namelist.config to enable output.
+! ============================================================================
 &land_ice
-use_landice_water=.false.
-landice_start_mon=5
-landice_end_mon=10
-fwf_path='./mesh/'
-
+use_landice_water = .false.  ! enable land ice freshwater forcing
+landice_start_mon = 5        ! start month for land ice forcing (1-12)
+landice_end_mon   = 10       ! end month for land ice forcing (1-12)
+fwf_path          = './mesh/'    ! path to land ice freshwater flux data files
 /
 
+! ============================================================================
+! AGE TRACER CONFIGURATION
+! ============================================================================
+! Configuration for passive age tracer (tracks water mass age).
+! Requires use_age_tracer=.true. in namelist.config to enable output.
+! ============================================================================
 &age_tracer
-use_age_tracer=.false.
-use_age_mask=.false.
-age_tracer_path='./mesh/'
-age_start_year=2000
-
+use_age_tracer    = .false.  ! enable age tracer computation
+use_age_mask      = .false.  ! use spatial mask for age tracer initialization
+age_tracer_path   = './mesh/'    ! path to age tracer mask file (if use_age_mask=.true.)
+age_start_year    = 2000     ! year to start age tracer (tracer age = 0 at this year)
 /
 
+! ============================================================================
+! SURFACE BOUNDARY CONDITION (FORCING DATA)
+! ============================================================================
+! Specification of atmospheric forcing data files and variables.
+! File paths are relative to the run directory.
+! ============================================================================
 &nam_sbc
-   nm_xwind_file = 'u_10.'        ! name of file with winds
-   nm_ywind_file = 'v_10.'        ! name of file with winds
-   nm_humi_file  = 'q_10.'        ! name of file with humidity
-   nm_qsr_file   = 'ncar_rad.'    ! name of file with solar heat
-   nm_qlw_file   = 'ncar_rad.'    ! name of file with Long wave
-   nm_tair_file  = 't_10.'        ! name of file with 2m air temperature
+   ! --- Forcing file paths ---
+   nm_xwind_file = 'u_10.'       ! name of file with zonal wind speeds
+   nm_ywind_file = 'v_10.'       ! name of file with meridional wind speeds
+   nm_humi_file  = 'q_10.'       ! name of file with air humidity
+   nm_qsr_file   = 'ncar_rad.'   ! name of file with short wave radiation
+   nm_qlw_file   = 'ncar_rad.'   ! name of file with long wave radiation
+   nm_tair_file  = 't_10.'       ! name of file with 2m air temperature
    nm_prec_file  = 'ncar_precip.' ! name of file with total precipitation
    nm_snow_file  = 'ncar_precip.' ! name of file with snow precipitation
    nm_mslp_file  = 'slp.'         ! air_pressure_at_sea_level
-   nm_xwind_var  = 'U_10_MOD'   ! name of variable in file with wind
-   nm_ywind_var  = 'V_10_MOD'   ! name of variable in file with wind
-   nm_humi_var   = 'Q_10_MOD'   ! name of variable in file with humidity
-   nm_qsr_var    = 'SWDN_MOD'   ! name of variable in file with solar heat
-   nm_qlw_var    = 'LWDN_MOD'   ! name of variable in file with Long wave
-   nm_tair_var   = 'T_10_MOD'   ! name of variable in file with 2m air temperature
-   nm_prec_var   = 'RAIN'       ! name of variable in file with total precipitation
-   nm_snow_var   = 'SNOW'       ! name of variable in file with total precipitation
-   nm_mslp_var   = 'SLP'        ! name of variable in file with air_pressure_at_sea_level
-   nm_nc_iyear   = 1948
-   nm_nc_imm     = 1            ! initial month of time axis in netCDF
-   nm_nc_idd     = 1            ! initial day of time axis in netCDF
-   nm_nc_freq    = 1            ! data points per day
-   nm_nc_tmid    = 1            ! 1 if the time stamps are given at the mid points
-   y_perpetual   = .false.
-   l_xwind=.true.
-   l_ywind=.true.
-   l_humi=.true.
-   l_qsr=.true.
-   l_qlw=.true.
-   l_tair=.true.
-   l_prec=.true.
-   l_mslp=.false.
-   l_cloud=.false.
-   l_snow=.true.
-   runoff_data_source ='CORE2'  !Dai09, CORE2
-   nm_runoff_file     ='runoff.nc'
-   sss_data_source    ='CORE2'
-   nm_sss_data_file   ='PHC2_salx.nc'
-   chl_data_source    ='None' !'Sweeney' monthly chlorophyll climatology or 'NONE' for constant chl_const (below). Make use_sw_pene=.TRUE. in namelist.config!
-   nm_chl_data_file   ='/pool/data/AWICM/FESOM2/FORCING/Sweeney/Sweeney_2005.nc'
-   chl_const          = 0.1
-   use_runoff_mapper  = .FALSE.
-   runoff_basins_file = 'runoff_maps_regular.nc'
-   runoff_radius      = 500000.
+
+   ! --- Variable names in netCDF forcing files ---
+   nm_xwind_var  = 'U_10_MOD' ! name of variable in file with zonal wind
+   nm_ywind_var  = 'V_10_MOD' ! name of variable in file with meridional wind
+   nm_humi_var   = 'Q_10_MOD' ! name of variable in file with humidity
+   nm_qsr_var    = 'SWDN_MOD' ! name of variable in file with solar heat
+   nm_qlw_var    = 'LWDN_MOD' ! name of variable in file with long wave
+   nm_tair_var   = 'T_10_MOD' ! name of variable in file with 2m air temperature
+   nm_prec_var   = 'RAIN'     ! name of variable in file with total precipitation
+   nm_snow_var   = 'SNOW'     ! name of variable in file with snow precipitation
+   nm_mslp_var   = 'SLP'      ! name of variable in file with air_pressure_at_sea_level
+
+   ! --- Time axis configuration in forcing files ---
+   nm_nc_iyear   = 1948       ! initial year of forcing data time axis (note, not the first year in the file!)
+   nm_nc_imm     = 1          ! initial month of forcing data time axis (1-12)
+   nm_nc_idd     = 1          ! initial day of forcing data time axis (1-31)
+   nm_nc_freq    = 1          ! divisor converting the time axis of the forcing files to days (1 = days, 24 = hours, 86400 = seconds)
+   nm_nc_tmid    = 1          ! time stamp position: 1=mid-point, 0=start of interval
+   y_perpetual   = .false.    ! use perpetual year forcing (repeat single year)
+
+   ! --- Enable/disable individual forcing fields ---
+   l_xwind       = .true.     ! use zonal wind forcing
+   l_ywind       = .true.     ! use meridional wind forcing
+   l_humi        = .true.     ! use specific humidity forcing
+   l_qsr         = .true.     ! use shortwave radiation forcing
+   l_qlw         = .true.     ! use longwave radiation forcing
+   l_tair        = .true.     ! use air temperature forcing
+   l_prec        = .true.     ! use precipitation forcing
+   l_mslp        = .false.    ! use mean sea level pressure forcing
+   l_cloud       = .false.    ! use cloud cover forcing
+   l_snow        = .true.     ! use snow precipitation forcing
+
+   ! --- Runoff configuration ---
+   runoff_data_source = 'CORE2'       ! runoff data source: 'Dai09', 'JRA55', 'CORE1', 'CORE2' or 'NONE'
+   nm_runoff_file     = 'runoff.nc'        ! CORE2 monthly climatology with runoff_climatology=.true.
+   !nm_runoff_file     = 'friver.'  ! Dai09/JRA55 with runoff_climatology=.false.: prefix, year and '.nc' are appended (friver.1958.nc).
+
+   ! --- Sea surface salinity restoring ---
+   sss_data_source  = 'CORE2'  ! SSS restoring data source: 'CORE2', 'WOA', or 'NONE'
+   nm_sss_data_file = 'PHC2_salx.nc'  ! path to SSS restoring data file, e.g. PHC2_salx.nc
+
+   ! --- Chlorophyll data for shortwave penetration ---
+   chl_data_source  = 'None'      ! chlorophyll data source: 'Sweeney' (monthly climatology) or 'None' (constant)
+                               ! requires use_sw_pene=.true. in namelist.config
+   nm_chl_data_file = '/pool/data/AWICM/FESOM2/FORCING/Sweeney/Sweeney_2005.nc'  ! chlorophyll data file (if Sweeney)
+   chl_const        = 0.1      ! constant chlorophyll concentration [mg/m³] (if chl_data_source='None')
+
+   ! --- Runoff mapper (distributes runoff over coastal area) ---
+   use_runoff_mapper  = .false.  ! enable runoff mapper (spreads runoff spatially)
+   runoff_basins_file = 'runoff_maps_regular.nc' ! runoff basin mapping file
+   runoff_radius      = 500000.  ! radius for runoff spreading [m] (if use_runoff_mapper=.true.)
 /

--- a/config/namelist.forcing.JRA
+++ b/config/namelist.forcing.JRA
@@ -1,84 +1,157 @@
-! This is the namelist file for forcing
+! ============================================================================
+! ============= Namelist file for FESOM2 atmospheric forcing ================
+! ============================================================================
+! This file contains configuration for atmospheric forcing and surface boundary
+! conditions, including:
+! - Bulk formulae exchange coefficients (heat, momentum, moisture)
+! - Bulk formulae options and reference heights
+! - Land ice freshwater forcing
+! - Age tracer configuration
+! - Surface forcing data files and variables
+! - Runoff and salinity restoring
+! - Chlorophyll data for shortwave penetration
+! ============================================================================
+! ----------------------------------------------------------------------------
+! File names below are relative to ForcingDataPath in namelist.config. A name
+! starting with '/' is used as given, which is how files outside the forcing
+! tree (for example the Sweeney chlorophyll climatology) are pointed at.
+! ----------------------------------------------------------------------------
 
+! ============================================================================
+! BULK FORMULAE EXCHANGE COEFFICIENTS
+! ============================================================================
+! These coefficients control the turbulent exchange of heat, moisture, and
+! momentum between the atmosphere and ocean/ice surfaces.
+! ============================================================================
 &forcing_exchange_coeff
-Ce_atm_oce=0.00175 ! exchange coeff. of latent heat over open water
-Ch_atm_oce=0.00175 ! exchange coeff. of sensible heat over open water
-Cd_atm_oce=0.001  ! drag coefficient between atmosphere and water
-Ce_atm_ice=0.00175 ! exchange coeff. of latent heat over ice
-Ch_atm_ice=0.00175 ! exchange coeff. of sensible heat over ice
-Cd_atm_ice=0.0012  ! drag coefficient between atmosphere and ice 
-Swind     =0.0     ! parameterization for coupled current feedback
+Ce_atm_oce = 0.00175    ! exchange coefficient of latent heat over open water (dimensionless)
+Ch_atm_oce = 0.00175    ! exchange coefficient of sensible heat over open water (dimensionless)
+Cd_atm_oce = 0.001      ! drag coefficient between atmosphere and water (dimensionless)
+Ce_atm_ice = 0.00175    ! exchange coefficient of latent heat over ice (dimensionless)
+Ch_atm_ice = 0.00175    ! exchange coefficient of sensible heat over ice (dimensionless)
+Cd_atm_ice = 0.0012     ! drag coefficient between atmosphere and ice (dimensionless)
+Swind       = 0.0       ! parameterization for coupled current feedback (0.0 = disabled)
+                        ! non-zero values reduce wind stress based on ocean surface currents
 /
 
+! ============================================================================
+! BULK FORMULAE OPTIONS
+! ============================================================================
+! Configuration for bulk formulae calculations (turbulent fluxes).
+! Reference heights must match the forcing data specifications.
+! ============================================================================
 &forcing_bulk
-AOMIP_drag_coeff=.false.
-ncar_bulk_formulae=.true.
-ncar_bulk_z_wind=10.0 ! height at which wind forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-ncar_bulk_z_tair=10.0 ! height at which temp forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-ncar_bulk_z_shum=10.0 ! height at which humi forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-
+AOMIP_drag_coeff  = .false.  ! use AOMIP drag coefficient formulation (false = use standard)
+ncar_bulk_formulae = .true.  ! use NCAR bulk formulae (Large & Yeager 2004, 2009)
+ncar_bulk_z_wind   = 10.0    ! reference height for wind forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_tair   = 10.0    ! reference height for air temperature forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_shum   = 10.0    ! reference height for specific humidity forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
 /
 
+! ============================================================================
+! LAND ICE FRESHWATER FORCING
+! ============================================================================
+! Configuration for freshwater input from land ice (glaciers, ice sheets).
+! Requires use_landice_water=.true. in namelist.config to enable output.
+! ============================================================================
 &land_ice
-use_landice_water=.false.
-landice_start_mon=5
-landice_end_mon=10
-fwf_path='./mesh/'
-
+use_landice_water = .false.  ! enable land ice freshwater forcing
+landice_start_mon = 5        ! start month for land ice forcing (1-12)
+landice_end_mon   = 10       ! end month for land ice forcing (1-12)
+fwf_path          = './mesh/'    ! path to land ice freshwater flux data files
 /
 
+! ============================================================================
+! AGE TRACER CONFIGURATION
+! ============================================================================
+! Configuration for passive age tracer (tracks water mass age).
+! Requires use_age_tracer=.true. in namelist.config to enable output.
+! ============================================================================
 &age_tracer
-use_age_tracer=.false.
-use_age_mask=.false.
-age_tracer_path='./mesh/'
-age_start_year=2000
-
+use_age_tracer    = .false.  ! enable age tracer computation
+use_age_mask      = .false.  ! use spatial mask for age tracer initialization
+age_tracer_path   = './mesh/'    ! path to age tracer mask file (if use_age_mask=.true.)
+age_start_year    = 2000     ! year to start age tracer (tracer age = 0 at this year)
 /
 
+! ============================================================================
+! SURFACE BOUNDARY CONDITION (FORCING DATA)
+! ============================================================================
+! Specification of atmospheric forcing data files and variables.
+! File paths are relative to the run directory.
+! ============================================================================
 &nam_sbc
-   nm_xwind_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/uas.'        ! name of file with wind speeds x
-   nm_ywind_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/vas.'        ! name of file with wind speeds y
-   nm_xstre_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/uas.'        ! name of file with wind stress x
-   nm_ystre_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/vas.'        ! name of file with wind stress y
-   nm_humi_file  = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/huss.'        ! name of file with humidity
-   nm_qsr_file   = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/rsds.'    ! name of file with solar heat
-   nm_qlw_file   = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/rlds.'    ! name of file with Long wave
-   nm_tair_file  = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/tas.'        ! name of file with 2m air temperature
+   ! --- Forcing file paths ---
+   nm_xwind_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/uas.' ! name of file with zonal wind speeds
+   nm_ywind_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/vas.' ! name of file with meridional wind speeds
+   nm_xstre_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/uas.' ! name of file with zonal wind stress
+   nm_ystre_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/vas.' ! name of file with meridional wind stress
+   nm_humi_file  = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/huss.' ! name of file with air humidity
+   nm_qsr_file   = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/rsds.' ! name of file with short wave radiation
+   nm_qlw_file   = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/rlds.' ! name of file with long wave radiation
+   nm_tair_file  = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/tas.' ! name of file with 2m air temperature
    nm_prec_file  = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/prra.' ! name of file with total precipitation
-   nm_snow_file  = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/prsn.' ! name of file with snow  precipitation
+   nm_snow_file  = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/prsn.' ! name of file with snow precipitation
    nm_mslp_file  = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/psl.'         ! air_pressure_at_sea_level
-   nm_xwind_var  = 'uas'   ! name of variable in file with wind
-   nm_ywind_var  = 'vas'   ! name of variable in file with wind
-   nm_xstre_var  = 'uas'   ! name of variable in file with wind
-   nm_ystre_var  = 'vas'   ! name of variable in file with wind
-   nm_humi_var   = 'huss'  ! name of variable in file with humidity
-   nm_qsr_var    = 'rsds'  ! name of variable in file with solar heat
-   nm_qlw_var    = 'rlds'  ! name of variable in file with Long wave
-   nm_tair_var   = 'tas'   ! name of variable in file with 2m air temperature
-   nm_prec_var   = 'prra'  ! name of variable in file with total precipitation
-   nm_snow_var   = 'prsn'  ! name of variable in file with total precipitation
-   nm_mslp_var   = 'psl'   ! name of variable in file with air_pressure_at_sea_level
-   nm_nc_iyear   = 1900
-   nm_nc_imm     = 1            ! initial month of time axis in netCDF 
-   nm_nc_idd     = 1            ! initial day of time axis in netCDF
-   nm_nc_freq    = 1            ! data points per day (i.e. 86400 if the time axis is in seconds)
-   nm_nc_tmid    = 0            ! 1 if the time stamps are given at the mid points of the netcdf file, 0 otherwise (i.e. 1 in CORE1, CORE2; 0 in JRA55)
-   l_xwind=.true. l_ywind=.true. l_xstre=.false. l_ystre=.false. l_humi=.true. l_qsr=.true. l_qlw=.true. l_tair=.true. l_prec=.true. l_mslp=.false. l_cloud=.false. l_snow=.true.
+
+   ! --- Variable names in netCDF forcing files ---
+   nm_xwind_var  = 'uas'      ! name of variable in file with zonal wind
+   nm_ywind_var  = 'vas'      ! name of variable in file with meridional wind
+   nm_xstre_var  = 'uas'      ! name of variable in file with zonal wind stress
+   nm_ystre_var  = 'vas'      ! name of variable in file with meridional wind stress
+   nm_humi_var   = 'huss'     ! name of variable in file with humidity
+   nm_qsr_var    = 'rsds'     ! name of variable in file with solar heat
+   nm_qlw_var    = 'rlds'     ! name of variable in file with long wave
+   nm_tair_var   = 'tas'      ! name of variable in file with 2m air temperature
+   nm_prec_var   = 'prra'     ! name of variable in file with total precipitation
+   nm_snow_var   = 'prsn'     ! name of variable in file with snow precipitation
+   nm_mslp_var   = 'psl'      ! name of variable in file with air_pressure_at_sea_level
+
+   ! --- Time axis configuration in forcing files ---
+   nm_nc_iyear   = 1900       ! initial year of forcing data time axis (note, not the first year in the file!)
+   nm_nc_imm     = 1          ! initial month of forcing data time axis (1-12)
+   nm_nc_idd     = 1          ! initial day of forcing data time axis (1-31)
+   nm_nc_freq    = 1          ! divisor converting the time axis of the forcing files to days (1 = days, 24 = hours, 86400 = seconds)
+   nm_nc_tmid    = 0          ! time stamp position: 1=mid-point, 0=start of interval
+
+   ! --- Enable/disable individual forcing fields ---
+   l_xwind       = .true.     ! use zonal wind forcing
+   l_ystre=.false.
+   l_ywind       = .true.     ! use meridional wind forcing
    use_ocean_only_forcing = .true.
    nm_ocean_mask_file     = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/sftof_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr.nc'
    nm_ocean_mask_var      = 'sftof'
    ocean_mask_threshold   = 90.0
-   runoff_data_source ='CORE2'	!Dai09, CORE2
-   nm_runoff_file     ='/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/CORE2_runoff.nc'
-   !nm_runoff_file     ='/work/ollie/qwang/FESOM2_input/mesh/CORE2_finaltopo_mean/forcing_data_on_grid/runoff_clim.nc'
-   !runoff_data_source ='Dai09'  !Dai09, CORE2, JRA55
-   !runoff_climatology =.true.
-   sss_data_source    ='CORE2'
-   nm_sss_data_file   ='/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/PHC2_salx.nc'
-   chl_data_source    ='None' !'Sweeney' monthly chlorophyll climatology or 'NONE' for constant chl_const (below). Make use_sw_pene=.TRUE. in namelist.config!
-   nm_chl_data_file   ='/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/Sweeney/Sweeney_2005.nc'
-   chl_const          = 0.1
-   use_runoff_mapper  = .FALSE.
-   runoff_basins_file = 'runoff_maps_regular.nc'
-   runoff_radius      = 500000.
+   l_humi        = .true.     ! use specific humidity forcing
+   l_qsr         = .true.     ! use shortwave radiation forcing
+   l_qlw         = .true.     ! use longwave radiation forcing
+   l_tair        = .true.     ! use air temperature forcing
+   l_xstre=.false.
+   l_prec        = .true.     ! use precipitation forcing
+   l_mslp        = .false.    ! use mean sea level pressure forcing
+   l_cloud       = .false.    ! use cloud cover forcing
+   l_snow        = .true.     ! use snow precipitation forcing
+
+   ! --- Runoff configuration ---
+   runoff_data_source = 'CORE2'       ! runoff data source: 'Dai09', 'JRA55', 'CORE1', 'CORE2' or 'NONE'
+   nm_runoff_file     = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/CORE2_runoff.nc' ! CORE2 monthly climatology with runoff_climatology=.true.
+   !nm_runoff_file     = 'friver.'  ! Dai09/JRA55 with runoff_climatology=.false.: prefix, year and '.nc' are appended (friver.1958.nc).
+
+   ! --- Sea surface salinity restoring ---
+   sss_data_source  = 'CORE2'  ! SSS restoring data source: 'CORE2', 'WOA', or 'NONE'
+   nm_sss_data_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/PHC2_salx.nc' ! path to SSS restoring data file, e.g. PHC2_salx.nc
+
+   ! --- Chlorophyll data for shortwave penetration ---
+   chl_data_source  = 'None'      ! chlorophyll data source: 'Sweeney' (monthly climatology) or 'None' (constant)
+                               ! requires use_sw_pene=.true. in namelist.config
+   nm_chl_data_file = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/Sweeney/Sweeney_2005.nc' ! chlorophyll data file (if Sweeney)
+   chl_const        = 0.1      ! constant chlorophyll concentration [mg/m³] (if chl_data_source='None')
+
+   ! --- Runoff mapper (distributes runoff over coastal area) ---
+   use_runoff_mapper  = .false.  ! enable runoff mapper (spreads runoff spatially)
+   runoff_basins_file = 'runoff_maps_regular.nc' ! runoff basin mapping file
+   runoff_radius      = 500000.  ! radius for runoff spreading [m] (if use_runoff_mapper=.true.)
 /

--- a/config/namelist.forcing.era5
+++ b/config/namelist.forcing.era5
@@ -1,58 +1,122 @@
-! This is the namelist file for forcing
+! ============================================================================
+! ============= Namelist file for FESOM2 atmospheric forcing ================
+! ============================================================================
+! This file contains configuration for atmospheric forcing and surface boundary
+! conditions, including:
+! - Bulk formulae exchange coefficients (heat, momentum, moisture)
+! - Bulk formulae options and reference heights
+! - Land ice freshwater forcing
+! - Age tracer configuration
+! - Surface forcing data files and variables
+! - Runoff and salinity restoring
+! - Chlorophyll data for shortwave penetration
+! ============================================================================
+! ----------------------------------------------------------------------------
+! File names below are relative to ForcingDataPath in namelist.config. A name
+! starting with '/' is used as given, which is how files outside the forcing
+! tree (for example the Sweeney chlorophyll climatology) are pointed at.
+! ----------------------------------------------------------------------------
 
+! ============================================================================
+! BULK FORMULAE EXCHANGE COEFFICIENTS
+! ============================================================================
+! These coefficients control the turbulent exchange of heat, moisture, and
+! momentum between the atmosphere and ocean/ice surfaces.
+! ============================================================================
 &forcing_exchange_coeff
-Ce_atm_oce=1.75e-3 ! exchange coeff. of latent heat over open water
-Ch_atm_oce=1.75e-3 ! exchange coeff. of sensible heat over open water
-Cd_atm_oce=1.0e-3  ! drag coefficient between atmosphere and water
-Ce_atm_ice=1.75e-3 ! exchange coeff. of latent heat over ice
-Ch_atm_ice=1.75e-3 ! exchange coeff. of sensible heat over ice
-Cd_atm_ice=1.2e-3  ! drag coefficient between atmosphere and ice
-Swind     =0.0     ! parameterization for coupled current feedback
+Ce_atm_oce = 0.00175    ! exchange coefficient of latent heat over open water (dimensionless)
+Ch_atm_oce = 0.00175    ! exchange coefficient of sensible heat over open water (dimensionless)
+Cd_atm_oce = 0.001      ! drag coefficient between atmosphere and water (dimensionless)
+Ce_atm_ice = 0.00175    ! exchange coefficient of latent heat over ice (dimensionless)
+Ch_atm_ice = 0.00175    ! exchange coefficient of sensible heat over ice (dimensionless)
+Cd_atm_ice = 0.0012     ! drag coefficient between atmosphere and ice (dimensionless)
+Swind       = 0.0       ! parameterization for coupled current feedback (0.0 = disabled)
+                        ! non-zero values reduce wind stress based on ocean surface currents
 /
 
+! ============================================================================
+! BULK FORMULAE OPTIONS
+! ============================================================================
+! Configuration for bulk formulae calculations (turbulent fluxes).
+! Reference heights must match the forcing data specifications.
+! ============================================================================
 &forcing_bulk
-AOMIP_drag_coeff=.false.
-ncar_bulk_formulae=.true.
-ncar_bulk_z_wind=10.0 ! height at which wind forcing is located (CORE:10m, JRA:2m)
-ncar_bulk_z_tair=2.0  ! height at which temp forcing is located (CORE:10m, JRA:2m)
-ncar_bulk_z_shum=2.0  ! height at which humi forcing is located (CORE:10m, JRA:2m)
-
+AOMIP_drag_coeff  = .false.  ! use AOMIP drag coefficient formulation (false = use standard)
+ncar_bulk_formulae = .true.  ! use NCAR bulk formulae (Large & Yeager 2004, 2009)
+ncar_bulk_z_wind   = 10.0    ! reference height for wind forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_tair   = 2.0     ! reference height for air temperature forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_shum   = 2.0     ! reference height for specific humidity forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
 /
 
+! ============================================================================
+! LAND ICE FRESHWATER FORCING
+! ============================================================================
+! Configuration for freshwater input from land ice (glaciers, ice sheets).
+! Requires use_landice_water=.true. in namelist.config to enable output.
+! ============================================================================
 &land_ice
-use_landice_water=.false.
-landice_start_mon=5
-landice_end_mon=10
+use_landice_water = .false.  ! enable land ice freshwater forcing
+landice_start_mon = 5        ! start month for land ice forcing (1-12)
+landice_end_mon   = 10       ! end month for land ice forcing (1-12)
 /
 
+! ============================================================================
+! SURFACE BOUNDARY CONDITION (FORCING DATA)
+! ============================================================================
+! Specification of atmospheric forcing data files and variables.
+! File paths are relative to the run directory.
+! ============================================================================
 &nam_sbc
-   nm_xwind_file = '/mnt/lustre01/work/ba1138/a270099/era5/forcing/inverted/u.'         ! name of file with winds, if nm_sbc=2
-   nm_ywind_file = '/mnt/lustre01/work/ba1138/a270099/era5/forcing/inverted/v.'         ! name of file with winds, if nm_sbc=2
-   nm_humi_file  = '/mnt/lustre01/work/ba1138/a270099/era5/forcing/inverted/q.'         ! name of file with humidity
-   nm_qsr_file   = '/mnt/lustre01/work/ba1138/a270099/era5/forcing/inverted/ssrd.'      ! name of file with solar heat
-   nm_qlw_file   = '/mnt/lustre01/work/ba1138/a270099/era5/forcing/inverted/strd.'      ! name of file with Long wave
-   nm_tair_file  = '/mnt/lustre01/work/ba1138/a270099/era5/forcing/inverted/t2m.'       ! name of file with 2m air temperature
-   nm_prec_file  = '/mnt/lustre01/work/ba1138/a270099/era5/forcing/inverted/rf.'        ! name of file with total precipitation
-   nm_snow_file  = '/mnt/lustre01/work/ba1138/a270099/era5/forcing/inverted/sf.'        ! name of file with snow  precipitation
+   ! --- Forcing file paths ---
+   nm_xwind_file = '/mnt/lustre01/work/ba1138/a270099/era5/forcing/inverted/u.' ! name of file with zonal wind speeds
+   nm_ywind_file = '/mnt/lustre01/work/ba1138/a270099/era5/forcing/inverted/v.' ! name of file with meridional wind speeds
+   nm_humi_file  = '/mnt/lustre01/work/ba1138/a270099/era5/forcing/inverted/q.' ! name of file with air humidity
+   nm_qsr_file   = '/mnt/lustre01/work/ba1138/a270099/era5/forcing/inverted/ssrd.' ! name of file with short wave radiation
+   nm_qlw_file   = '/mnt/lustre01/work/ba1138/a270099/era5/forcing/inverted/strd.' ! name of file with long wave radiation
+   nm_tair_file  = '/mnt/lustre01/work/ba1138/a270099/era5/forcing/inverted/t2m.' ! name of file with 2m air temperature
+   nm_prec_file  = '/mnt/lustre01/work/ba1138/a270099/era5/forcing/inverted/rf.' ! name of file with total precipitation
+   nm_snow_file  = '/mnt/lustre01/work/ba1138/a270099/era5/forcing/inverted/sf.' ! name of file with snow precipitation
    nm_mslp_file  = '/mnt/lustre01/work/ba1138/a270099/era5/forcing/inverted/sp.'        ! air_pressure_at_sea_level
-   nm_xwind_var  = 'u'     ! name of variable in file with wind
-   nm_ywind_var  = 'v'     ! name of variable in file with wind
-   nm_humi_var   = 'q'     ! name of variable in file with humidity
-   nm_qsr_var    = 'ssrd'  ! name of variable in file with solar heat
-   nm_qlw_var    = 'strd'  ! name of variable in file with Long wave
-   nm_tair_var   = 't2m'   ! name of variable in file with 2m air temperature
-   nm_prec_var   = 'rf'    ! name of variable in file with total precipitation
-   nm_snow_var   = 'sf'    ! name of variable in file with total precipitation
-   nm_mslp_var   = 'sp'    ! name of variable in file with air_pressure_at_sea_level
-   nm_nc_iyear   = 1900
-   nm_nc_imm     = 1            ! initial month of time axis in netCDF
-   nm_nc_idd     = 1            ! initial day of time axis in netCDF
-   nm_nc_freq    = 1            ! data points per day (i.e. 86400 if the time axis is in seconds)
-   nm_nc_tmid    = 0            ! 1 if the time stamps are given at the mid points of the netcdf file, 0 otherwise (i.e. 1 in CORE1, CORE2; 0 in JRA55)
-   l_xwind=.true., l_ywind=.true., l_humi=.true., l_qsr=.true., l_qlw=.true., l_tair=.true., l_prec=.true., l_mslp=.false., l_cloud=.false., l_snow=.true.
-   nm_runoff_file     ='/pool/data/AWICM/FESOM2/FORCING/CORE2/runoff.nc'
-   runoff_data_source ='CORE2'  !Dai09, CORE2, JRA55
-   !runoff_climatology =.true. ????
-   nm_sss_data_file   ='/pool/data/AWICM/FESOM2/FORCING/CORE2/PHC2_salx.nc'
-   sss_data_source    ='CORE2'
+
+   ! --- Variable names in netCDF forcing files ---
+   nm_xwind_var  = 'u'        ! name of variable in file with zonal wind
+   nm_ywind_var  = 'v'        ! name of variable in file with meridional wind
+   nm_humi_var   = 'q'        ! name of variable in file with humidity
+   nm_qsr_var    = 'ssrd'     ! name of variable in file with solar heat
+   nm_qlw_var    = 'strd'     ! name of variable in file with long wave
+   nm_tair_var   = 't2m'      ! name of variable in file with 2m air temperature
+   nm_prec_var   = 'rf'       ! name of variable in file with total precipitation
+   nm_snow_var   = 'sf'       ! name of variable in file with snow precipitation
+   nm_mslp_var   = 'sp'       ! name of variable in file with air_pressure_at_sea_level
+
+   ! --- Time axis configuration in forcing files ---
+   nm_nc_iyear   = 1900       ! initial year of forcing data time axis (note, not the first year in the file!)
+   nm_nc_imm     = 1          ! initial month of forcing data time axis (1-12)
+   nm_nc_idd     = 1          ! initial day of forcing data time axis (1-31)
+   nm_nc_freq    = 1          ! divisor converting the time axis of the forcing files to days (1 = days, 24 = hours, 86400 = seconds)
+   nm_nc_tmid    = 0          ! time stamp position: 1=mid-point, 0=start of interval
+
+   ! --- Enable/disable individual forcing fields ---
+   l_xwind       = .true.     ! use zonal wind forcing
+   l_ywind       = .true.     ! use meridional wind forcing
+   l_humi        = .true.     ! use specific humidity forcing
+   l_qsr         = .true.     ! use shortwave radiation forcing
+   l_qlw         = .true.     ! use longwave radiation forcing
+   l_tair        = .true.     ! use air temperature forcing
+   l_prec        = .true.     ! use precipitation forcing
+   l_mslp        = .false.    ! use mean sea level pressure forcing
+   l_cloud       = .false.    ! use cloud cover forcing
+   l_snow        = .true.     ! use snow precipitation forcing
+
+   ! --- Runoff configuration ---
+   runoff_data_source = 'CORE2'       ! runoff data source: 'Dai09', 'JRA55', 'CORE1', 'CORE2' or 'NONE'
+   nm_runoff_file     = '/pool/data/AWICM/FESOM2/FORCING/CORE2/runoff.nc' ! CORE2 monthly climatology with runoff_climatology=.true.
+   !nm_runoff_file     = 'friver.'  ! Dai09/JRA55 with runoff_climatology=.false.: prefix, year and '.nc' are appended (friver.1958.nc).
+
+   ! --- Sea surface salinity restoring ---
+   sss_data_source  = 'CORE2'  ! SSS restoring data source: 'CORE2', 'WOA', or 'NONE'
+   nm_sss_data_file = '/pool/data/AWICM/FESOM2/FORCING/CORE2/PHC2_salx.nc' ! path to SSS restoring data file, e.g. PHC2_salx.nc
 /

--- a/config/namelist.forcing.ncep
+++ b/config/namelist.forcing.ncep
@@ -1,55 +1,105 @@
-/bin/bash: This: cng_exchange_coeff
-Ce_atm_oce=1.75e-3 ! exchange coeff. of latent heat over open water
-Ch_atm_oce=1.75e-3 ! exchange coeff. of sensible heat over open water
-Cd_atm_oce=1.0e-3  ! drag coefficient between atmosphere and water
-Ce_atm_ice=1.75e-3 ! exchange coeff. of latent heat over ice
-Ch_atm_ice=1.75e-3 ! exchange coeff. of sensible heat over ice
-Cd_atm_ice=1.2e-3  ! drag coefficient between atmosphere and ice
-Swind     =0.0     ! parameterization for coupled current feedback
-/
+! ============================================================================
+! ============= Namelist file for FESOM2 atmospheric forcing ================
+! ============================================================================
+! This file contains configuration for atmospheric forcing and surface boundary
+! conditions, including:
+! - Bulk formulae exchange coefficients (heat, momentum, moisture)
+! - Bulk formulae options and reference heights
+! - Land ice freshwater forcing
+! - Age tracer configuration
+! - Surface forcing data files and variables
+! - Runoff and salinity restoring
+! - Chlorophyll data for shortwave penetration
+! ============================================================================
+! ----------------------------------------------------------------------------
+! File names below are relative to ForcingDataPath in namelist.config. A name
+! starting with '/' is used as given, which is how files outside the forcing
+! tree (for example the Sweeney chlorophyll climatology) are pointed at.
+! ----------------------------------------------------------------------------
 
+! ============================================================================
+! BULK FORMULAE OPTIONS
+! ============================================================================
+! Configuration for bulk formulae calculations (turbulent fluxes).
+! Reference heights must match the forcing data specifications.
+! ============================================================================
 &forcing_bulk
-AOMIP_drag_coeff=.false.
-ncar_bulk_formulae=.true.
-ncar_bulk_z_wind=2.0 ! height at which wind forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-ncar_bulk_z_tair=2.0 ! height at which temp forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-ncar_bulk_z_shum=2.0 ! height at which humi forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-
+AOMIP_drag_coeff  = .false.  ! use AOMIP drag coefficient formulation (false = use standard)
+ncar_bulk_formulae = .true.  ! use NCAR bulk formulae (Large & Yeager 2004, 2009)
+ncar_bulk_z_wind   = 2.0     ! reference height for wind forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_tair   = 2.0     ! reference height for air temperature forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_shum   = 2.0     ! reference height for specific humidity forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
 /
 
+! ============================================================================
+! LAND ICE FRESHWATER FORCING
+! ============================================================================
+! Configuration for freshwater input from land ice (glaciers, ice sheets).
+! Requires use_landice_water=.true. in namelist.config to enable output.
+! ============================================================================
 &land_ice
-use_landice_water=.false.
-landice_start_mon=5
-landice_end_mon=10
+use_landice_water = .false.  ! enable land ice freshwater forcing
+landice_start_mon = 5        ! start month for land ice forcing (1-12)
+landice_end_mon   = 10       ! end month for land ice forcing (1-12)
 /
 
+! ============================================================================
+! SURFACE BOUNDARY CONDITION (FORCING DATA)
+! ============================================================================
+! Specification of atmospheric forcing data files and variables.
+! File paths are relative to the run directory.
+! ============================================================================
 &nam_sbc
-   nm_xwind_file = '/mnt/lustre01/work/ba1138/a270099/ncep/forcing/UGRD_10maboveground.flxf06.gdas.'        ! name of file with winds, if nm_sbc=2
-   nm_ywind_file = '/mnt/lustre01/work/ba1138/a270099/ncep/forcing/VGRD_10maboveground.flxf06.gdas.'        ! name of file with winds, if nm_sbc=2
-   nm_humi_file  = '/mnt/lustre01/work/ba1138/a270099/ncep/forcing/SPFH_2maboveground.flxf06.gdas.'         ! name of file with 2m specific humidity
-   nm_qsr_file   = '/mnt/lustre01/work/ba1138/a270099/ncep/forcing/DSWRF_surface.flxf06.gdas.'              ! name of file with solar heat
-   nm_qlw_file   = '/mnt/lustre01/work/ba1138/a270099/ncep/forcing/DLWRF_surface.flxf06.gdas.'              ! name of file with Long wave
-   nm_tair_file  = '/mnt/lustre01/work/ba1138/a270099/ncep/forcing/TMP_2maboveground.flxf06.gdas.'          ! name of file with 2m air temperature
-   nm_prec_file  = '/mnt/lustre01/work/ba1138/a270099/ncep/forcing/RRATE_surface.flxf06.gdas.'              ! name of file with rain fall
-   nm_snow_file  = '/mnt/lustre01/work/ba1138/a270099/ncep/forcing/SRATE_surface.flxf06.gdas.'              ! name of file with snow fall
+   ! --- Forcing file paths ---
+   nm_xwind_file = '/mnt/lustre01/work/ba1138/a270099/ncep/forcing/UGRD_10maboveground.flxf06.gdas.' ! name of file with zonal wind speeds
+   nm_ywind_file = '/mnt/lustre01/work/ba1138/a270099/ncep/forcing/VGRD_10maboveground.flxf06.gdas.' ! name of file with meridional wind speeds
+   nm_humi_file  = '/mnt/lustre01/work/ba1138/a270099/ncep/forcing/SPFH_2maboveground.flxf06.gdas.' ! name of file with air humidity
+   nm_qsr_file   = '/mnt/lustre01/work/ba1138/a270099/ncep/forcing/DSWRF_surface.flxf06.gdas.' ! name of file with short wave radiation
+   nm_qlw_file   = '/mnt/lustre01/work/ba1138/a270099/ncep/forcing/DLWRF_surface.flxf06.gdas.' ! name of file with long wave radiation
+   nm_tair_file  = '/mnt/lustre01/work/ba1138/a270099/ncep/forcing/TMP_2maboveground.flxf06.gdas.' ! name of file with 2m air temperature
+   nm_prec_file  = '/mnt/lustre01/work/ba1138/a270099/ncep/forcing/RRATE_surface.flxf06.gdas.' ! name of file with total precipitation
+   nm_snow_file  = '/mnt/lustre01/work/ba1138/a270099/ncep/forcing/SRATE_surface.flxf06.gdas.' ! name of file with snow precipitation
    nm_mslp_file  = '/work/ollie/fkauker/fesom2/cfsr/'                                        ! air_pressure_at_sea_level
-   nm_xwind_var  = 'UGRD_10maboveground'   ! name of variable in file with wind
-   nm_ywind_var  = 'VGRD_10maboveground'   ! name of variable in file with wind
-   nm_humi_var   = 'SPFH_2maboveground'    ! name of variable in file with humidity
-   nm_qsr_var    = 'DSWRF_surface'         ! name of variable in file with solar heat
-   nm_qlw_var    = 'DLWRF_surface'         ! name of variable in file with Long wave
-   nm_tair_var   = 'TMP_2maboveground'     ! name of variable in file with 2m air temperature
-   nm_prec_var   = 'RRATE_surface'         ! name of variable in file with total precipitation
-   nm_snow_var   = 'SRATE_surface'         ! name of variable in file with total precipitation
-   nm_mslp_var   = ''                      ! name of variable in file with air_pressure_at_sea_level
-   nm_nc_iyear   = 1970
-   nm_nc_imm     = 1            ! initial month of time axis in netCDF
-   nm_nc_idd     = 1            ! initial day of time axis in netCDF
-   nm_nc_freq    = 86400        ! data points per day (i.e. 86400 if the time axis is in seconds)
-   nm_nc_tmid    = 0            ! 1 if the time stamps are given at the mid points of the netcdf file, 0 otherwise (i.e. 1 in CORE1, CORE2; 0 in JRA55)
-   l_xwind=.true., l_ywind=.true., l_humi=.true., l_qsr=.true., l_qlw=.true., l_tair=.true., l_prec=.true., l_mslp=.false., l_cloud=.false., l_snow=.true.
-   nm_runoff_file     ='/pool/data/AWICM/FESOM2/FORCING/CORE2/runoff.nc'
-   runoff_data_source ='CORE2'  !Dai09, CORE2, JRA55
-   nm_sss_data_file   ='/pool/data/AWICM/FESOM2/FORCING/CORE2/PHC2_salx.nc'
-   sss_data_source    ='CORE2'
+
+   ! --- Variable names in netCDF forcing files ---
+   nm_xwind_var  = 'UGRD_10maboveground' ! name of variable in file with zonal wind
+   nm_ywind_var  = 'VGRD_10maboveground' ! name of variable in file with meridional wind
+   nm_humi_var   = 'SPFH_2maboveground' ! name of variable in file with humidity
+   nm_qsr_var    = 'DSWRF_surface' ! name of variable in file with solar heat
+   nm_qlw_var    = 'DLWRF_surface' ! name of variable in file with long wave
+   nm_tair_var   = 'TMP_2maboveground' ! name of variable in file with 2m air temperature
+   nm_prec_var   = 'RRATE_surface' ! name of variable in file with total precipitation
+   nm_snow_var   = 'SRATE_surface' ! name of variable in file with snow precipitation
+   nm_mslp_var   = ''         ! name of variable in file with air_pressure_at_sea_level
+
+   ! --- Time axis configuration in forcing files ---
+   nm_nc_iyear   = 1970       ! initial year of forcing data time axis (note, not the first year in the file!)
+   nm_nc_imm     = 1          ! initial month of forcing data time axis (1-12)
+   nm_nc_idd     = 1          ! initial day of forcing data time axis (1-31)
+   nm_nc_freq    = 86400      ! divisor converting the time axis of the forcing files to days (1 = days, 24 = hours, 86400 = seconds)
+   nm_nc_tmid    = 0          ! time stamp position: 1=mid-point, 0=start of interval
+
+   ! --- Enable/disable individual forcing fields ---
+   l_xwind       = .true.     ! use zonal wind forcing
+   l_ywind       = .true.     ! use meridional wind forcing
+   l_humi        = .true.     ! use specific humidity forcing
+   l_qsr         = .true.     ! use shortwave radiation forcing
+   l_qlw         = .true.     ! use longwave radiation forcing
+   l_tair        = .true.     ! use air temperature forcing
+   l_prec        = .true.     ! use precipitation forcing
+   l_mslp        = .false.    ! use mean sea level pressure forcing
+   l_cloud       = .false.    ! use cloud cover forcing
+   l_snow        = .true.     ! use snow precipitation forcing
+
+   ! --- Runoff configuration ---
+   runoff_data_source = 'CORE2'       ! runoff data source: 'Dai09', 'JRA55', 'CORE1', 'CORE2' or 'NONE'
+   nm_runoff_file     = '/pool/data/AWICM/FESOM2/FORCING/CORE2/runoff.nc' ! CORE2 monthly climatology with runoff_climatology=.true.
+   !nm_runoff_file     = 'friver.'  ! Dai09/JRA55 with runoff_climatology=.false.: prefix, year and '.nc' are appended (friver.1958.nc).
+
+   ! --- Sea surface salinity restoring ---
+   sss_data_source  = 'CORE2'  ! SSS restoring data source: 'CORE2', 'WOA', or 'NONE'
+   nm_sss_data_file = '/pool/data/AWICM/FESOM2/FORCING/CORE2/PHC2_salx.nc' ! path to SSS restoring data file, e.g. PHC2_salx.nc
 /

--- a/config/namelist.forcing.ncep2
+++ b/config/namelist.forcing.ncep2
@@ -1,56 +1,122 @@
-! This is the namelist file for forcing
+! ============================================================================
+! ============= Namelist file for FESOM2 atmospheric forcing ================
+! ============================================================================
+! This file contains configuration for atmospheric forcing and surface boundary
+! conditions, including:
+! - Bulk formulae exchange coefficients (heat, momentum, moisture)
+! - Bulk formulae options and reference heights
+! - Land ice freshwater forcing
+! - Age tracer configuration
+! - Surface forcing data files and variables
+! - Runoff and salinity restoring
+! - Chlorophyll data for shortwave penetration
+! ============================================================================
+! ----------------------------------------------------------------------------
+! File names below are relative to ForcingDataPath in namelist.config. A name
+! starting with '/' is used as given, which is how files outside the forcing
+! tree (for example the Sweeney chlorophyll climatology) are pointed at.
+! ----------------------------------------------------------------------------
 
+! ============================================================================
+! BULK FORMULAE EXCHANGE COEFFICIENTS
+! ============================================================================
+! These coefficients control the turbulent exchange of heat, moisture, and
+! momentum between the atmosphere and ocean/ice surfaces.
+! ============================================================================
 &forcing_exchange_coeff
-Ce_atm_oce=0.00175 ! exchange coeff. of latent heat over open water
-Ch_atm_oce=0.00175 ! exchange coeff. of sensible heat over open water
-Cd_atm_oce=0.001  ! drag coefficient between atmosphere and water
-Ce_atm_ice=0.00175 ! exchange coeff. of latent heat over ice
-Ch_atm_ice=0.00175 ! exchange coeff. of sensible heat over ice
-Cd_atm_ice=0.0012  ! drag coefficient between atmosphere and ice 
-Swind     =0.0     ! parameterization for coupled current feedback
+Ce_atm_oce = 0.00175    ! exchange coefficient of latent heat over open water (dimensionless)
+Ch_atm_oce = 0.00175    ! exchange coefficient of sensible heat over open water (dimensionless)
+Cd_atm_oce = 0.001      ! drag coefficient between atmosphere and water (dimensionless)
+Ce_atm_ice = 0.00175    ! exchange coefficient of latent heat over ice (dimensionless)
+Ch_atm_ice = 0.00175    ! exchange coefficient of sensible heat over ice (dimensionless)
+Cd_atm_ice = 0.0012     ! drag coefficient between atmosphere and ice (dimensionless)
+Swind       = 0.0       ! parameterization for coupled current feedback (0.0 = disabled)
+                        ! non-zero values reduce wind stress based on ocean surface currents
 /
 
+! ============================================================================
+! BULK FORMULAE OPTIONS
+! ============================================================================
+! Configuration for bulk formulae calculations (turbulent fluxes).
+! Reference heights must match the forcing data specifications.
+! ============================================================================
 &forcing_bulk
-AOMIP_drag_coeff=.false.
-ncar_bulk_formulae=.true.
-ncar_bulk_z_wind=10.0 ! height at which wind forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-ncar_bulk_z_tair=2.0 ! height at which temp forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
-ncar_bulk_z_shum=2.0 ! height at which humi forcing is located (CORE, JRA-do: 10m, JRA, NCEP:2m)
+AOMIP_drag_coeff  = .false.  ! use AOMIP drag coefficient formulation (false = use standard)
+ncar_bulk_formulae = .true.  ! use NCAR bulk formulae (Large & Yeager 2004, 2009)
+ncar_bulk_z_wind   = 10.0    ! reference height for wind forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_tair   = 2.0     ! reference height for air temperature forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_shum   = 2.0     ! reference height for specific humidity forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
 /
 
+! ============================================================================
+! LAND ICE FRESHWATER FORCING
+! ============================================================================
+! Configuration for freshwater input from land ice (glaciers, ice sheets).
+! Requires use_landice_water=.true. in namelist.config to enable output.
+! ============================================================================
 &land_ice
-use_landice_water=.false.
-landice_start_mon=5
-landice_end_mon=10
+use_landice_water = .false.  ! enable land ice freshwater forcing
+landice_start_mon = 5        ! start month for land ice forcing (1-12)
+landice_end_mon   = 10       ! end month for land ice forcing (1-12)
 /
 
+! ============================================================================
+! SURFACE BOUNDARY CONDITION (FORCING DATA)
+! ============================================================================
+! Specification of atmospheric forcing data files and variables.
+! File paths are relative to the run directory.
+! ============================================================================
 &nam_sbc
-   nm_xwind_file = '/work/ollie/clidyn/forcing/NCEP2/uwnd.10m.gauss.'   ! name of file with winds, if nm_sbc=2
-   nm_ywind_file = '/work/ollie/clidyn/forcing/NCEP2/vwnd.10m.gauss.'   ! name of file with winds, if nm_sbc=2
-   nm_humi_file  = '/work/ollie/clidyn/forcing/NCEP2/shum.2m.gauss.'    ! name of file with 2m specific humidity
-   nm_qsr_file   = '/work/ollie/clidyn/forcing/NCEP2/dswrf.sfc.gauss.'  ! name of file with solar heat
-   nm_qlw_file   = '/work/ollie/clidyn/forcing/NCEP2/dlwrf.sfc.gauss.'  ! name of file with Long wave
-   nm_tair_file  = '/work/ollie/clidyn/forcing/NCEP2/air.2m.gauss.'     ! name of file with 2m air temperature
-   nm_prec_file  = '/work/ollie/clidyn/forcing/NCEP2/prate.sfc.gauss.'  ! name of file with rain fall
-   nm_snow_file  = ''                                                   ! name of file with snow fall
+   ! --- Forcing file paths ---
+   nm_xwind_file = '/work/ollie/clidyn/forcing/NCEP2/uwnd.10m.gauss.' ! name of file with zonal wind speeds
+   nm_ywind_file = '/work/ollie/clidyn/forcing/NCEP2/vwnd.10m.gauss.' ! name of file with meridional wind speeds
+   nm_humi_file  = '/work/ollie/clidyn/forcing/NCEP2/shum.2m.gauss.' ! name of file with air humidity
+   nm_qsr_file   = '/work/ollie/clidyn/forcing/NCEP2/dswrf.sfc.gauss.' ! name of file with short wave radiation
+   nm_qlw_file   = '/work/ollie/clidyn/forcing/NCEP2/dlwrf.sfc.gauss.' ! name of file with long wave radiation
+   nm_tair_file  = '/work/ollie/clidyn/forcing/NCEP2/air.2m.gauss.' ! name of file with 2m air temperature
+   nm_prec_file  = '/work/ollie/clidyn/forcing/NCEP2/prate.sfc.gauss.' ! name of file with total precipitation
+   nm_snow_file  = ''            ! name of file with snow precipitation
    nm_mslp_file  = ''                                                   ! air_pressure_at_sea_level
-   nm_xwind_var  = 'uwnd'   	! name of variable in file with wind
-   nm_ywind_var  = 'vwnd'   	! name of variable in file with wind
-   nm_humi_var   = 'shum'   	! name of variable in file with humidity
-   nm_qsr_var    = 'dswrf'  	! name of variable in file with solar heat
-   nm_qlw_var    = 'dlwrf'  	! name of variable in file with Long wave
-   nm_tair_var   = 'air'    	! name of variable in file with 2m air temperature
-   nm_prec_var   = 'prate'  	! name of variable in file with total precipitation
-   nm_snow_var   = ''       	! name of variable in file with total precipitation
-   nm_mslp_var   = ''       	! name of variable in file with air_pressure_at_sea_level
-   nm_nc_iyear   = 1800
-   nm_nc_imm     = 1            ! initial month of time axis in netCDF
-   nm_nc_idd     = 1            ! initial day of time axis in netCDF
-   nm_nc_freq    = 24           ! data points per day (i.e. 86400 if the time axis is in seconds)
-   nm_nc_tmid    = 0            ! 1 if the time stamps are given at the mid points of the netcdf file, 0 otherwise (i.e. 1 in CORE1, CORE2; 0 in JRA55)
-   l_xwind=.true., l_ywind=.true., l_humi=.true., l_qsr=.true., l_qlw=.true., l_tair=.true., l_prec=.true., l_mslp=.false., l_cloud=.false., l_snow=.false.
-   nm_runoff_file     ='/work/ollie/clidyn/forcing/JRA55-do-v1.4.0/CORE2_runoff.nc'
-   runoff_data_source ='CORE2'  !Dai09, CORE2, JRA55
-   nm_sss_data_file   ='/work/ollie/clidyn/forcing/JRA55-do-v1.4.0/PHC2_salx.nc'
-   sss_data_source    ='CORE2'
+
+   ! --- Variable names in netCDF forcing files ---
+   nm_xwind_var  = 'uwnd'     ! name of variable in file with zonal wind
+   nm_ywind_var  = 'vwnd'     ! name of variable in file with meridional wind
+   nm_humi_var   = 'shum'     ! name of variable in file with humidity
+   nm_qsr_var    = 'dswrf'    ! name of variable in file with solar heat
+   nm_qlw_var    = 'dlwrf'    ! name of variable in file with long wave
+   nm_tair_var   = 'air'      ! name of variable in file with 2m air temperature
+   nm_prec_var   = 'prate'    ! name of variable in file with total precipitation
+   nm_snow_var   = ''         ! name of variable in file with snow precipitation
+   nm_mslp_var   = ''         ! name of variable in file with air_pressure_at_sea_level
+
+   ! --- Time axis configuration in forcing files ---
+   nm_nc_iyear   = 1800       ! initial year of forcing data time axis (note, not the first year in the file!)
+   nm_nc_imm     = 1          ! initial month of forcing data time axis (1-12)
+   nm_nc_idd     = 1          ! initial day of forcing data time axis (1-31)
+   nm_nc_freq    = 24         ! divisor converting the time axis of the forcing files to days (1 = days, 24 = hours, 86400 = seconds)
+   nm_nc_tmid    = 0          ! time stamp position: 1=mid-point, 0=start of interval
+
+   ! --- Enable/disable individual forcing fields ---
+   l_xwind       = .true.     ! use zonal wind forcing
+   l_ywind       = .true.     ! use meridional wind forcing
+   l_humi        = .true.     ! use specific humidity forcing
+   l_qsr         = .true.     ! use shortwave radiation forcing
+   l_qlw         = .true.     ! use longwave radiation forcing
+   l_tair        = .true.     ! use air temperature forcing
+   l_prec        = .true.     ! use precipitation forcing
+   l_mslp        = .false.    ! use mean sea level pressure forcing
+   l_cloud       = .false.    ! use cloud cover forcing
+   l_snow        = .false.    ! use snow precipitation forcing
+
+   ! --- Runoff configuration ---
+   runoff_data_source = 'CORE2'       ! runoff data source: 'Dai09', 'JRA55', 'CORE1', 'CORE2' or 'NONE'
+   nm_runoff_file     = '/work/ollie/clidyn/forcing/JRA55-do-v1.4.0/CORE2_runoff.nc' ! CORE2 monthly climatology with runoff_climatology=.true.
+   !nm_runoff_file     = 'friver.'  ! Dai09/JRA55 with runoff_climatology=.false.: prefix, year and '.nc' are appended (friver.1958.nc).
+
+   ! --- Sea surface salinity restoring ---
+   sss_data_source  = 'CORE2'  ! SSS restoring data source: 'CORE2', 'WOA', or 'NONE'
+   nm_sss_data_file = '/work/ollie/clidyn/forcing/JRA55-do-v1.4.0/PHC2_salx.nc' ! path to SSS restoring data file, e.g. PHC2_salx.nc
 /

--- a/config/namelist.forcing_COREI
+++ b/config/namelist.forcing_COREI
@@ -1,57 +1,121 @@
-! This is the namelist file for forcing
+! ============================================================================
+! ============= Namelist file for FESOM2 atmospheric forcing ================
+! ============================================================================
+! This file contains configuration for atmospheric forcing and surface boundary
+! conditions, including:
+! - Bulk formulae exchange coefficients (heat, momentum, moisture)
+! - Bulk formulae options and reference heights
+! - Land ice freshwater forcing
+! - Age tracer configuration
+! - Surface forcing data files and variables
+! - Runoff and salinity restoring
+! - Chlorophyll data for shortwave penetration
+! ============================================================================
+! ----------------------------------------------------------------------------
+! File names below are relative to ForcingDataPath in namelist.config. A name
+! starting with '/' is used as given, which is how files outside the forcing
+! tree (for example the Sweeney chlorophyll climatology) are pointed at.
+! ----------------------------------------------------------------------------
 
+! ============================================================================
+! BULK FORMULAE EXCHANGE COEFFICIENTS
+! ============================================================================
+! These coefficients control the turbulent exchange of heat, moisture, and
+! momentum between the atmosphere and ocean/ice surfaces.
+! ============================================================================
 &forcing_exchange_coeff
-Ce_atm_oce=1.75e-3 ! exchange coeff. of latent heat over open water
-Ch_atm_oce=1.75e-3 ! exchange coeff. of sensible heat over open water
-Cd_atm_oce=1.0e-3  ! drag coefficient between atmosphere and water
-Ce_atm_ice=1.75e-3 ! exchange coeff. of latent heat over ice
-Ch_atm_ice=1.75e-3 ! exchange coeff. of sensible heat over ice
-Cd_atm_ice=1.2e-3  ! drag coefficient between atmosphere and ice 
+Ce_atm_oce = 0.00175    ! exchange coefficient of latent heat over open water (dimensionless)
+Ch_atm_oce = 0.00175    ! exchange coefficient of sensible heat over open water (dimensionless)
+Cd_atm_oce = 0.001      ! drag coefficient between atmosphere and water (dimensionless)
+Ce_atm_ice = 0.00175    ! exchange coefficient of latent heat over ice (dimensionless)
+Ch_atm_ice = 0.00175    ! exchange coefficient of sensible heat over ice (dimensionless)
+Cd_atm_ice = 0.0012     ! drag coefficient between atmosphere and ice (dimensionless)
 /
 
+! ============================================================================
+! BULK FORMULAE OPTIONS
+! ============================================================================
+! Configuration for bulk formulae calculations (turbulent fluxes).
+! Reference heights must match the forcing data specifications.
+! ============================================================================
 &forcing_bulk
-AOMIP_drag_coeff=.false.
-ncar_bulk_formulae=.true.
-ncar_bulk_z_wind=10.0 ! height at which wind forcing is located (CORE:10m, JRA:2m)
-ncar_bulk_z_tair=10.0 ! height at which temp forcing is located (CORE:10m, JRA:2m)
-ncar_bulk_z_shum=10.0 ! height at which humi forcing is located (CORE:10m, JRA:2m)
-
+AOMIP_drag_coeff  = .false.  ! use AOMIP drag coefficient formulation (false = use standard)
+ncar_bulk_formulae = .true.  ! use NCAR bulk formulae (Large & Yeager 2004, 2009)
+ncar_bulk_z_wind   = 10.0    ! reference height for wind forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_tair   = 10.0    ! reference height for air temperature forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
+ncar_bulk_z_shum   = 10.0    ! reference height for specific humidity forcing [m]
+                             ! CORE2, JRA55-do: 10m; JRA55, NCEP: 2m
 /
 
+! ============================================================================
+! LAND ICE FRESHWATER FORCING
+! ============================================================================
+! Configuration for freshwater input from land ice (glaciers, ice sheets).
+! Requires use_landice_water=.true. in namelist.config to enable output.
+! ============================================================================
 &land_ice
-use_landice_water=.false.
-landice_start_mon=5
-landice_end_mon=10
+use_landice_water = .false.  ! enable land ice freshwater forcing
+landice_start_mon = 5        ! start month for land ice forcing (1-12)
+landice_end_mon   = 10       ! end month for land ice forcing (1-12)
 /
 
+! ============================================================================
+! SURFACE BOUNDARY CONDITION (FORCING DATA)
+! ============================================================================
+! Specification of atmospheric forcing data files and variables.
+! File paths are relative to the run directory.
+! ============================================================================
 &nam_sbc
-   nm_xwind_file = '/work/ollie/clidyn/forcing/CORE1/u_10'        ! name of file with winds, if nm_sbc=2
-   nm_ywind_file = '/work/ollie/clidyn/forcing/CORE1/v_10'        ! name of file with winds, if nm_sbc=2
-   nm_humi_file  = '/work/ollie/clidyn/forcing/CORE1/q_10'        ! name of file with humidity
-   nm_qsr_file   = '/work/ollie/clidyn/forcing/CORE1/ncar_rad'    ! name of file with solar heat
-   nm_qlw_file   = '/work/ollie/clidyn/forcing/CORE1/ncar_rad'    ! name of file with Long wave
-   nm_tair_file  = '/work/ollie/clidyn/forcing/CORE1/t_10'        ! name of file with 2m air temperature
+   ! --- Forcing file paths ---
+   nm_xwind_file = '/work/ollie/clidyn/forcing/CORE1/u_10' ! name of file with zonal wind speeds
+   nm_ywind_file = '/work/ollie/clidyn/forcing/CORE1/v_10' ! name of file with meridional wind speeds
+   nm_humi_file  = '/work/ollie/clidyn/forcing/CORE1/q_10' ! name of file with air humidity
+   nm_qsr_file   = '/work/ollie/clidyn/forcing/CORE1/ncar_rad' ! name of file with short wave radiation
+   nm_qlw_file   = '/work/ollie/clidyn/forcing/CORE1/ncar_rad' ! name of file with long wave radiation
+   nm_tair_file  = '/work/ollie/clidyn/forcing/CORE1/t_10' ! name of file with 2m air temperature
    nm_prec_file  = '/work/ollie/clidyn/forcing/CORE1/ncar_precip' ! name of file with total precipitation
-   nm_snow_file  = '/work/ollie/clidyn/forcing/CORE1/ncar_precip' ! name of file with snow  precipitation
+   nm_snow_file  = '/work/ollie/clidyn/forcing/CORE1/ncar_precip' ! name of file with snow precipitation
    nm_mslp_file  = '/work/ollie/clidyn/forcing/CORE1/slp.'         ! air_pressure_at_sea_level
-   nm_xwind_var  = 'U_10_MOD'   ! name of variable in file with wind
-   nm_ywind_var  = 'V_10_MOD'   ! name of variable in file with wind
-   nm_humi_var   = 'Q_10_MOD'   ! name of variable in file with humidity
-   nm_qsr_var    = 'SWDN_MOD'   ! name of variable in file with solar heat
-   nm_qlw_var    = 'LWDN_MOD'   ! name of variable in file with Long wave
-   nm_tair_var   = 'T_10_MOD'   ! name of variable in file with 2m air temperature
-   nm_prec_var   = 'RAIN'       ! name of variable in file with total precipitation
-   nm_snow_var   = 'SNOW'       ! name of variable in file with total precipitation
-   nm_mslp_var   = 'SLP'        ! name of variable in file with air_pressure_at_sea_level
-   nm_nc_iyear   = 1948
-   nm_nc_imm     = 1            ! initial month of time axis in netCDF 
-   nm_nc_idd     = 1            ! initial day of time axis in netCDF
-   nm_nc_freq    = 1            ! data points per day (i.e. 86400 if the time axis is in seconds)
-   nm_nc_tmid    = 1            ! 1 if the time stamps are given at the mid points of the netcdf file, 0 otherwise (i.e. 1 in CORE1, CORE2; 0 in JRA55)
-   y_perpetual   = .true.
-   l_xwind=.true., l_ywind=.true., l_humi=.true., l_qsr=.true., l_qlw=.true., l_tair=.true., l_prec=.true., l_mslp=.false., l_cloud=.false., l_snow=.true.
-   nm_runoff_file     ='/work/ollie/dsein/input/forcing/CORE2/runoff.nc'
-   runoff_data_source ='CORE2'	!Dai09, CORE2
-   nm_sss_data_file   ='/work/ollie/dsein/input/forcing/CORE2/PHC2_salx.nc'
-   sss_data_source    ='CORE2'
+
+   ! --- Variable names in netCDF forcing files ---
+   nm_xwind_var  = 'U_10_MOD' ! name of variable in file with zonal wind
+   nm_ywind_var  = 'V_10_MOD' ! name of variable in file with meridional wind
+   nm_humi_var   = 'Q_10_MOD' ! name of variable in file with humidity
+   nm_qsr_var    = 'SWDN_MOD' ! name of variable in file with solar heat
+   nm_qlw_var    = 'LWDN_MOD' ! name of variable in file with long wave
+   nm_tair_var   = 'T_10_MOD' ! name of variable in file with 2m air temperature
+   nm_prec_var   = 'RAIN'     ! name of variable in file with total precipitation
+   nm_snow_var   = 'SNOW'     ! name of variable in file with snow precipitation
+   nm_mslp_var   = 'SLP'      ! name of variable in file with air_pressure_at_sea_level
+
+   ! --- Time axis configuration in forcing files ---
+   nm_nc_iyear   = 1948       ! initial year of forcing data time axis (note, not the first year in the file!)
+   nm_nc_imm     = 1          ! initial month of forcing data time axis (1-12)
+   nm_nc_idd     = 1          ! initial day of forcing data time axis (1-31)
+   nm_nc_freq    = 1          ! divisor converting the time axis of the forcing files to days (1 = days, 24 = hours, 86400 = seconds)
+   nm_nc_tmid    = 1          ! time stamp position: 1=mid-point, 0=start of interval
+   y_perpetual   = .true.     ! use perpetual year forcing (repeat single year)
+
+   ! --- Enable/disable individual forcing fields ---
+   l_xwind       = .true.     ! use zonal wind forcing
+   l_ywind       = .true.     ! use meridional wind forcing
+   l_humi        = .true.     ! use specific humidity forcing
+   l_qsr         = .true.     ! use shortwave radiation forcing
+   l_qlw         = .true.     ! use longwave radiation forcing
+   l_tair        = .true.     ! use air temperature forcing
+   l_prec        = .true.     ! use precipitation forcing
+   l_mslp        = .false.    ! use mean sea level pressure forcing
+   l_cloud       = .false.    ! use cloud cover forcing
+   l_snow        = .true.     ! use snow precipitation forcing
+
+   ! --- Runoff configuration ---
+   runoff_data_source = 'CORE2'       ! runoff data source: 'Dai09', 'JRA55', 'CORE1', 'CORE2' or 'NONE'
+   nm_runoff_file     = '/work/ollie/dsein/input/forcing/CORE2/runoff.nc' ! CORE2 monthly climatology with runoff_climatology=.true.
+   !nm_runoff_file     = 'friver.'  ! Dai09/JRA55 with runoff_climatology=.false.: prefix, year and '.nc' are appended (friver.1958.nc).
+
+   ! --- Sea surface salinity restoring ---
+   sss_data_source  = 'CORE2'  ! SSS restoring data source: 'CORE2', 'WOA', or 'NONE'
+   nm_sss_data_file = '/work/ollie/dsein/input/forcing/CORE2/PHC2_salx.nc' ! path to SSS restoring data file, e.g. PHC2_salx.nc
 /

--- a/config/namelist.ice_ERA5
+++ b/config/namelist.ice_ERA5
@@ -81,7 +81,7 @@ albsnm            = 0.77           ! albedo of melting snow (dimensionless, 0-1)
 albi              = 0.7            ! albedo of frozen ice (dimensionless, 0-1)
 albim             = 0.68           ! albedo of melting ice (dimensionless, 0-1)
 albw              = 0.1            ! albedo of open water (dimensionless, 0-1)
-open_water_albedo = 2              ! open water albedo scheme:
+open_water_albedo = 2           ! open water albedo scheme:
                                 !   0 = default (constant albw)
                                 !   1 = Taylor et al.
                                 !   2 = Briegleb et al.
@@ -96,4 +96,3 @@ snowdist       = .false.        ! distribute snow depth according to ice thickne
 ! --- Melting Parameters ---
 c_melt         = 0.3            ! constant in concentration equation for melting conditions (0-1)
 /
-

--- a/config/namelist.icepack
+++ b/config/namelist.icepack
@@ -1,4 +1,23 @@
-&env_nml                    ! In the original release these variables are defined in the icepack.settings
+! ============================================================================
+! =============== Namelist file for FESOM2 Icepack sea ice ===================
+! ============================================================================
+! This file contains configuration for the Icepack column physics package,
+! used when FESOM2 is built with Icepack (see docs/icepack_in_fesom.rst):
+! - Tracer array sizes and switches
+! - Ice thickness distribution and thermodynamics
+! - Shortwave radiation and albedo
+! - Melt ponds
+! - Surface forcing options
+! - Ridging and ice strength
+! - Icepack output variables
+! ============================================================================
+
+! ============================================================================
+! ENVIRONMENT (ARRAY SIZES)
+! ============================================================================
+! In the original Icepack release these are set in icepack.settings.
+! ============================================================================
+&env_nml
     nicecat   = 5           ! number of ice thickness categories
     nfsdcat   = 1           ! number of floe size categories
     nicelyr   = 4           ! number of vertical layers in the ice
@@ -6,110 +25,160 @@
     ntraero   = 0           ! number of aerosol tracers (up to max_aero in ice_domain_size.F90)
     trzaero   = 0           ! number of z aerosol tracers (up to max_aero = 6)
     tralg     = 0           ! number of algal tracers (up to max_algae = 3)
-    trdoc     = 0           ! number of dissolve organic carbon (up to max_doc = 3)
-    trdic     = 0           ! number of dissolve inorganic carbon (up to max_dic = 1)
-    trdon     = 0           ! number of dissolve organic nitrogen (up to max_don = 1)
-    trfed     = 0           ! number of dissolved iron tracers (up to max_fe  = 2)
-    trfep     = 0           ! number of particulate iron tracers (up to max_fe  = 2)
+    trdoc     = 0           ! number of dissolved organic carbon tracers (up to max_doc = 3)
+    trdic     = 0           ! number of dissolved inorganic carbon tracers (up to max_dic = 1)
+    trdon     = 0           ! number of dissolved organic nitrogen tracers (up to max_don = 1)
+    trfed     = 0           ! number of dissolved iron tracers (up to max_fe = 2)
+    trfep     = 0           ! number of particulate iron tracers (up to max_fe = 2)
     nbgclyr   = 0           ! number of zbgc layers
-    trbgcz    = 0           ! set to 1 for zbgc tracers (needs TRBGCS = 0 and TRBRI = 1)
-    trzs      = 0           ! set to 1 for zsalinity tracer (needs TRBRI = 1)
+    trbgcz    = 0           ! set to 1 for zbgc tracers (needs trbgcs = 0 and trbri = 1)
+    trzs      = 0           ! set to 1 for zsalinity tracer (needs trbri = 1)
     trbri     = 0           ! set to 1 for brine height tracer
     trage     = 0           ! set to 1 for ice age tracer
     trfy      = 0           ! set to 1 for first-year ice area tracer
     trlvl     = 0           ! set to 1 for level and deformed ice tracers
     trpnd     = 0           ! set to 1 for melt pond tracers
-    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs TRBGCZ = 0)
+    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs trbgcz = 0)
     ndtd      = 1           ! dynamic time steps per thermodynamic time step
 /
 
+! ============================================================================
+! ICE THICKNESS CATEGORIES
+! ============================================================================
 &grid_nml
-    kcatbound    = 1
+    kcatbound    = 1        ! category boundary formula:
+                            !   -1 = single category (column configurations, nicecat = 1)
+                            !    0 = old formula, 1 = new formula with round numbers
+                            !    2 = WMO standard categories (nicecat = 5, 6 or 7 only)
+                            !    3 = asymptotic scheme
 /
 
+! ============================================================================
+! TRACER SWITCHES
+! ============================================================================
+! Any melt pond scheme with calc_Tsfc = .true. needs shortwave = 'dEdd'.
+! ============================================================================
 &tracer_nml
-    tr_iage      = .false.
-    tr_FY        = .false.
-    tr_lvl       = .false.
-    tr_pond_cesm = .false.
-    tr_pond_topo = .false.
-    tr_pond_lvl  = .false.
-    tr_aero      = .false.
-    tr_fsd       = .false.
+    tr_iage      = .false.  ! ice age tracer
+    tr_FY        = .false.  ! first-year ice area tracer
+    tr_lvl       = .false.  ! level (undeformed) ice area and volume tracers
+    tr_pond_cesm = .false.  ! CESM melt pond scheme
+    tr_pond_topo = .false.  ! topographic melt pond scheme
+    tr_pond_lvl  = .false.  ! level-ice melt pond scheme (needs tr_lvl, forces hs0 = 0)
+    tr_aero      = .false.  ! aerosol tracers (needs shortwave = 'dEdd')
+    tr_fsd       = .false.  ! floe size distribution
 /
 
+! ============================================================================
+! THERMODYNAMICS
+! ============================================================================
 &thermo_nml
-    kitd              = 1
-    ktherm            = 1
-    conduct           = 'bubbly'
-    a_rapid_mode      =  0.5e-3
-    Rac_rapid_mode    =    10.0
-    aspect_rapid_mode =     1.0
-    dSdt_slow_mode    = -5.0e-8
-    phi_c_slow_mode   =    0.05
-    phi_i_mushy       =    0.85
-    ksno              = 0.3
+! --- Thickness Distribution and Thermodynamics Scheme ---
+    kitd              = 1           ! ice thickness distribution: 0 = delta function, 1 = linear remapping
+    ktherm            = 1           ! thermodynamics: 1 = Bitz & Lipscomb (1999), 2 = mushy layer
+                                    ! ktherm = 1 expects tfrz_option = 'linear_salt',
+                                    ! ktherm = 2 expects tfrz_option = 'mushy' and calc_Tsfc = .true.
+    conduct           = 'bubbly'    ! ice thermal conductivity (ktherm = 1):
+                                    !   'MU71' = Maykut & Untersteiner (1971), 'bubbly' = Pringle et al. (2007)
+
+! --- Mushy Layer Brine Drainage (ktherm = 2) ---
+    a_rapid_mode      =  0.5e-3     ! brine channel diameter [m]
+    Rac_rapid_mode    =    10.0     ! critical Rayleigh number for rapid drainage
+    aspect_rapid_mode =     1.0     ! brine convection aspect ratio
+    dSdt_slow_mode    = -5.0e-8     ! slow drainage strength parameter [m/(s K)]
+    phi_c_slow_mode   =    0.05     ! critical liquid fraction for slow drainage
+    phi_i_mushy       =    0.85     ! solid fraction at the lower ice boundary
+
+! --- Snow ---
+    ksno              = 0.3         ! thermal conductivity of snow [W/(m K)]
 /
 
+! ============================================================================
+! SHORTWAVE RADIATION AND ALBEDO
+! ============================================================================
 &shortwave_nml
-    shortwave       = 'ccsm3'
-    albedo_type     = 'ccsm3'
-    albicev         = 0.78
-    albicei         = 0.36
-    albsnowv        = 0.98
-    albsnowi        = 0.70
-    albocn          = 0.1
-    ahmax           = 0.3
-    R_ice           = 0.
-    R_pnd           = 0.
-    R_snw           = 1.5
-    dT_mlt          = 1.5
-    rsnw_mlt        = 1500.
-    kalg            = 0.6
+! --- Scheme Selection ---
+    shortwave       = 'ccsm3'   ! shortwave scheme: 'ccsm3' (bulk albedo) or 'dEdd' (Delta-Eddington)
+    albedo_type     = 'ccsm3'   ! albedo parameterization with shortwave = 'ccsm3': 'ccsm3' or 'constant'
+
+! --- Bulk Albedos (shortwave = 'ccsm3') ---
+    albicev         = 0.78      ! visible albedo of thick bare ice
+    albicei         = 0.36      ! near-infrared albedo of thick bare ice
+    albsnowv        = 0.98      ! visible albedo of cold snow
+    albsnowi        = 0.70      ! near-infrared albedo of cold snow
+    albocn          = 0.1       ! ocean albedo
+    ahmax           = 0.3       ! ice thickness above which the albedo is constant [m]
+
+! --- Delta-Eddington Tuning (shortwave = 'dEdd') ---
+    R_ice           = 0.        ! sea ice albedo tuning [standard deviations]
+    R_pnd           = 0.        ! melt pond albedo tuning [standard deviations]
+    R_snw           = 1.5       ! snow grain radius tuning [standard deviations]
+    dT_mlt          = 1.5       ! temperature change that gives rsnw_mlt [deg C]
+    rsnw_mlt        = 1500.     ! maximum melting snow grain radius [micrometres]
+    kalg            = 0.6       ! absorption coefficient for algae
 /
 
+! ============================================================================
+! MELT PONDS
+! ============================================================================
 &ponds_nml
-    hp1             = 0.01
-    hs0             = 0.
-    hs1             = 0.03
-    dpscale         = 1.e-3
-    frzpnd          = 'hlid'
-    rfracmin        = 0.15
-    rfracmax        = 1.
-    pndaspect       = 0.8
+    hp1             = 0.01      ! critical parameter for pond ice thickness [m]
+    hs0             = 0.        ! snow depth for transition to bare sea ice [m]
+    hs1             = 0.03      ! snow depth for transition to pond ice [m] (tr_pond_lvl)
+    dpscale         = 1.e-3     ! time scale for flushing in permeable ice (not used with tr_pond_cesm)
+    frzpnd          = 'hlid'    ! pond refreezing: 'cesm' or 'hlid' (Stefan refreezing with a pond ice lid)
+    rfracmin        = 0.15      ! minimum fraction of melt water added to ponds
+    rfracmax        = 1.        ! maximum fraction of melt water added to ponds
+    pndaspect       = 0.8       ! aspect ratio of pond changes (depth:area)
 /
 
+! ============================================================================
+! SURFACE FORCING OPTIONS
+! ============================================================================
 &forcing_nml
-    formdrag        = .false.
-    atmbndy         = 'default'
-    calc_strair     = .true.
-    calc_Tsfc       = .true.
-    highfreq        = .false.
-    natmiter        = 5
-    ustar_min       = 0.0005
-    emissivity      = 0.95
-    fbot_xfer_type  = 'constant'
-    update_ocn_f    = .true.
-    l_mpond_fresh   = .false.
-    tfrz_option     = 'linear_salt'
-    oceanmixed_ice  = .true.
-    wave_spec_type  = 'none'
+! --- Atmosphere-Ice Exchange ---
+    formdrag        = .false.       ! calculate form drag (needs calc_strair and tr_lvl, not atmbndy = 'constant')
+    atmbndy         = 'default'     ! atmospheric boundary layer: 'default' (stability dependent) or 'constant'
+    calc_strair     = .true.        ! calculate the wind stress in Icepack instead of reading it
+    calc_Tsfc       = .true.        ! calculate the surface temperature in Icepack instead of reading it
+    highfreq        = .false.       ! high-frequency atmosphere-ice coupling (Roberts et al. 2015)
+    natmiter        = 5             ! number of iterations for the atmospheric boundary layer fluxes
+    emissivity      = 0.95          ! emissivity of snow and ice
+
+! --- Ice-Ocean Exchange ---
+    ustar_min       = 0.0005        ! minimum friction velocity for the ice-ocean heat flux [m/s]
+    fbot_xfer_type  = 'constant'    ! ice-ocean heat transfer coefficient: 'constant' or 'Cdn_ocn' (needs formdrag)
+    update_ocn_f    = .true.        ! include frazil ice fluxes in the ocean flux fields
+    l_mpond_fresh   = .false.       ! retain (topo) pond water until the ponds drain
+    tfrz_option     = 'linear_salt' ! seawater freezing temperature: 'minus1p8', 'linear_salt' or 'mushy'
+    oceanmixed_ice  = .true.        ! active ocean mixed layer calculation in Icepack
+
+! --- Waves ---
+    wave_spec_type  = 'none'        ! wave spectrum for the floe size distribution: 'none', 'constant' or 'random'
 /
 
+! ============================================================================
+! RIDGING AND ICE STRENGTH
+! ============================================================================
 &dynamics_nml
-    kstrength       = 1
-    krdg_partic     = 1
-    krdg_redist     = 1
-    mu_rdg          = 3
-    Cf              = 17.
-    P_star          = 27000.
-    C_star          = 20.
+    kstrength       = 1         ! ice strength formulation: 0 = Hibler (1979), 1 = Rothrock (1975)
+    krdg_partic     = 1         ! ridging participation function: 0 = Thorndike et al. (1975), 1 = exponential
+    krdg_redist     = 1         ! ridging redistribution function: 0 = Hibler (1980), 1 = exponential
+    mu_rdg          = 3         ! e-folding scale of ridged ice [m^0.5] (krdg_redist = 1)
+    Cf              = 17.       ! ratio of ridging work to change in potential energy (kstrength = 1)
+    P_star          = 27000.    ! ice strength parameter [N/m²] (kstrength = 0)
+    C_star          = 20.       ! ice strength decay constant [dimensionless] (kstrength = 0)
 /
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!!!!!!!!!                Icepack output namelist                    !!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
+! ============================================================================
+! ICEPACK OUTPUT VARIABLES
+! ============================================================================
+! Format: 'variable_id', frequency, unit, precision
+!   frequency  = output frequency (integer)
+!   unit       = 'y' (yearly), 'm' (monthly), 'd' (daily), 'h' (hourly), 's' (steps)
+!   precision  = 4 (single precision) or 8 (double precision)
+! Remove the leading '!' to enable a variable.
+! ============================================================================
 &nml_list_icepack
 io_list_icepack =  'aicen     ',1, 'm', 4, ! Sea ice concentration
                    'vicen     ',1, 'm', 4, ! Volume per unit area of ice

--- a/config/namelist.icepack.cesm.ponds
+++ b/config/namelist.icepack.cesm.ponds
@@ -1,4 +1,23 @@
-&env_nml                    ! In the original release these variables are defined in the icepack.settings
+! ============================================================================
+! =============== Namelist file for FESOM2 Icepack sea ice ===================
+! ============================================================================
+! This file contains configuration for the Icepack column physics package,
+! used when FESOM2 is built with Icepack (see docs/icepack_in_fesom.rst):
+! - Tracer array sizes and switches
+! - Ice thickness distribution and thermodynamics
+! - Shortwave radiation and albedo
+! - Melt ponds
+! - Surface forcing options
+! - Ridging and ice strength
+! - Icepack output variables
+! ============================================================================
+
+! ============================================================================
+! ENVIRONMENT (ARRAY SIZES)
+! ============================================================================
+! In the original Icepack release these are set in icepack.settings.
+! ============================================================================
+&env_nml
     nicecat   = 5           ! number of ice thickness categories
     nfsdcat   = 1           ! number of floe size categories
     nicelyr   = 4           ! number of vertical layers in the ice
@@ -6,108 +25,156 @@
     ntraero   = 0           ! number of aerosol tracers (up to max_aero in ice_domain_size.F90)
     trzaero   = 0           ! number of z aerosol tracers (up to max_aero = 6)
     tralg     = 0           ! number of algal tracers (up to max_algae = 3)
-    trdoc     = 0           ! number of dissolve organic carbon (up to max_doc = 3)
-    trdic     = 0           ! number of dissolve inorganic carbon (up to max_dic = 1)
-    trdon     = 0           ! number of dissolve organic nitrogen (up to max_don = 1)
-    trfed     = 0           ! number of dissolved iron tracers (up to max_fe  = 2)
-    trfep     = 0           ! number of particulate iron tracers (up to max_fe  = 2)
+    trdoc     = 0           ! number of dissolved organic carbon tracers (up to max_doc = 3)
+    trdic     = 0           ! number of dissolved inorganic carbon tracers (up to max_dic = 1)
+    trdon     = 0           ! number of dissolved organic nitrogen tracers (up to max_don = 1)
+    trfed     = 0           ! number of dissolved iron tracers (up to max_fe = 2)
+    trfep     = 0           ! number of particulate iron tracers (up to max_fe = 2)
     nbgclyr   = 0           ! number of zbgc layers
-    trbgcz    = 0           ! set to 1 for zbgc tracers (needs TRBGCS = 0 and TRBRI = 1)
-    trzs      = 0           ! set to 1 for zsalinity tracer (needs TRBRI = 1)
+    trbgcz    = 0           ! set to 1 for zbgc tracers (needs trbgcs = 0 and trbri = 1)
+    trzs      = 0           ! set to 1 for zsalinity tracer (needs trbri = 1)
     trbri     = 0           ! set to 1 for brine height tracer
     trage     = 0           ! set to 1 for ice age tracer
     trfy      = 0           ! set to 1 for first-year ice area tracer
     trlvl     = 0           ! set to 1 for level and deformed ice tracers
     trpnd     = 1           ! set to 1 for melt pond tracers
-    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs TRBGCZ = 0)
+    trbgcs    = 0           ! set to 1 for skeletal layer tracers (needs trbgcz = 0)
     ndtd      = 1           ! dynamic time steps per thermodynamic time step
 /
 
+! ============================================================================
+! ICE THICKNESS CATEGORIES
+! ============================================================================
 &grid_nml
-    kcatbound    = 1
+    kcatbound    = 1        ! category boundary formula:
+                            !   -1 = single category (column configurations, nicecat = 1)
+                            !    0 = old formula, 1 = new formula with round numbers
+                            !    2 = WMO standard categories (nicecat = 5, 6 or 7 only)
+                            !    3 = asymptotic scheme
 /
 
+! ============================================================================
+! TRACER SWITCHES
+! ============================================================================
+! Any melt pond scheme with calc_Tsfc = .true. needs shortwave = 'dEdd'.
+! ============================================================================
 &tracer_nml
-    tr_iage      = .false.
-    tr_FY        = .false.
-    tr_lvl       = .false.
-    tr_pond_cesm = .true.
-    tr_pond_topo = .false.
-    tr_pond_lvl  = .false.
-    tr_aero      = .false.
-    tr_fsd       = .false.
+    tr_iage      = .false.  ! ice age tracer
+    tr_FY        = .false.  ! first-year ice area tracer
+    tr_lvl       = .false.  ! level (undeformed) ice area and volume tracers
+    tr_pond_cesm = .true.   ! CESM melt pond scheme
+    tr_pond_topo = .false.  ! topographic melt pond scheme
+    tr_pond_lvl  = .false.  ! level-ice melt pond scheme (needs tr_lvl, forces hs0 = 0)
+    tr_aero      = .false.  ! aerosol tracers (needs shortwave = 'dEdd')
+    tr_fsd       = .false.  ! floe size distribution
 /
 
+! ============================================================================
+! THERMODYNAMICS
+! ============================================================================
 &thermo_nml
-    kitd              = 1
-    ktherm            = 1
-    conduct           = 'bubbly'
-    a_rapid_mode      =  0.5e-3
-    Rac_rapid_mode    =    10.0
-    aspect_rapid_mode =     1.0
-    dSdt_slow_mode    = -5.0e-8
-    phi_c_slow_mode   =    0.05
-    phi_i_mushy       =    0.85
+! --- Thickness Distribution and Thermodynamics Scheme ---
+    kitd              = 1           ! ice thickness distribution: 0 = delta function, 1 = linear remapping
+    ktherm            = 1           ! thermodynamics: 1 = Bitz & Lipscomb (1999), 2 = mushy layer
+                                    ! ktherm = 1 expects tfrz_option = 'linear_salt',
+                                    ! ktherm = 2 expects tfrz_option = 'mushy' and calc_Tsfc = .true.
+    conduct           = 'bubbly'    ! ice thermal conductivity (ktherm = 1):
+                                    !   'MU71' = Maykut & Untersteiner (1971), 'bubbly' = Pringle et al. (2007)
+
+! --- Mushy Layer Brine Drainage (ktherm = 2) ---
+    a_rapid_mode      =  0.5e-3     ! brine channel diameter [m]
+    Rac_rapid_mode    =    10.0     ! critical Rayleigh number for rapid drainage
+    aspect_rapid_mode =     1.0     ! brine convection aspect ratio
+    dSdt_slow_mode    = -5.0e-8     ! slow drainage strength parameter [m/(s K)]
+    phi_c_slow_mode   =    0.05     ! critical liquid fraction for slow drainage
+    phi_i_mushy       =    0.85     ! solid fraction at the lower ice boundary
 /
 
+! ============================================================================
+! SHORTWAVE RADIATION AND ALBEDO
+! ============================================================================
 &shortwave_nml
-    shortwave       = 'dEdd'
-    albedo_type     = 'ccsm3'
-    albicev         = 0.78
-    albicei         = 0.36
-    albsnowv        = 0.98
-    albsnowi        = 0.70
-    ahmax           = 0.3
-    R_ice           = 0.
-    R_pnd           = 0.
-    R_snw           = 1.5
-    dT_mlt          = 1.5
-    rsnw_mlt        = 1500.
-    kalg            = 0.6
+! --- Scheme Selection ---
+    shortwave       = 'dEdd'    ! shortwave scheme: 'ccsm3' (bulk albedo) or 'dEdd' (Delta-Eddington)
+    albedo_type     = 'ccsm3'   ! albedo parameterization with shortwave = 'ccsm3': 'ccsm3' or 'constant'
+
+! --- Bulk Albedos (shortwave = 'ccsm3') ---
+    albicev         = 0.78      ! visible albedo of thick bare ice
+    albicei         = 0.36      ! near-infrared albedo of thick bare ice
+    albsnowv        = 0.98      ! visible albedo of cold snow
+    albsnowi        = 0.70      ! near-infrared albedo of cold snow
+    ahmax           = 0.3       ! ice thickness above which the albedo is constant [m]
+
+! --- Delta-Eddington Tuning (shortwave = 'dEdd') ---
+    R_ice           = 0.        ! sea ice albedo tuning [standard deviations]
+    R_pnd           = 0.        ! melt pond albedo tuning [standard deviations]
+    R_snw           = 1.5       ! snow grain radius tuning [standard deviations]
+    dT_mlt          = 1.5       ! temperature change that gives rsnw_mlt [deg C]
+    rsnw_mlt        = 1500.     ! maximum melting snow grain radius [micrometres]
+    kalg            = 0.6       ! absorption coefficient for algae
 /
 
+! ============================================================================
+! MELT PONDS
+! ============================================================================
 &ponds_nml
-    hp1             = 0.01
-    hs0             = 0.
-    hs1             = 0.03
-    dpscale         = 1.e-3
-    frzpnd          = 'hlid'
-    rfracmin        = 0.15
-    rfracmax        = 1.
-    pndaspect       = 0.8
+    hp1             = 0.01      ! critical parameter for pond ice thickness [m]
+    hs0             = 0.        ! snow depth for transition to bare sea ice [m]
+    hs1             = 0.03      ! snow depth for transition to pond ice [m] (tr_pond_lvl)
+    dpscale         = 1.e-3     ! time scale for flushing in permeable ice (not used with tr_pond_cesm)
+    frzpnd          = 'hlid'    ! pond refreezing: 'cesm' or 'hlid' (Stefan refreezing with a pond ice lid)
+    rfracmin        = 0.15      ! minimum fraction of melt water added to ponds
+    rfracmax        = 1.        ! maximum fraction of melt water added to ponds
+    pndaspect       = 0.8       ! aspect ratio of pond changes (depth:area)
 /
 
+! ============================================================================
+! SURFACE FORCING OPTIONS
+! ============================================================================
 &forcing_nml
-    formdrag        = .false.
-    atmbndy         = 'default'
-    calc_strair     = .true.
-    calc_Tsfc       = .true.
-    highfreq        = .false.
-    natmiter        = 5
-    ustar_min       = 0.0005
-    emissivity      = 0.95
-    fbot_xfer_type  = 'constant'
-    update_ocn_f    = .true.
-    l_mpond_fresh   = .false.
-    tfrz_option     = 'linear_salt'
-    oceanmixed_ice  = .true.
-    wave_spec_type  = 'none'
+! --- Atmosphere-Ice Exchange ---
+    formdrag        = .false.       ! calculate form drag (needs calc_strair and tr_lvl, not atmbndy = 'constant')
+    atmbndy         = 'default'     ! atmospheric boundary layer: 'default' (stability dependent) or 'constant'
+    calc_strair     = .true.        ! calculate the wind stress in Icepack instead of reading it
+    calc_Tsfc       = .true.        ! calculate the surface temperature in Icepack instead of reading it
+    highfreq        = .false.       ! high-frequency atmosphere-ice coupling (Roberts et al. 2015)
+    natmiter        = 5             ! number of iterations for the atmospheric boundary layer fluxes
+    emissivity      = 0.95          ! emissivity of snow and ice
+
+! --- Ice-Ocean Exchange ---
+    ustar_min       = 0.0005        ! minimum friction velocity for the ice-ocean heat flux [m/s]
+    fbot_xfer_type  = 'constant'    ! ice-ocean heat transfer coefficient: 'constant' or 'Cdn_ocn' (needs formdrag)
+    update_ocn_f    = .true.        ! include frazil ice fluxes in the ocean flux fields
+    l_mpond_fresh   = .false.       ! retain (topo) pond water until the ponds drain
+    tfrz_option     = 'linear_salt' ! seawater freezing temperature: 'minus1p8', 'linear_salt' or 'mushy'
+    oceanmixed_ice  = .true.        ! active ocean mixed layer calculation in Icepack
+
+! --- Waves ---
+    wave_spec_type  = 'none'        ! wave spectrum for the floe size distribution: 'none', 'constant' or 'random'
 /
 
+! ============================================================================
+! RIDGING AND ICE STRENGTH
+! ============================================================================
 &dynamics_nml
-    kstrength       = 1
-    krdg_partic     = 1
-    krdg_redist     = 1
-    mu_rdg          = 3
-    Cf              = 17.
-    P_star          = 27000.
-    C_star          = 20.
+    kstrength       = 1         ! ice strength formulation: 0 = Hibler (1979), 1 = Rothrock (1975)
+    krdg_partic     = 1         ! ridging participation function: 0 = Thorndike et al. (1975), 1 = exponential
+    krdg_redist     = 1         ! ridging redistribution function: 0 = Hibler (1980), 1 = exponential
+    mu_rdg          = 3         ! e-folding scale of ridged ice [m^0.5] (krdg_redist = 1)
+    Cf              = 17.       ! ratio of ridging work to change in potential energy (kstrength = 1)
+    P_star          = 27000.    ! ice strength parameter [N/m²] (kstrength = 0)
+    C_star          = 20.       ! ice strength decay constant [dimensionless] (kstrength = 0)
 /
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!!!!!!!!!                Icepack output namelist                    !!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
+! ============================================================================
+! ICEPACK OUTPUT VARIABLES
+! ============================================================================
+! Format: 'variable_id', frequency, unit, precision
+!   frequency  = output frequency (integer)
+!   unit       = 'y' (yearly), 'm' (monthly), 'd' (daily), 'h' (hourly), 's' (steps)
+!   precision  = 4 (single precision) or 8 (double precision)
+! Remove the leading '!' to enable a variable.
+! ============================================================================
 &nml_list_icepack
 io_list_icepack =  'aicen     ',1, 'm', 4, ! Sea ice concentration
                    'vicen     ',1, 'm', 4, ! Volume per unit area of ice

--- a/config/namelist.io.nextGEMS
+++ b/config/namelist.io.nextGEMS
@@ -1,28 +1,57 @@
+! ============================================================================
+! ============ Namelist file for FESOM2 output configuration =================
+! ============================================================================
+! This file contains configuration for model output and diagnostics:
+! - Diagnostic flags for optional output fields
+! - General output settings (compression, rotation)
+! - Output variable list with frequency and precision
+! - Complete catalog of all available output fields
+!
+! See the output catalog at the end of this file for all possible variables.
+! Some outputs require specific flags in &diag_list or other namelists.
+! ============================================================================
+
+! ============================================================================
+! DIAGNOSTIC FLAGS
+! ============================================================================
+! Enable/disable optional diagnostic computations and outputs.
+! Setting these to .true. enables additional output fields (see catalog below).
+! ============================================================================
 &diag_list
-ldiag_solver     =.false.
-lcurt_stress_surf=.false.
-ldiag_curl_vel3  =.false.
-ldiag_Ri         =.false.
-ldiag_turbflux   =.false.
-ldiag_salt3D     =.false.
-ldiag_dMOC       =.false.
-ldiag_DVD        =.false.
-ldiag_forc       =.false.
-ldiag_extflds    =.false.
+ldiag_solver      = .false.  ! enables solver diagnostics (convergence, iterations)
+lcurt_stress_surf = .false.  ! enables 'curl_surf' output (vorticity of surface stress)
+ldiag_curl_vel3   = .false.  ! enables 'curl_u' output (relative vorticity from 3D velocity)
+ldiag_Ri          = .false.  ! enables Richardson number diagnostics ('shear', 'Ri')
+ldiag_turbflux    = .false.  ! enables turbulent flux diagnostics ('KvdTdz', 'KvdSdz')
+ldiag_salt3D      = .false.  ! enables 3D salinity diagnostics
+ldiag_dMOC        = .false.  ! enables 'dMOC' output (density MOC diagnostics)
+ldiag_DVD         = .false.  ! enables 'DVD' output (Discrete Variance Decay diagnostics)
+ldiag_forc        = .false.  ! enables 'FORC' output (comprehensive forcing diagnostics)
+ldiag_extflds     = .false.  ! enables extended field diagnostics
 /
 
+! ============================================================================
+! GENERAL OUTPUT SETTINGS
+! ============================================================================
 &nml_general
-io_listsize    =100 !number of streams to allocate. shallbe large or equal to the number of streams in &nml_list
-vec_autorotate =.false.
+io_listsize       = 100      ! total number of streams to allocate. Shall be larger or equal to the number of streams in &nml_list (max. 150)
+vec_autorotate    = .false.  ! unrotate vector fields (velocities, winds) before writing to output files
 lnextGEMS=.true.
 nlev_upper=10
 /
 
-! for sea ice related variables use_ice should be true, otherewise there will be no output
-! for 'curl_surf' to work lcurt_stress_surf must be .true. otherwise no output
-! for 'fer_C', 'bolus_u', 'bolus_v', 'bolus_w', 'fer_K' to work Fer_GM must be .true. otherwise no output
-! 'otracers' - all other tracers if applicable
-! for 'dMOC' to work ldiag_dMOC must be .true. otherwise no output
+! ============================================================================
+! OUTPUT VARIABLE LIST
+! ============================================================================
+! Format: 'variable_id', frequency, unit, precision
+!   frequency  = output frequency (integer)
+!   unit       = 'y' (yearly), 'm' (monthly), 'd' (daily), 'h' (hourly), 's' (steps)
+!   precision  = 4 (single precision) or 8 (double precision)
+!   Note: in a single-precision build (WP=4) a field requesting precision 8 is
+!   still honoured (written as NF_DOUBLE; means accumulated in real64), but its
+!   samples are single-precision-sourced. FESOM prints one summary line at
+!   startup listing such fields.
+! ============================================================================
 &nml_list
 io_list =  'sst       ',1, 'm', 4,
            'sss       ',1, 'm', 4,
@@ -51,3 +80,277 @@ io_list =  'sst       ',1, 'm', 4,
            'bolus_v   ',1, 'y', 4,
            'bolus_w   ',1, 'y', 4,
 /
+
+! ============================================================================
+! COMPLETE CATALOG OF ALL POSSIBLE OUTPUT FIELDS
+! ============================================================================
+! Below is a comprehensive list of all valid io_list IDs available in FESOM2.
+! To enable any field, copy the line to the &nml_list section above.
+! NOTE: Some fields require specific flags to be enabled (see comments).
+! ============================================================================
+
+! --- 2D OCEAN SURFACE FIELDS ---
+! 'sst       ',1, 'm', 4,  ! sea surface temperature [C]
+! 'sss       ',1, 'm', 4,  ! sea surface salinity [psu]
+! 'ssh       ',1, 'm', 4,  ! sea surface elevation [m]
+! 'vve_5     ',1, 'm', 4,  ! vertical velocity at 5th level [m/s]
+! 't_star    ',1, 'm', 4,  ! air temperature [C]
+! 'qsr       ',1, 'm', 4,  ! solar radiation [W/s^2]
+
+! --- 3D OCEAN FIELDS ---
+! 'temp      ',1, 'm', 4,  ! temperature [C]
+! 'salt      ',1, 'm', 8,  ! salinity [psu]
+! 'sigma0    ',1, 'm', 4,  ! potential density [kg/m3]
+! 'u         ',1, 'm', 4,  ! zonal velocity [m/s]
+! 'v         ',1, 'm', 4,  ! meridional velocity [m/s]
+! 'unod      ',1, 'm', 4,  ! zonal velocity at nodes [m/s]
+! 'vnod      ',1, 'm', 4,  ! meridional velocity at nodes [m/s]
+! 'w         ',1, 'm', 4,  ! vertical velocity [m/s]
+! 'otracers  ',1, 'm', 4,  ! all other tracers if applicable
+! 'age       ',1, 'm', 4,  ! water age tracer [year] (require use_age_tracer=.true.)
+
+! --- 2D SSH DIAGNOSTIC VARIABLES ---
+! 'ssh_rhs   ',1, 'm', 4,  ! ssh rhs [m/s]
+! 'ssh_rhs_old',1, 'm', 4, ! ssh rhs old [m/s]
+! 'd_eta     ',1, 'm', 4,  ! dssh from solver [m]
+! 'hbar      ',1, 'm', 4,  ! ssh n+0.5 tstep [m]
+! 'hbar_old  ',1, 'm', 4,  ! ssh n-0.5 tstep [m]
+! 'dhe       ',1, 'm', 4,  ! dhbar @ elem [m]
+
+! --- SEA ICE FIELDS (require use_ice=.true.) ---
+! 'uice      ',1, 'm', 4,  ! ice velocity x [m/s]
+! 'vice      ',1, 'm', 4,  ! ice velocity y [m/s]
+! 'a_ice     ',1, 'm', 4,  ! ice concentration [%]
+! 'm_ice     ',1, 'm', 4,  ! ice height per unit area [m]
+! 'thdgrice  ',1, 'm', 4,  ! thermodynamic growth rate ice [m/s]
+! 'thdgrarea ',1, 'm', 4,  ! thermodynamic growth rate ice concentration [frac/s]
+! 'dyngrarea' ,1, 'm', 4,  ! dynamic growth rate ice concentration [frac/s]
+! 'dyngrice  ',1, 'm', 4,  ! dynamic growth rate ice [m/s]
+! 'thdgrsn   ',1, 'm', 4,  ! thermodynamic growth rate snow [m/s]
+! 'dyngrsnw  ',1, 'm', 4,  ! dynamic growth rate snow [m/s] 
+! 'flice     ',1, 'm', 4,  ! flooding growth rate ice [m/s]
+! 'm_snow    ',1, 'm', 4,  ! snow height per unit area [m]
+! 'h_ice     ',1, 'm', 4,  ! ice thickness over ice-covered fraction [m]
+! 'h_snow    ',1, 'm', 4,  ! snow thickness over ice-covered fraction [m]
+! 'fw_ice    ',1, 'm', 4,  ! fresh water flux from ice ['m/s']
+! 'fw_snw    ',1, 'm', 4,  ! fresh water flux from snow ['m/s']
+
+! --- SEA ICE DEBUG VARIABLES (require use_ice=.true.) ---
+! 'strength_ice',1, 'm', 4,  ! ice strength [?]
+! 'inv_areamass',1, 'm', 4,  ! inv_areamass [?]
+! 'rhs_a     ',1, 'm', 4,  ! rhs_a [?]
+! 'rhs_m     ',1, 'm', 4,  ! rhs_m [?]
+! 'sgm11     ',1, 'm', 4,  ! sgm11 [?]
+! 'sgm12     ',1, 'm', 4,  ! sgm12 [?]
+! 'sgm22     ',1, 'm', 4,  ! sgm22 [?]
+! 'eps11     ',1, 'm', 4,  ! eps11 [?]
+! 'eps12     ',1, 'm', 4,  ! eps12 [?]
+! 'eps22     ',1, 'm', 4,  ! eps22 [?]
+! 'u_rhs_ice ',1, 'm', 4,  ! u_rhs_ice [?]
+! 'v_rhs_ice ',1, 'm', 4,  ! v_rhs_ice [?]
+! 'metric_fac',1, 'm', 4,  ! metric_fac [?]
+! 'elevat_ice',1, 'm', 4,  ! elevat_ice [?]
+! 'uwice     ',1, 'm', 4,  ! uwice [?]
+! 'vwice     ',1, 'm', 4,  ! vwice [?]
+! 'twice     ',1, 'm', 4,  ! twice [?]
+! 'swice     ',1, 'm', 4,  ! swice [?]
+
+! --- MIXED LAYER DEPTH ---
+! 'MLD1      ',1, 'm', 4,  ! Mixed Layer Depth [m] Large et al. 1997, bvfreq(nz, node) > db_max
+! 'MLD2      ',1, 'm', 4,  ! Mixed Layer Depth [m] Levitus treshold, rhopot(nz)-rhopot(1) > 0.125_WP kg/m
+! 'MLD3      ',1, 'm', 4,  ! Mixed Layer Depth [m] Griffies 2016 , rhopot(nz)-rhopot(1) > 0.03_WP kg/m
+
+! --- HEAT CONTENT (require ldiag_destine=.true.) ---
+! 'hc300m    ',1, 'm', 4,  ! Vertically integrated heat content upper 300m [J m**-2]
+! 'hc700m    ',1, 'm', 4,  ! Vertically integrated heat content upper 700m [J m**-2]
+! 'hc        ',1, 'm', 4,  ! Vertically integrated heat content total column [J m**-2]
+
+! --- WATER ISOTOPES IN SEA ICE (require lwiso=.true.) ---
+! 'h2o18_ice ',1, 'm', 4,  ! h2o18 concentration in sea ice [kmol/m**3]
+! 'hDo16_ice ',1, 'm', 4,  ! hDo16 concentration in sea ice [kmol/m**3]
+! 'h2o16_ice ',1, 'm', 4,  ! h2o16 concentration in sea ice [kmol/m**3]
+
+! --- FRESHWATER FLUX (require use_landice_water=.true.) ---
+! 'landice   ',1, 'm', 4,  ! freshwater flux [m/s]
+
+! --- SURFACE FORCING ---
+! 'tx_sur    ',1, 'm', 4,  ! zonal wind str. to ocean [N/m2]
+! 'ty_sur    ',1, 'm', 4,  ! meridional wind str. to ocean [N/m2]
+! 'curl_surf ',1, 'm', 4,  ! vorticity of the surface stress [none] (require lcurt_stress_surf=.true.)
+! 'fh        ',1, 'm', 4,  ! heat flux [W/m2]
+! 'fw        ',1, 'm', 4,  ! fresh water flux [m/s]
+! 'atmice_x  ',1, 'm', 4,  ! stress atmice x [N/m2]
+! 'atmice_y  ',1, 'm', 4,  ! stress atmice y [N/m2]
+! 'atmoce_x  ',1, 'm', 4,  ! stress atmoce x [N/m2]
+! 'atmoce_y  ',1, 'm', 4,  ! stress atmoce y [N/m2]
+! 'iceoce_x  ',1, 'm', 4,  ! stress iceoce x [N/m2]
+! 'iceoce_y  ',1, 'm', 4,  ! stress iceoce y [N/m2]
+! 'alpha     ',1, 'm', 4,  ! thermal expansion [none]
+! 'beta      ',1, 'm', 4,  ! saline contraction [none]
+! 'dens_flux ',1, 'm', 4,  ! density flux [kg/(m3*s)]
+! 'runoff    ',1, 'm', 4,  ! river runoff [m/s]
+! 'evap      ',1, 'm', 4,  ! evaporation [m/s]
+! 'prec      ',1, 'm', 4,  ! precipitation rain [m/s]
+! 'snow      ',1, 'm', 4,  ! precipitation snow [m/s]
+! 'tair      ',1, 'm', 4,  ! surface air temperature [°C]
+! 'shum      ',1, 'm', 4,  ! specific humidity []
+! 'swr       ',1, 'm', 4,  ! short wave radiation [W/m^2]
+! 'lwr       ',1, 'm', 4,  ! long wave radiation [W/m^2]
+! 'uwind     ',1, 'm', 4,  ! 10m zonal surface wind velocity [m/s]
+! 'vwind     ',1, 'm', 4,  ! 10m merid. surface wind velocity [m/s]
+! 'virtsalt  ',1, 'm', 4,  ! virtual salt flux [m/s*psu]
+! 'relaxsalt ',1, 'm', 4,  ! relaxation salt flux [m/s*psu]
+! 'realsalt  ',1, 'm', 4,  ! real salt flux from sea ice [m/s*psu]
+
+! --- KPP VERTICAL MIXING (require mix_scheme_nmb==1,17,3,37) ---
+! 'kpp_obldepth',1, 'm', 4, ! KPP ocean boundary layer depth [m]
+! 'kpp_sbuoyflx',1, 'm', 4, ! surface buoyancy flux [m2/s3]
+
+! --- RECOM 2D BIOGEOCHEMISTRY (require use_REcoM=.true. and __recom) ---
+! 'dpCO2s    ',1, 'm', 4,  ! Difference of oceanic pCO2 minus atmospheric pCO2 [uatm]
+! 'pCO2s     ',1, 'm', 4,  ! Partial pressure of oceanic CO2 [uatm]
+! 'CO2f      ',1, 'm', 4,  ! CO2-flux into the surface water [mmolC/m2/d]
+! 'O2f       ',1, 'm', 4,  ! O2-flux into the surface water [mmolO/m2/d]
+! 'Hp        ',1, 'm', 4,  ! Mean of H-plus ions in the surface water [mol/kg]
+! 'aFe       ',1, 'm', 4,  ! Atmospheric iron input [umolFe/m2/s]
+! 'aN        ',1, 'm', 4,  ! Atmospheric DIN input [mmolN/m2/s]
+! 'benN      ',1, 'm', 4,  ! Benthos Nitrogen [mmol]
+! 'benC      ',1, 'm', 4,  ! Benthos Carbon [mmol]
+! 'benSi     ',1, 'm', 4,  ! Benthos silicon [mmol]
+! 'benCalc   ',1, 'm', 4,  ! Benthos calcite [mmol]
+! 'NPPn      ',1, 'm', 4,  ! Mean NPP nanophytoplankton [mmolC/m2/d]
+! 'NPPd      ',1, 'm', 4,  ! Mean NPP diatoms [mmolC/m2/d]
+! 'GPPn      ',1, 'm', 4,  ! Mean GPP nanophytoplankton [mmolC/m2/d]
+! 'GPPd      ',1, 'm', 4,  ! Mean GPP diatoms [mmolC/m2/d]
+! 'NNAn      ',1, 'm', 4,  ! Net N-assimilation nanophytoplankton [mmolN/m2/d]
+! 'NNAd      ',1, 'm', 4,  ! Net N-assimilation diatoms [mmolN/m2/d]
+! 'Chldegn   ',1, 'm', 4,  ! Chlorophyll degradation nanophytoplankton [1/d]
+! 'Chldegd   ',1, 'm', 4,  ! Chlorophyll degradation diatoms [1/d]
+! 'NPPc      ',1, 'm', 4,  ! Mean NPP coccolithophores [mmolC/(m2*d)]
+! 'GPPc      ',1, 'm', 4,  ! Mean GPP coccolithophores [mmolC/m2/d]
+! 'NNAc      ',1, 'm', 4,  ! Net N-assimilation coccolithophores [mmolN/(m2*d)]
+! 'Chldegc   ',1, 'm', 4,  ! Chlorophyll degradation coccolithophores [1/d]
+
+! --- RECOM 3D BIOGEOCHEMISTRY (require use_REcoM=.true. and __recom) ---
+! 'PAR       ',1, 'm', 4,  ! PAR [W/m2]
+! 'respmeso  ',1, 'm', 4,  ! Respiration rate of mesozooplankton [mmolC/m2/d]
+! 'respmacro ',1, 'm', 4,  ! Respiration rate of macrozooplankton [mmolC/m2/d]
+! 'respmicro ',1, 'm', 4,  ! Respiration rate of microzooplankton [mmolC/m2/d]
+! 'calcdiss  ',1, 'm', 4,  ! Calcite dissolution [mmolC/m2/d]
+! 'calcif    ',1, 'm', 4,  ! Calcification [mmolC/m2/d]
+! 'aggn      ',1, 'm', 4,  ! Aggregation of small phytoplankton [mmolC/m2/d]
+! 'aggd      ',1, 'm', 4,  ! Aggregation of diatoms [mmolC/m2/d]
+! 'aggc      ',1, 'm', 4,  ! Aggregation of coccolithophores [mmolC/m2/d]
+! 'docexn    ',1, 'm', 4,  ! DOC excretion by small phytoplankton [mmolC/m2/d]
+! 'docexd    ',1, 'm', 4,  ! DOC excretion by diatoms [mmolC/m2/d]
+! 'docexc    ',1, 'm', 4,  ! DOC excretion by coccolithophores [mmolC/m2/d]
+! 'respn     ',1, 'm', 4,  ! Respiration by small phytoplankton [mmolC/m2/d]
+! 'respd     ',1, 'm', 4,  ! Respiration by diatoms [mmolC/m2/d]
+! 'respc     ',1, 'm', 4,  ! Respiration by coccolithophores [mmolC/(m2*d)]
+! 'NPPn3D    ',1, 'm', 4,  ! Net primary production of small phytoplankton [mmolC/(m3*d)]
+! 'NPPd3D    ',1, 'm', 4,  ! Net primary production of diatoms [mmolC/(m3*d)]
+! 'NPPc3D    ',1, 'm', 4,  ! Net primary production of coccolithophores [mmolC/(m3*d)]
+
+! --- WATER ISOTOPES IN OCEAN (require lwiso=.true.) ---
+! 'h2o18     ',1, 'm', 4,  ! h2o18 concentration [kmol/m**3]
+! 'hDo16     ',1, 'm', 4,  ! hDo16 concentration [kmol/m**3]
+! 'h2o16     ',1, 'm', 4,  ! h2o16 concentration [kmol/m**3]
+
+! --- NEUTRAL SLOPES ---
+! 'slopetap_x',1, 'm', 4,  ! neutral slope tapered X [none]
+! 'slopetap_y',1, 'm', 4,  ! neutral slope tapered Y [none]
+! 'slopetap_z',1, 'm', 4,  ! neutral slope tapered Z [none]
+! 'slope_x   ',1, 'm', 4,  ! neutral slope X [none]
+! 'slope_y   ',1, 'm', 4,  ! neutral slope Y [none]
+! 'slope_z   ',1, 'm', 4,  ! neutral slope Z [none]
+
+! --- MIXING AND DYNAMICS ---
+! 'N2        ',1, 'm', 4,  ! brunt väisälä [1/s2]
+! 'Kv        ',1, 'm', 4,  ! vertical diffusivity Kv [m2/s]
+! 'Av        ',1, 'm', 4,  ! vertical viscosity Av [m2/s]
+
+! --- VISCOSITY TENDENCIES (require dynamics%opt_visc==8) ---
+! 'u_dis_tend',1, 'm', 4,  ! horizontal velocity viscosity tendency [m/s]
+! 'v_dis_tend',1, 'm', 4,  ! meridional velocity viscosity tendency [m/s]
+! 'u_back_tend',1, 'm', 4, ! horizontal velocity backscatter tendency [m2/s2]
+! 'v_back_tend',1, 'm', 4, ! meridional velocity backscatter tendency [m2/s2]
+! 'u_total_tend',1, 'm', 4,! horizontal velocity total viscosity tendency [m/s]
+! 'v_total_tend',1, 'm', 4,! meridional velocity total viscosity tendency [m/s]
+
+! --- FERRARI/GM PARAMETERISATION (require Fer_GM=.true.) ---
+! 'bolus_u   ',1, 'm', 4,  ! GM bolus velocity U [m/s]
+! 'bolus_v   ',1, 'm', 4,  ! GM bolus velocity V [m/s]
+! 'bolus_w   ',1, 'm', 4,  ! GM bolus velocity W [m/s]
+! 'fer_K     ',1, 'm', 4,  ! GM, stirring diff. [m2/s]
+! 'fer_scal  ',1, 'm', 4,  ! GM surface scaling []
+! 'fer_C     ',1, 'm', 4,  ! GM, depth independent speed [m/s]
+! 'cfl_z     ',1, 'm', 4,  ! vertical CFL criteria [?]
+
+! --- DENSITY MOC DIAGNOSTICS (require ldiag_dMOC=.true.) ---
+! 'dMOC      ',1, 'm', 4,  ! fluxes for density MOC (multiple variables)
+
+! --- PRESSURE GRADIENT FORCE ---
+! 'pgf_x     ',1, 'm', 4,  ! zonal pressure gradient force [m/s^2]
+! 'pgf_y     ',1, 'm', 4,  ! meridional pressure gradient force [m/s^2]
+
+! --- ALE LAYER THICKNESS ---
+! 'hnode     ',1, 'm', 4,  ! vertice layer thickness [m]
+! 'hnode_new ',1, 'm', 4,  ! hnode_new [m]
+! 'helem     ',1, 'm', 4,  ! elemental layer thickness [m]
+
+! --- OIFS/IFS INTERFACE (require __oifs or __ifsinterface) ---
+! 'alb       ',1, 'm', 4,  ! ice albedo [none]
+! 'ist       ',1, 'm', 4,  ! ice surface temperature [K]
+! 'qsi       ',1, 'm', 4,  ! ice heat flux [W/m^2]
+! 'qso       ',1, 'm', 4,  ! oce heat flux [W/m^2]
+! 'enthalpy  ',1, 'm', 4,  ! enthalpy of fusion [W/m^2]
+! 'qcon      ',1, 'm', 4,  ! conductive heat flux [W/m^2]
+! 'qres      ',1, 'm', 4,  ! residual heat flux [W/m^2]
+! 'runoff_liquid',1, 'm', 4, ! liquid water runoff [m/s]
+! 'runoff_solid',1, 'm', 4, ! solid water runoff [m/s]
+
+! --- ICEBERG OUTPUTS (require use_icebergs=.true.) ---
+! 'icb       ',1, 'm', 4,  ! iceberg outputs (multiple variables)
+
+! --- TKE MIXING DIAGNOSTICS (require mix_scheme_nmb==5 or 56) ---
+! 'TKE       ',1, 'm', 4,  ! TKE diagnostics (multiple variables)
+
+! --- IDEMIX MIXING DIAGNOSTICS (require mod(mix_scheme_nmb,10)==6) ---
+! 'IDEMIX    ',1, 'm', 4,  ! IDEMIX diagnostics (multiple variables)
+
+! --- TIDAL MIXING DIAGNOSTICS (require mod(mix_scheme_nmb,10)==7) ---
+! 'TIDAL     ',1, 'm', 4,  ! TIDAL diagnostics (multiple variables)
+
+! --- FORCING DIAGNOSTICS (require ldiag_forc=.true.) ---
+! 'FORC      ',1, 'm', 4,  ! forcing diagnostics (multiple variables)
+
+! --- DISCRETE VARIANCE DECAY (require ldiag_DVD=.true.) ---
+! 'DVD       ',1, 'm', 4,  ! DVD diagnostics (multiple variables)
+
+! --- SPLIT-EXPLICIT SUBCYCLING (require dynamics%use_ssh_se_subcycl=.true.) ---
+! 'SPLIT-EXPL',1, 'm', 4,  ! split-explicit diagnostics (multiple variables)
+
+! --- SQUARED VELOCITIES (require ldiag_uvw_sqr=.true.) ---
+! 'UVW_SQR   ',1, 'm', 4,  ! squared velocities (u2, v2, w2)
+
+! --- TRACER GRADIENTS (require ldiag_trgrd_xyz=.true.) ---
+! 'TRGRD_XYZ ',1, 'm', 4,  ! horizontal and vertical tracer gradients
+
+! --- CMOR DIAGNOSTICS FOR CMIP6/CMIP7 (require ldiag_cmor=.true.) ---
+! 'tos       ',1, 'm', 8,  ! sea surface temperature [degC] (CMOR standard)
+! 'sos       ',1, 'm', 8,  ! sea surface salinity [psu] (CMOR standard)
+! 'pbo       ',1, 'm', 8,  ! sea water pressure at sea floor [Pa]
+! 'opottemptend',1, 'm', 8,! ocean potential temperature tendency [W/m^2]
+! 'volo      ',1, 'm', 8,  ! ocean volume [m^3] (global scalar)
+! 'soga      ',1, 'm', 8,  ! global mean sea water salinity [psu] (global scalar)
+! 'thetaoga  ',1, 'm', 8,  ! global mean sea water potential temperature [degC] (global scalar)
+! 'siarean   ',1, 'm', 8,  ! sea ice area Northern hemisphere [10^12 m^2] (global scalar)
+! 'siareas   ',1, 'm', 8,  ! sea ice area Southern hemisphere [10^12 m^2] (global scalar)
+! 'siextentn ',1, 'm', 8,  ! sea ice extent Northern hemisphere [10^12 m^2] (global scalar)
+! 'siextents ',1, 'm', 8,  ! sea ice extent Southern hemisphere [10^12 m^2] (global scalar)
+! 'sivoln    ',1, 'm', 8,  ! sea ice volume Northern hemisphere [10^9 m^3] (global scalar)
+! 'sivols    ',1, 'm', 8,  ! sea ice volume Southern hemisphere [10^9 m^3] (global scalar)
+
+! ============================================================================
+! END OF CATALOG
+! ============================================================================

--- a/config/namelist.io.recom.2p3z2d
+++ b/config/namelist.io.recom.2p3z2d
@@ -1,31 +1,60 @@
+! ============================================================================
+! ============ Namelist file for FESOM2 output configuration =================
+! ============================================================================
+! This file contains configuration for model output and diagnostics:
+! - Diagnostic flags for optional output fields
+! - General output settings (compression, rotation)
+! - Output variable list with frequency and precision
+! - Complete catalog of all available output fields
+!
+! See the output catalog at the end of this file for all possible variables.
+! Some outputs require specific flags in &diag_list or other namelists.
+! ============================================================================
+
+! ============================================================================
+! DIAGNOSTIC FLAGS
+! ============================================================================
+! Enable/disable optional diagnostic computations and outputs.
+! Setting these to .true. enables additional output fields (see catalog below).
+! ============================================================================
 &diag_list
-ldiag_solver     =.false.
-lcurt_stress_surf=.false.
-ldiag_curl_vel3  =.false.
-ldiag_Ri         =.false.
-ldiag_turbflux   =.false.
-ldiag_salt3D     =.false.
-ldiag_dMOC       =.false.
-ldiag_DVD        =.false.
-ldiag_forc       =.false.
-ldiag_extflds    =.false.
-ldiag_destine    =.false.
-ldiag_trflx      =.false.
-ldiag_uvw_sqr    =.false.
-ldiag_trgrd_xyz  =.false.
+ldiag_solver      = .false.  ! enables solver diagnostics (convergence, iterations)
+lcurt_stress_surf = .false.  ! enables 'curl_surf' output (vorticity of surface stress)
+ldiag_curl_vel3   = .false.  ! enables 'curl_u' output (relative vorticity from 3D velocity)
+ldiag_Ri          = .false.  ! enables Richardson number diagnostics ('shear', 'Ri')
+ldiag_turbflux    = .false.  ! enables turbulent flux diagnostics ('KvdTdz', 'KvdSdz')
+ldiag_salt3D      = .false.  ! enables 3D salinity diagnostics
+ldiag_dMOC        = .false.  ! enables 'dMOC' output (density MOC diagnostics)
+ldiag_DVD         = .false.  ! enables 'DVD' output (Discrete Variance Decay diagnostics)
+ldiag_forc        = .false.  ! enables 'FORC' output (comprehensive forcing diagnostics)
+ldiag_extflds     = .false.  ! enables extended field diagnostics
+ldiag_destine     = .false.  ! enables heat content computation ('hc300m', 'hc700m', 'hc')
+ldiag_trflx       = .false.  ! enables tracer flux diagnostics ('utemp', 'vtemp', 'usalt', 'vsalt')
+ldiag_uvw_sqr     = .false.  ! enables 'UVW_SQR' output (squared velocities: u2, v2, w2)
+ldiag_trgrd_xyz   = .false.  ! enables 'TRGRD_XYZ' output (horizontal & vertical tracer gradients)
 /
 
+! ============================================================================
+! GENERAL OUTPUT SETTINGS
+! ============================================================================
 &nml_general
-io_listsize    =150 !number of streams to allocate. shallbe large or equal to the number of streams in &nml_list
-vec_autorotate =.false.
-compression_level = 1
+io_listsize       = 150      ! total number of streams to allocate. Shall be larger or equal to the number of streams in &nml_list (max. 150)
+vec_autorotate    = .false.  ! unrotate vector fields (velocities, winds) before writing to output files
+compression_level = 1        ! compression level for netCDF output (1=fastest, 9=smallest)
 /
 
-! for sea ice related variables use_ice should be true, otherewise there will be no output
-! for 'curl_surf' to work lcurt_stress_surf must be .true. otherwise no output
-! for 'fer_C', 'bolus_u', 'bolus_v', 'bolus_w', 'fer_K' to work Fer_GM must be .true. otherwise no output
-! 'otracers' - all other tracers if applicable
-! for 'dMOC' to work ldiag_dMOC must be .true. otherwise no output
+! ============================================================================
+! OUTPUT VARIABLE LIST
+! ============================================================================
+! Format: 'variable_id', frequency, unit, precision
+!   frequency  = output frequency (integer)
+!   unit       = 'y' (yearly), 'm' (monthly), 'd' (daily), 'h' (hourly), 's' (steps)
+!   precision  = 4 (single precision) or 8 (double precision)
+!   Note: in a single-precision build (WP=4) a field requesting precision 8 is
+!   still honoured (written as NF_DOUBLE; means accumulated in real64), but its
+!   samples are single-precision-sourced. FESOM prints one summary line at
+!   startup listing such fields.
+! ============================================================================
 &nml_list
 io_list =  'sst       ',1, 'm', 4,
            'sss       ',1, 'm', 4,
@@ -93,3 +122,277 @@ io_list =  'sst       ',1, 'm', 4,
            'respn',1, 'm', 4,
            'respd',1, 'm', 4,
 /
+
+! ============================================================================
+! COMPLETE CATALOG OF ALL POSSIBLE OUTPUT FIELDS
+! ============================================================================
+! Below is a comprehensive list of all valid io_list IDs available in FESOM2.
+! To enable any field, copy the line to the &nml_list section above.
+! NOTE: Some fields require specific flags to be enabled (see comments).
+! ============================================================================
+
+! --- 2D OCEAN SURFACE FIELDS ---
+! 'sst       ',1, 'm', 4,  ! sea surface temperature [C]
+! 'sss       ',1, 'm', 4,  ! sea surface salinity [psu]
+! 'ssh       ',1, 'm', 4,  ! sea surface elevation [m]
+! 'vve_5     ',1, 'm', 4,  ! vertical velocity at 5th level [m/s]
+! 't_star    ',1, 'm', 4,  ! air temperature [C]
+! 'qsr       ',1, 'm', 4,  ! solar radiation [W/s^2]
+
+! --- 3D OCEAN FIELDS ---
+! 'temp      ',1, 'm', 4,  ! temperature [C]
+! 'salt      ',1, 'm', 8,  ! salinity [psu]
+! 'sigma0    ',1, 'm', 4,  ! potential density [kg/m3]
+! 'u         ',1, 'm', 4,  ! zonal velocity [m/s]
+! 'v         ',1, 'm', 4,  ! meridional velocity [m/s]
+! 'unod      ',1, 'm', 4,  ! zonal velocity at nodes [m/s]
+! 'vnod      ',1, 'm', 4,  ! meridional velocity at nodes [m/s]
+! 'w         ',1, 'm', 4,  ! vertical velocity [m/s]
+! 'otracers  ',1, 'm', 4,  ! all other tracers if applicable
+! 'age       ',1, 'm', 4,  ! water age tracer [year] (require use_age_tracer=.true.)
+
+! --- 2D SSH DIAGNOSTIC VARIABLES ---
+! 'ssh_rhs   ',1, 'm', 4,  ! ssh rhs [m/s]
+! 'ssh_rhs_old',1, 'm', 4, ! ssh rhs old [m/s]
+! 'd_eta     ',1, 'm', 4,  ! dssh from solver [m]
+! 'hbar      ',1, 'm', 4,  ! ssh n+0.5 tstep [m]
+! 'hbar_old  ',1, 'm', 4,  ! ssh n-0.5 tstep [m]
+! 'dhe       ',1, 'm', 4,  ! dhbar @ elem [m]
+
+! --- SEA ICE FIELDS (require use_ice=.true.) ---
+! 'uice      ',1, 'm', 4,  ! ice velocity x [m/s]
+! 'vice      ',1, 'm', 4,  ! ice velocity y [m/s]
+! 'a_ice     ',1, 'm', 4,  ! ice concentration [%]
+! 'm_ice     ',1, 'm', 4,  ! ice height per unit area [m]
+! 'thdgrice  ',1, 'm', 4,  ! thermodynamic growth rate ice [m/s]
+! 'thdgrarea ',1, 'm', 4,  ! thermodynamic growth rate ice concentration [frac/s]
+! 'dyngrarea' ,1, 'm', 4,  ! dynamic growth rate ice concentration [frac/s]
+! 'dyngrice  ',1, 'm', 4,  ! dynamic growth rate ice [m/s]
+! 'thdgrsn   ',1, 'm', 4,  ! thermodynamic growth rate snow [m/s]
+! 'dyngrsnw  ',1, 'm', 4,  ! dynamic growth rate snow [m/s] 
+! 'flice     ',1, 'm', 4,  ! flooding growth rate ice [m/s]
+! 'm_snow    ',1, 'm', 4,  ! snow height per unit area [m]
+! 'h_ice     ',1, 'm', 4,  ! ice thickness over ice-covered fraction [m]
+! 'h_snow    ',1, 'm', 4,  ! snow thickness over ice-covered fraction [m]
+! 'fw_ice    ',1, 'm', 4,  ! fresh water flux from ice ['m/s']
+! 'fw_snw    ',1, 'm', 4,  ! fresh water flux from snow ['m/s']
+
+! --- SEA ICE DEBUG VARIABLES (require use_ice=.true.) ---
+! 'strength_ice',1, 'm', 4,  ! ice strength [?]
+! 'inv_areamass',1, 'm', 4,  ! inv_areamass [?]
+! 'rhs_a     ',1, 'm', 4,  ! rhs_a [?]
+! 'rhs_m     ',1, 'm', 4,  ! rhs_m [?]
+! 'sgm11     ',1, 'm', 4,  ! sgm11 [?]
+! 'sgm12     ',1, 'm', 4,  ! sgm12 [?]
+! 'sgm22     ',1, 'm', 4,  ! sgm22 [?]
+! 'eps11     ',1, 'm', 4,  ! eps11 [?]
+! 'eps12     ',1, 'm', 4,  ! eps12 [?]
+! 'eps22     ',1, 'm', 4,  ! eps22 [?]
+! 'u_rhs_ice ',1, 'm', 4,  ! u_rhs_ice [?]
+! 'v_rhs_ice ',1, 'm', 4,  ! v_rhs_ice [?]
+! 'metric_fac',1, 'm', 4,  ! metric_fac [?]
+! 'elevat_ice',1, 'm', 4,  ! elevat_ice [?]
+! 'uwice     ',1, 'm', 4,  ! uwice [?]
+! 'vwice     ',1, 'm', 4,  ! vwice [?]
+! 'twice     ',1, 'm', 4,  ! twice [?]
+! 'swice     ',1, 'm', 4,  ! swice [?]
+
+! --- MIXED LAYER DEPTH ---
+! 'MLD1      ',1, 'm', 4,  ! Mixed Layer Depth [m] Large et al. 1997, bvfreq(nz, node) > db_max
+! 'MLD2      ',1, 'm', 4,  ! Mixed Layer Depth [m] Levitus treshold, rhopot(nz)-rhopot(1) > 0.125_WP kg/m
+! 'MLD3      ',1, 'm', 4,  ! Mixed Layer Depth [m] Griffies 2016 , rhopot(nz)-rhopot(1) > 0.03_WP kg/m
+
+! --- HEAT CONTENT (require ldiag_destine=.true.) ---
+! 'hc300m    ',1, 'm', 4,  ! Vertically integrated heat content upper 300m [J m**-2]
+! 'hc700m    ',1, 'm', 4,  ! Vertically integrated heat content upper 700m [J m**-2]
+! 'hc        ',1, 'm', 4,  ! Vertically integrated heat content total column [J m**-2]
+
+! --- WATER ISOTOPES IN SEA ICE (require lwiso=.true.) ---
+! 'h2o18_ice ',1, 'm', 4,  ! h2o18 concentration in sea ice [kmol/m**3]
+! 'hDo16_ice ',1, 'm', 4,  ! hDo16 concentration in sea ice [kmol/m**3]
+! 'h2o16_ice ',1, 'm', 4,  ! h2o16 concentration in sea ice [kmol/m**3]
+
+! --- FRESHWATER FLUX (require use_landice_water=.true.) ---
+! 'landice   ',1, 'm', 4,  ! freshwater flux [m/s]
+
+! --- SURFACE FORCING ---
+! 'tx_sur    ',1, 'm', 4,  ! zonal wind str. to ocean [N/m2]
+! 'ty_sur    ',1, 'm', 4,  ! meridional wind str. to ocean [N/m2]
+! 'curl_surf ',1, 'm', 4,  ! vorticity of the surface stress [none] (require lcurt_stress_surf=.true.)
+! 'fh        ',1, 'm', 4,  ! heat flux [W/m2]
+! 'fw        ',1, 'm', 4,  ! fresh water flux [m/s]
+! 'atmice_x  ',1, 'm', 4,  ! stress atmice x [N/m2]
+! 'atmice_y  ',1, 'm', 4,  ! stress atmice y [N/m2]
+! 'atmoce_x  ',1, 'm', 4,  ! stress atmoce x [N/m2]
+! 'atmoce_y  ',1, 'm', 4,  ! stress atmoce y [N/m2]
+! 'iceoce_x  ',1, 'm', 4,  ! stress iceoce x [N/m2]
+! 'iceoce_y  ',1, 'm', 4,  ! stress iceoce y [N/m2]
+! 'alpha     ',1, 'm', 4,  ! thermal expansion [none]
+! 'beta      ',1, 'm', 4,  ! saline contraction [none]
+! 'dens_flux ',1, 'm', 4,  ! density flux [kg/(m3*s)]
+! 'runoff    ',1, 'm', 4,  ! river runoff [m/s]
+! 'evap      ',1, 'm', 4,  ! evaporation [m/s]
+! 'prec      ',1, 'm', 4,  ! precipitation rain [m/s]
+! 'snow      ',1, 'm', 4,  ! precipitation snow [m/s]
+! 'tair      ',1, 'm', 4,  ! surface air temperature [°C]
+! 'shum      ',1, 'm', 4,  ! specific humidity []
+! 'swr       ',1, 'm', 4,  ! short wave radiation [W/m^2]
+! 'lwr       ',1, 'm', 4,  ! long wave radiation [W/m^2]
+! 'uwind     ',1, 'm', 4,  ! 10m zonal surface wind velocity [m/s]
+! 'vwind     ',1, 'm', 4,  ! 10m merid. surface wind velocity [m/s]
+! 'virtsalt  ',1, 'm', 4,  ! virtual salt flux [m/s*psu]
+! 'relaxsalt ',1, 'm', 4,  ! relaxation salt flux [m/s*psu]
+! 'realsalt  ',1, 'm', 4,  ! real salt flux from sea ice [m/s*psu]
+
+! --- KPP VERTICAL MIXING (require mix_scheme_nmb==1,17,3,37) ---
+! 'kpp_obldepth',1, 'm', 4, ! KPP ocean boundary layer depth [m]
+! 'kpp_sbuoyflx',1, 'm', 4, ! surface buoyancy flux [m2/s3]
+
+! --- RECOM 2D BIOGEOCHEMISTRY (require use_REcoM=.true. and __recom) ---
+! 'dpCO2s    ',1, 'm', 4,  ! Difference of oceanic pCO2 minus atmospheric pCO2 [uatm]
+! 'pCO2s     ',1, 'm', 4,  ! Partial pressure of oceanic CO2 [uatm]
+! 'CO2f      ',1, 'm', 4,  ! CO2-flux into the surface water [mmolC/m2/d]
+! 'O2f       ',1, 'm', 4,  ! O2-flux into the surface water [mmolO/m2/d]
+! 'Hp        ',1, 'm', 4,  ! Mean of H-plus ions in the surface water [mol/kg]
+! 'aFe       ',1, 'm', 4,  ! Atmospheric iron input [umolFe/m2/s]
+! 'aN        ',1, 'm', 4,  ! Atmospheric DIN input [mmolN/m2/s]
+! 'benN      ',1, 'm', 4,  ! Benthos Nitrogen [mmol]
+! 'benC      ',1, 'm', 4,  ! Benthos Carbon [mmol]
+! 'benSi     ',1, 'm', 4,  ! Benthos silicon [mmol]
+! 'benCalc   ',1, 'm', 4,  ! Benthos calcite [mmol]
+! 'NPPn      ',1, 'm', 4,  ! Mean NPP nanophytoplankton [mmolC/m2/d]
+! 'NPPd      ',1, 'm', 4,  ! Mean NPP diatoms [mmolC/m2/d]
+! 'GPPn      ',1, 'm', 4,  ! Mean GPP nanophytoplankton [mmolC/m2/d]
+! 'GPPd      ',1, 'm', 4,  ! Mean GPP diatoms [mmolC/m2/d]
+! 'NNAn      ',1, 'm', 4,  ! Net N-assimilation nanophytoplankton [mmolN/m2/d]
+! 'NNAd      ',1, 'm', 4,  ! Net N-assimilation diatoms [mmolN/m2/d]
+! 'Chldegn   ',1, 'm', 4,  ! Chlorophyll degradation nanophytoplankton [1/d]
+! 'Chldegd   ',1, 'm', 4,  ! Chlorophyll degradation diatoms [1/d]
+! 'NPPc      ',1, 'm', 4,  ! Mean NPP coccolithophores [mmolC/(m2*d)]
+! 'GPPc      ',1, 'm', 4,  ! Mean GPP coccolithophores [mmolC/m2/d]
+! 'NNAc      ',1, 'm', 4,  ! Net N-assimilation coccolithophores [mmolN/(m2*d)]
+! 'Chldegc   ',1, 'm', 4,  ! Chlorophyll degradation coccolithophores [1/d]
+
+! --- RECOM 3D BIOGEOCHEMISTRY (require use_REcoM=.true. and __recom) ---
+! 'PAR       ',1, 'm', 4,  ! PAR [W/m2]
+! 'respmeso  ',1, 'm', 4,  ! Respiration rate of mesozooplankton [mmolC/m2/d]
+! 'respmacro ',1, 'm', 4,  ! Respiration rate of macrozooplankton [mmolC/m2/d]
+! 'respmicro ',1, 'm', 4,  ! Respiration rate of microzooplankton [mmolC/m2/d]
+! 'calcdiss  ',1, 'm', 4,  ! Calcite dissolution [mmolC/m2/d]
+! 'calcif    ',1, 'm', 4,  ! Calcification [mmolC/m2/d]
+! 'aggn      ',1, 'm', 4,  ! Aggregation of small phytoplankton [mmolC/m2/d]
+! 'aggd      ',1, 'm', 4,  ! Aggregation of diatoms [mmolC/m2/d]
+! 'aggc      ',1, 'm', 4,  ! Aggregation of coccolithophores [mmolC/m2/d]
+! 'docexn    ',1, 'm', 4,  ! DOC excretion by small phytoplankton [mmolC/m2/d]
+! 'docexd    ',1, 'm', 4,  ! DOC excretion by diatoms [mmolC/m2/d]
+! 'docexc    ',1, 'm', 4,  ! DOC excretion by coccolithophores [mmolC/m2/d]
+! 'respn     ',1, 'm', 4,  ! Respiration by small phytoplankton [mmolC/m2/d]
+! 'respd     ',1, 'm', 4,  ! Respiration by diatoms [mmolC/m2/d]
+! 'respc     ',1, 'm', 4,  ! Respiration by coccolithophores [mmolC/(m2*d)]
+! 'NPPn3D    ',1, 'm', 4,  ! Net primary production of small phytoplankton [mmolC/(m3*d)]
+! 'NPPd3D    ',1, 'm', 4,  ! Net primary production of diatoms [mmolC/(m3*d)]
+! 'NPPc3D    ',1, 'm', 4,  ! Net primary production of coccolithophores [mmolC/(m3*d)]
+
+! --- WATER ISOTOPES IN OCEAN (require lwiso=.true.) ---
+! 'h2o18     ',1, 'm', 4,  ! h2o18 concentration [kmol/m**3]
+! 'hDo16     ',1, 'm', 4,  ! hDo16 concentration [kmol/m**3]
+! 'h2o16     ',1, 'm', 4,  ! h2o16 concentration [kmol/m**3]
+
+! --- NEUTRAL SLOPES ---
+! 'slopetap_x',1, 'm', 4,  ! neutral slope tapered X [none]
+! 'slopetap_y',1, 'm', 4,  ! neutral slope tapered Y [none]
+! 'slopetap_z',1, 'm', 4,  ! neutral slope tapered Z [none]
+! 'slope_x   ',1, 'm', 4,  ! neutral slope X [none]
+! 'slope_y   ',1, 'm', 4,  ! neutral slope Y [none]
+! 'slope_z   ',1, 'm', 4,  ! neutral slope Z [none]
+
+! --- MIXING AND DYNAMICS ---
+! 'N2        ',1, 'm', 4,  ! brunt väisälä [1/s2]
+! 'Kv        ',1, 'm', 4,  ! vertical diffusivity Kv [m2/s]
+! 'Av        ',1, 'm', 4,  ! vertical viscosity Av [m2/s]
+
+! --- VISCOSITY TENDENCIES (require dynamics%opt_visc==8) ---
+! 'u_dis_tend',1, 'm', 4,  ! horizontal velocity viscosity tendency [m/s]
+! 'v_dis_tend',1, 'm', 4,  ! meridional velocity viscosity tendency [m/s]
+! 'u_back_tend',1, 'm', 4, ! horizontal velocity backscatter tendency [m2/s2]
+! 'v_back_tend',1, 'm', 4, ! meridional velocity backscatter tendency [m2/s2]
+! 'u_total_tend',1, 'm', 4,! horizontal velocity total viscosity tendency [m/s]
+! 'v_total_tend',1, 'm', 4,! meridional velocity total viscosity tendency [m/s]
+
+! --- FERRARI/GM PARAMETERISATION (require Fer_GM=.true.) ---
+! 'bolus_u   ',1, 'm', 4,  ! GM bolus velocity U [m/s]
+! 'bolus_v   ',1, 'm', 4,  ! GM bolus velocity V [m/s]
+! 'bolus_w   ',1, 'm', 4,  ! GM bolus velocity W [m/s]
+! 'fer_K     ',1, 'm', 4,  ! GM, stirring diff. [m2/s]
+! 'fer_scal  ',1, 'm', 4,  ! GM surface scaling []
+! 'fer_C     ',1, 'm', 4,  ! GM, depth independent speed [m/s]
+! 'cfl_z     ',1, 'm', 4,  ! vertical CFL criteria [?]
+
+! --- DENSITY MOC DIAGNOSTICS (require ldiag_dMOC=.true.) ---
+! 'dMOC      ',1, 'm', 4,  ! fluxes for density MOC (multiple variables)
+
+! --- PRESSURE GRADIENT FORCE ---
+! 'pgf_x     ',1, 'm', 4,  ! zonal pressure gradient force [m/s^2]
+! 'pgf_y     ',1, 'm', 4,  ! meridional pressure gradient force [m/s^2]
+
+! --- ALE LAYER THICKNESS ---
+! 'hnode     ',1, 'm', 4,  ! vertice layer thickness [m]
+! 'hnode_new ',1, 'm', 4,  ! hnode_new [m]
+! 'helem     ',1, 'm', 4,  ! elemental layer thickness [m]
+
+! --- OIFS/IFS INTERFACE (require __oifs or __ifsinterface) ---
+! 'alb       ',1, 'm', 4,  ! ice albedo [none]
+! 'ist       ',1, 'm', 4,  ! ice surface temperature [K]
+! 'qsi       ',1, 'm', 4,  ! ice heat flux [W/m^2]
+! 'qso       ',1, 'm', 4,  ! oce heat flux [W/m^2]
+! 'enthalpy  ',1, 'm', 4,  ! enthalpy of fusion [W/m^2]
+! 'qcon      ',1, 'm', 4,  ! conductive heat flux [W/m^2]
+! 'qres      ',1, 'm', 4,  ! residual heat flux [W/m^2]
+! 'runoff_liquid',1, 'm', 4, ! liquid water runoff [m/s]
+! 'runoff_solid',1, 'm', 4, ! solid water runoff [m/s]
+
+! --- ICEBERG OUTPUTS (require use_icebergs=.true.) ---
+! 'icb       ',1, 'm', 4,  ! iceberg outputs (multiple variables)
+
+! --- TKE MIXING DIAGNOSTICS (require mix_scheme_nmb==5 or 56) ---
+! 'TKE       ',1, 'm', 4,  ! TKE diagnostics (multiple variables)
+
+! --- IDEMIX MIXING DIAGNOSTICS (require mod(mix_scheme_nmb,10)==6) ---
+! 'IDEMIX    ',1, 'm', 4,  ! IDEMIX diagnostics (multiple variables)
+
+! --- TIDAL MIXING DIAGNOSTICS (require mod(mix_scheme_nmb,10)==7) ---
+! 'TIDAL     ',1, 'm', 4,  ! TIDAL diagnostics (multiple variables)
+
+! --- FORCING DIAGNOSTICS (require ldiag_forc=.true.) ---
+! 'FORC      ',1, 'm', 4,  ! forcing diagnostics (multiple variables)
+
+! --- DISCRETE VARIANCE DECAY (require ldiag_DVD=.true.) ---
+! 'DVD       ',1, 'm', 4,  ! DVD diagnostics (multiple variables)
+
+! --- SPLIT-EXPLICIT SUBCYCLING (require dynamics%use_ssh_se_subcycl=.true.) ---
+! 'SPLIT-EXPL',1, 'm', 4,  ! split-explicit diagnostics (multiple variables)
+
+! --- SQUARED VELOCITIES (require ldiag_uvw_sqr=.true.) ---
+! 'UVW_SQR   ',1, 'm', 4,  ! squared velocities (u2, v2, w2)
+
+! --- TRACER GRADIENTS (require ldiag_trgrd_xyz=.true.) ---
+! 'TRGRD_XYZ ',1, 'm', 4,  ! horizontal and vertical tracer gradients
+
+! --- CMOR DIAGNOSTICS FOR CMIP6/CMIP7 (require ldiag_cmor=.true.) ---
+! 'tos       ',1, 'm', 8,  ! sea surface temperature [degC] (CMOR standard)
+! 'sos       ',1, 'm', 8,  ! sea surface salinity [psu] (CMOR standard)
+! 'pbo       ',1, 'm', 8,  ! sea water pressure at sea floor [Pa]
+! 'opottemptend',1, 'm', 8,! ocean potential temperature tendency [W/m^2]
+! 'volo      ',1, 'm', 8,  ! ocean volume [m^3] (global scalar)
+! 'soga      ',1, 'm', 8,  ! global mean sea water salinity [psu] (global scalar)
+! 'thetaoga  ',1, 'm', 8,  ! global mean sea water potential temperature [degC] (global scalar)
+! 'siarean   ',1, 'm', 8,  ! sea ice area Northern hemisphere [10^12 m^2] (global scalar)
+! 'siareas   ',1, 'm', 8,  ! sea ice area Southern hemisphere [10^12 m^2] (global scalar)
+! 'siextentn ',1, 'm', 8,  ! sea ice extent Northern hemisphere [10^12 m^2] (global scalar)
+! 'siextents ',1, 'm', 8,  ! sea ice extent Southern hemisphere [10^12 m^2] (global scalar)
+! 'sivoln    ',1, 'm', 8,  ! sea ice volume Northern hemisphere [10^9 m^3] (global scalar)
+! 'sivols    ',1, 'm', 8,  ! sea ice volume Southern hemisphere [10^9 m^3] (global scalar)
+
+! ============================================================================
+! END OF CATALOG
+! ============================================================================

--- a/config/namelist.oce
+++ b/config/namelist.oce
@@ -28,7 +28,7 @@ SPP                = .false. ! enable Salt Plume Parameterization (for brine rej
 ! --- Gent-McWilliams (GM) Eddy Parameterization ---
 Fer_GM             = .true.  ! to swith on/off GM after Ferrari et al. 2010
 K_GM_max           = 1000.0  ! max. GM thickness diffusivity (m2/s)
-K_GM_min           = 2.0     ! max. GM thickness diffusivity (m2/s)
+K_GM_min           = 2.0     ! min. GM thickness diffusivity (m2/s)
 K_GM_bvref         = 1       ! def of bvref in ferreira scaling 0=srf,1=bot mld,2=mean over mld,3=weighted mean over mld
 K_GM_rampmax       = -1.0    ! Resol >K_GM_rampmax[km] GM on
 K_GM_rampmin       = -1.0    ! Resol <K_GM_rampmin[km] GM off, in between linear scaled down

--- a/config/namelist.oce.core2
+++ b/config/namelist.oce.core2
@@ -25,7 +25,7 @@ SPP                = .false. ! enable Salt Plume Parameterization (for brine rej
 ! --- Gent-McWilliams (GM) Eddy Parameterization ---
 Fer_GM             = .true.  ! to swith on/off GM after Ferrari et al. 2010
 K_GM_max           = 1000.0  ! max. GM thickness diffusivity (m2/s)
-K_GM_min           = 2.0     ! max. GM thickness diffusivity (m2/s)
+K_GM_min           = 2.0     ! min. GM thickness diffusivity (m2/s)
 K_GM_bvref         = 1       ! def of bvref in ferreira scaling 0=srf,1=bot mld,2=mean over mld,3=weighted mean over mld
 K_GM_rampmax       = -1.0    ! Resol >K_GM_rampmax[km] GM on
 K_GM_rampmin       = -1.0    ! Resol <K_GM_rampmin[km] GM off, in between linear scaled down
@@ -64,7 +64,7 @@ Redi_Kmin          = 100.0   ! minimum Redi difusivity thats left when Redi_Ktap
 
 ! --- Vertical Mixing Scheme ---
 visc_sh_limit      = 5.0e-3  ! maximum viscosity due to shear instability [m²/s] (for KPP)
-mix_scheme         = 'KPP'   ! vertical mixing scheme: 'KPP' (K-Profile Parameterization), 'PP' (Pacanowski-Philander), or 'TKE' (Turbulent Kinetic Energy)
+mix_scheme         = 'KPP'   ! vertical mixing scheme: 'KPP' (K-Profile Parameterization), 'PP' (Pacanowski-Philander), or 'cvmix_TKE' (Turbulent Kinetic Energy). For complete list of available shemes look at the oce_setup_step.F90. 
 
 ! --- Convection Parameters ---
 Ricr               = 0.3     ! critical bulk Richardson number (for convection onset)
@@ -74,6 +74,60 @@ concv              = 1.6     ! constant for pure convection (eq. 23 in Large et 
 ! --- Tidal Forcing ---
 use_global_tides   = .false. ! enable global tidal potential forcing
 /
+
+! ===================================================================
+! Initial condition perturbation settings
+! ===================================================================
+! This section controls random perturbation of initial temperature
+! and salinity fields. Useful for ensemble modeling and uncertainty
+! quantification.
+!
+! lperturb       : Enable/disable perturbation (.true./.false.)
+! perturb_mode   : When to apply perturbations
+!                  'initial_only' - Apply only during initial runs (not restarts)
+!                  'first_step'   - Apply during first time step (initial or restart)
+! perturb_method : Type of random distribution
+!                  'uniform'   - Uniform distribution between [min_val, max_val]
+!                  'gaussian'  - Gaussian distribution with mean=min_val, std_dev=max_val
+! perturb_seed   : Random seed for reproducible perturbations
+!                  -1 = use system time (different each run)
+!                  >0 = use specified seed (reproducible)
+! temp_perturb   : Temperature perturbation parameters
+!                  For uniform: [min_val, max_val] in Kelvin
+!                  For gaussian: [mean(=0.0), std_dev] in Kelvin
+! salt_perturb   : Salinity perturbation parameters
+!                  For uniform: [min_val, max_val] in PSU
+!                  For gaussian: [mean(=0.0), std_dev] in PSU
+!
+! Example for ensemble forecasting with Gaussian perturbations:
+!&oce_perturb
+!lperturb       = .true.
+!perturb_mode   = 'first_step'
+!perturb_method = 'gaussian'
+!perturb_seed   = 12345
+!temp_perturb   = 0.0, 1.D-13
+!salt_perturb   = 0.0, 2.D-13
+!/
+!
+! Example for sensitivity study with uniform perturbations:
+!&oce_perturb
+!lperturb       = .true.
+!perturb_mode   = 'initial_only'
+!perturb_method = 'uniform'
+!perturb_seed   = -1
+!temp_perturb   = -1.D-12, 1.D-12
+!salt_perturb   = -2.D-12, 2.D-12
+!/
+
+! Default behavior (no perturbations):
+!&oce_perturb
+!lperturb       = .false.
+!perturb_mode   = 'initial_only'
+!perturb_method = 'uniform'
+!perturb_seed   = -1
+!temp_perturb   = 0.0, 0.0
+!salt_perturb   = 0.0, 0.0
+!/
 
 ! ============================================================================
 ! NEVERWORLD2 (Toy_Neverworld2 module) -- only read if which_toy='neverworld2', unused here

--- a/config/namelist.oce.toy_dbgyre
+++ b/config/namelist.oce.toy_dbgyre
@@ -15,69 +15,122 @@
 ! ============================================================================
 &oce_dyn
 ! --- Basic ocean dynamics parameters ---
-C_d                = 0.001     ! bottom drag coefficient (dimensionless, typical: 0.0025)
-A_ver              = 1.e-4     ! background vertical viscosity [m²/s]
-scale_area         = 5.8e9     ! reference element area for viscosity/diffusivity scaling [m²]
+C_d                = 0.001   ! bottom drag coefficient (dimensionless, typical: 0.0025)
+A_ver              = 1.e-4   ! background vertical viscosity [m²/s]
+scale_area         = 5.8e9   ! reference element area for viscosity/diffusivity scaling [m²]
 
 ! --- Salt Plume Parameterization ---
-SPP                = .false.   ! enable Salt Plume Parameterization (for brine rejection under sea ice)
+SPP                = .false. ! enable Salt Plume Parameterization (for brine rejection under sea ice)
 
 ! --- Gent-McWilliams (GM) Eddy Parameterization ---
-Fer_GM             = .false.   ! to swith on/off GM after Ferrari et al. 2010
-K_GM_max           = 1000.0    ! max. GM thickness diffusivity (m2/s)
-K_GM_min           = 2.0       ! max. GM thickness diffusivity (m2/s)
-K_GM_bvref         = 2         ! def of bvref in ferreira scaling 0=srf,1=bot mld,2=mean over mld,3=weighted mean over mld
-K_GM_rampmax       = -1.0      ! Resol >K_GM_rampmax[km] GM on
-K_GM_rampmin       = -1.0      ! Resol <K_GM_rampmin[km] GM off, in between linear scaled down
-K_GM_resscalorder  = 1         ! scaling order 1: resol scaling, 2: area scaling 
-K_GM_cm            = 3.0       ! which baroclinic velocity used for GM ferrari method 1st, 2nd, 3rd, ...   
-K_GM_cmin          = 0.1       ! cutoff for near coastal minimum velocity
-K_GM_Ktaper        = .false.   ! apply neutral slope tapering function also to the GM coefficient
+Fer_GM             = .false. ! to swith on/off GM after Ferrari et al. 2010
+K_GM_max           = 1000.0  ! max. GM thickness diffusivity (m2/s)
+K_GM_min           = 2.0     ! min. GM thickness diffusivity (m2/s)
+K_GM_bvref         = 2       ! def of bvref in ferreira scaling 0=srf,1=bot mld,2=mean over mld,3=weighted mean over mld
+K_GM_rampmax       = -1.0    ! Resol >K_GM_rampmax[km] GM on
+K_GM_rampmin       = -1.0    ! Resol <K_GM_rampmin[km] GM off, in between linear scaled down
+K_GM_resscalorder  = 1       ! scaling order 1: resol scaling, 2: area scaling 
+K_GM_cm            = 3.0     ! which baroclinic velocity used for GM ferrari method 1st, 2nd, 3rd, ...   
+K_GM_cmin          = 0.1     ! cutoff for near coastal minimum velocity
+K_GM_Ktaper        = .false. ! apply neutral slope tapering function also to the GM coefficient
 
 ! --- GM Scaling Options ---
-scaling_Ferreira   = .false.   ! enable GM vertical scaling (Ferreira et al. 2005, as in FESOM 1.4)
-scaling_Rossby     = .false.   ! scale GM with Rossby radius (1.0 in coarse regions, 0.0 at 2 points/Rossby radius)
-scaling_resolution = .true.    ! scale GM with horizontal resolution (K_GM corresponds to 100km resolution)
-scaling_FESOM14    = .false.   ! use FESOM 1.4 GM treatment in Northern Hemisphere (zero within boundary layer)
+scaling_Ferreira   = .false. ! enable GM vertical scaling (Ferreira et al. 2005, as in FESOM 1.4)
+scaling_Rossby     = .false. ! scale GM with Rossby radius (1.0 in coarse regions, 0.0 at 2 points/Rossby radius)
+scaling_resolution = .true.  ! scale GM with horizontal resolution (K_GM corresponds to 100km resolution)
+scaling_FESOM14    = .false. ! use FESOM 1.4 GM treatment in Northern Hemisphere (zero within boundary layer)
 
-scaling_GMzexp     = .false.   ! do downscaling of GM & Redi over depth by exp(-z/z_ref)
-GMzexp_zref        = 500.0     ! reference for vertical exp GM scaling 
-GMzexp_smin        = 0.6       ! minimum scaling factor
+scaling_GMzexp     = .false. ! do downscaling of GM & Redi over depth by exp(-z/z_ref)
+GMzexp_zref        = 500.0   ! reference for vertical exp GM scaling 
+GMzexp_smin        = 0.6     ! minimum scaling factor
 
-scaling_GINsea     = .false.   ! Increase K_GM resolution scaling only in the GIN sea by factor 
-GINsea_fac         = 2.0       ! GIN sea K_GM upscaling factor 
+scaling_GINsea     = .false. ! Increase K_GM resolution scaling only in the GIN sea by factor 
+GINsea_fac         = 2.0     ! GIN sea K_GM upscaling factor 
 
-scaling_ODM95      = .true.    ! tapering based on critical slope, Danabasoglu and McWilliams, 1995
-ODM95_Scr          = 0.2e-2    ! Critical slope for tapering
-ODM95_Sd           = 1.0e-3    ! slope width of tapering smoothing zone
+scaling_ODM95      = .true.  ! tapering based on critical slope, Danabasoglu and McWilliams, 1995
+ODM95_Scr          = 0.2e-2  ! Critical slope for tapering
+ODM95_Sd           = 1.0e-3  ! slope width of tapering smoothing zone
 
-scaling_LDD97      = .false.   ! tapering in surface, William G. Large, Gokhan Danabasoglu, Scott C. Doney, 1997
-LDD97_c            = 2.0       ! [m/s] is the first baroclinic wave speed
-LDD97_rmin         = 15.0e3    ! rossby radius min cutoff [m]
-LDD97_rmax         = 100.0e3   ! rossby radius max cutoff [m]
+scaling_LDD97      = .false. ! tapering in surface, William G. Large, Gokhan Danabasoglu, Scott C. Doney, 1997
+LDD97_c            = 2.0     ! [m/s] is the first baroclinic wave speed
+LDD97_rmin         = 15.0e3  ! rossby radius min cutoff [m]
+LDD97_rmax         = 100.0e3 ! rossby radius max cutoff [m]
 
 ! --- Redi Isopycnal Diffusion ---
-Redi               = .false.   ! enable Redi isopycnal diffusion
-Redi_Ktaper        = .false.   ! apply neutral slope tapering function also to the Redi coefficient
-Redi_Kmax          = 0.0       ! Redi Diffusivity can be different from K_GM_max but recomment to be the same, if Redi_Kmax<=0 its synchronised with Redi_Kmax=K_GM_max 
-Redi_Kmin          = 100.0     ! minimum Redi difusivity thats left when Redi_Ktaper= .true.
+Redi               = .false. ! enable Redi isopycnal diffusion
+Redi_Ktaper        = .false. ! apply neutral slope tapering function also to the Redi coefficient
+Redi_Kmax          = 0.0	 ! Redi Diffusivity can be different from K_GM_max but recomment to be the same, if Redi_Kmax<=0 its synchronised with Redi_Kmax=K_GM_max 
+Redi_Kmin          = 100.0   ! minimum Redi difusivity thats left when Redi_Ktaper= .true.
 
 ! --- Vertical Mixing Scheme ---
-visc_sh_limit      = 5.0e-3    ! maximum viscosity due to shear instability [m²/s] (for KPP)
-mix_scheme         = 'PP'      ! vertical mixing scheme: 'KPP' (K-Profile Parameterization), 'PP' (Pacanowski-Philander), or 'TKE' (Turbulent Kinetic Energy)
+visc_sh_limit      = 5.0e-3  ! maximum viscosity due to shear instability [m²/s] (for KPP)
+mix_scheme         = 'PP'    ! vertical mixing scheme: 'KPP' (K-Profile Parameterization), 'PP' (Pacanowski-Philander), or 'cvmix_TKE' (Turbulent Kinetic Energy). For complete list of available shemes look at the oce_setup_step.F90. 
 
 ! --- Convection Parameters ---
-Ricr               = 0.3       ! critical bulk Richardson number (for convection onset)
-concv              = 1.6       ! constant for pure convection (eq. 23 in Large et al.)
+Ricr               = 0.3     ! critical bulk Richardson number (for convection onset)
+concv              = 1.6     ! constant for pure convection (eq. 23 in Large et al.)
                              ! typical values: Large 1.5-1.6, MOM default 1.8
 
 ! --- Tidal Forcing ---
-use_global_tides   = .false.   ! enable global tidal potential forcing
+use_global_tides   = .false. ! enable global tidal potential forcing
 /
+
+! ===================================================================
+! Initial condition perturbation settings
+! ===================================================================
+! This section controls random perturbation of initial temperature
+! and salinity fields. Useful for ensemble modeling and uncertainty
+! quantification.
+!
+! lperturb       : Enable/disable perturbation (.true./.false.)
+! perturb_mode   : When to apply perturbations
+!                  'initial_only' - Apply only during initial runs (not restarts)
+!                  'first_step'   - Apply during first time step (initial or restart)
+! perturb_method : Type of random distribution
+!                  'uniform'   - Uniform distribution between [min_val, max_val]
+!                  'gaussian'  - Gaussian distribution with mean=min_val, std_dev=max_val
+! perturb_seed   : Random seed for reproducible perturbations
+!                  -1 = use system time (different each run)
+!                  >0 = use specified seed (reproducible)
+! temp_perturb   : Temperature perturbation parameters
+!                  For uniform: [min_val, max_val] in Kelvin
+!                  For gaussian: [mean(=0.0), std_dev] in Kelvin
+! salt_perturb   : Salinity perturbation parameters
+!                  For uniform: [min_val, max_val] in PSU
+!                  For gaussian: [mean(=0.0), std_dev] in PSU
+!
+! Example for ensemble forecasting with Gaussian perturbations:
+!&oce_perturb
+!lperturb       = .true.
+!perturb_mode   = 'first_step'
+!perturb_method = 'gaussian'
+!perturb_seed   = 12345
+!temp_perturb   = 0.0, 1.D-13
+!salt_perturb   = 0.0, 2.D-13
+!/
+!
+! Example for sensitivity study with uniform perturbations:
+!&oce_perturb
+!lperturb       = .true.
+!perturb_mode   = 'initial_only'
+!perturb_method = 'uniform'
+!perturb_seed   = -1
+!temp_perturb   = -1.D-12, 1.D-12
+!salt_perturb   = -2.D-12, 2.D-12
+!/
+
+! Default behavior (no perturbations):
+!&oce_perturb
+!lperturb       = .false.
+!perturb_mode   = 'initial_only'
+!perturb_method = 'uniform'
+!perturb_seed   = -1
+!temp_perturb   = 0.0, 0.0
+!salt_perturb   = 0.0, 0.0
+!/
 
 ! ============================================================================
 ! NEVERWORLD2 (Toy_Neverworld2 module) -- only read if which_toy='neverworld2', unused here
 ! ============================================================================
 &oce_neverworld2
 /
-

--- a/config/namelist.oce.toy_neverworld2
+++ b/config/namelist.oce.toy_neverworld2
@@ -15,69 +15,122 @@
 ! ============================================================================
 &oce_dyn
 ! --- Basic ocean dynamics parameters ---
-C_d                = 0.001     ! bottom drag coefficient (dimensionless, typical: 0.0025)
-A_ver              = 1.e-4     ! background vertical viscosity [m²/s]
-scale_area         = 5.8e9     ! reference element area for viscosity/diffusivity scaling [m²]
+C_d                = 0.001   ! bottom drag coefficient (dimensionless, typical: 0.0025)
+A_ver              = 1.e-4   ! background vertical viscosity [m²/s]
+scale_area         = 5.8e9   ! reference element area for viscosity/diffusivity scaling [m²]
 
 ! --- Salt Plume Parameterization ---
-SPP                = .false.   ! enable Salt Plume Parameterization (for brine rejection under sea ice)
+SPP                = .false. ! enable Salt Plume Parameterization (for brine rejection under sea ice)
 
 ! --- Gent-McWilliams (GM) Eddy Parameterization ---
-Fer_GM             = .false.   ! to swith on/off GM after Ferrari et al. 2010
-K_GM_max           = 1000.0    ! max. GM thickness diffusivity (m2/s)
-K_GM_min           = 2.0       ! max. GM thickness diffusivity (m2/s)
-K_GM_bvref         = 2         ! def of bvref in ferreira scaling 0=srf,1=bot mld,2=mean over mld,3=weighted mean over mld
-K_GM_rampmax       = -1.0      ! Resol >K_GM_rampmax[km] GM on
-K_GM_rampmin       = -1.0      ! Resol <K_GM_rampmin[km] GM off, in between linear scaled down
-K_GM_resscalorder  = 1         ! scaling order 1: resol scaling, 2: area scaling 
-K_GM_cm            = 3.0       ! which baroclinic velocity used for GM ferrari method 1st, 2nd, 3rd, ...   
-K_GM_cmin          = 0.1       ! cutoff for near coastal minimum velocity
-K_GM_Ktaper        = .false.   ! apply neutral slope tapering function also to the GM coefficient
+Fer_GM             = .false. ! to swith on/off GM after Ferrari et al. 2010
+K_GM_max           = 1000.0  ! max. GM thickness diffusivity (m2/s)
+K_GM_min           = 2.0     ! min. GM thickness diffusivity (m2/s)
+K_GM_bvref         = 2       ! def of bvref in ferreira scaling 0=srf,1=bot mld,2=mean over mld,3=weighted mean over mld
+K_GM_rampmax       = -1.0    ! Resol >K_GM_rampmax[km] GM on
+K_GM_rampmin       = -1.0    ! Resol <K_GM_rampmin[km] GM off, in between linear scaled down
+K_GM_resscalorder  = 1       ! scaling order 1: resol scaling, 2: area scaling 
+K_GM_cm            = 3.0     ! which baroclinic velocity used for GM ferrari method 1st, 2nd, 3rd, ...   
+K_GM_cmin          = 0.1     ! cutoff for near coastal minimum velocity
+K_GM_Ktaper        = .false. ! apply neutral slope tapering function also to the GM coefficient
 
 ! --- GM Scaling Options ---
-scaling_Ferreira   = .false.   ! enable GM vertical scaling (Ferreira et al. 2005, as in FESOM 1.4)
-scaling_Rossby     = .false.   ! scale GM with Rossby radius (1.0 in coarse regions, 0.0 at 2 points/Rossby radius)
-scaling_resolution = .true.    ! scale GM with horizontal resolution (K_GM corresponds to 100km resolution)
-scaling_FESOM14    = .false.   ! use FESOM 1.4 GM treatment in Northern Hemisphere (zero within boundary layer)
+scaling_Ferreira   = .false. ! enable GM vertical scaling (Ferreira et al. 2005, as in FESOM 1.4)
+scaling_Rossby     = .false. ! scale GM with Rossby radius (1.0 in coarse regions, 0.0 at 2 points/Rossby radius)
+scaling_resolution = .true.  ! scale GM with horizontal resolution (K_GM corresponds to 100km resolution)
+scaling_FESOM14    = .false. ! use FESOM 1.4 GM treatment in Northern Hemisphere (zero within boundary layer)
 
-scaling_GMzexp     = .false.   ! do downscaling of GM & Redi over depth by exp(-z/z_ref)
-GMzexp_zref        = 500.0     ! reference for vertical exp GM scaling 
-GMzexp_smin        = 0.6       ! minimum scaling factor
+scaling_GMzexp     = .false. ! do downscaling of GM & Redi over depth by exp(-z/z_ref)
+GMzexp_zref        = 500.0   ! reference for vertical exp GM scaling 
+GMzexp_smin        = 0.6     ! minimum scaling factor
 
-scaling_GINsea     = .false.   ! Increase K_GM resolution scaling only in the GIN sea by factor 
-GINsea_fac         = 2.0       ! GIN sea K_GM upscaling factor 
+scaling_GINsea     = .false. ! Increase K_GM resolution scaling only in the GIN sea by factor 
+GINsea_fac         = 2.0     ! GIN sea K_GM upscaling factor 
 
-scaling_ODM95      = .true.    ! tapering based on critical slope, Danabasoglu and McWilliams, 1995
-ODM95_Scr          = 0.2e-2    ! Critical slope for tapering
-ODM95_Sd           = 1.0e-3    ! slope width of tapering smoothing zone
+scaling_ODM95      = .true.  ! tapering based on critical slope, Danabasoglu and McWilliams, 1995
+ODM95_Scr          = 0.2e-2  ! Critical slope for tapering
+ODM95_Sd           = 1.0e-3  ! slope width of tapering smoothing zone
 
-scaling_LDD97      = .false.   ! tapering in surface, William G. Large, Gokhan Danabasoglu, Scott C. Doney, 1997
-LDD97_c            = 2.0       ! [m/s] is the first baroclinic wave speed
-LDD97_rmin         = 15.0e3    ! rossby radius min cutoff [m]
-LDD97_rmax         = 100.0e3   ! rossby radius max cutoff [m]
+scaling_LDD97      = .false. ! tapering in surface, William G. Large, Gokhan Danabasoglu, Scott C. Doney, 1997
+LDD97_c            = 2.0     ! [m/s] is the first baroclinic wave speed
+LDD97_rmin         = 15.0e3  ! rossby radius min cutoff [m]
+LDD97_rmax         = 100.0e3 ! rossby radius max cutoff [m]
 
 ! --- Redi Isopycnal Diffusion ---
-Redi               = .false.   ! enable Redi isopycnal diffusion
-Redi_Ktaper        = .false.   ! apply neutral slope tapering function also to the Redi coefficient
-Redi_Kmax          = 0.0       ! Redi Diffusivity can be different from K_GM_max but recomment to be the same, if Redi_Kmax<=0 its synchronised with Redi_Kmax=K_GM_max 
-Redi_Kmin          = 100.0     ! minimum Redi difusivity thats left when Redi_Ktaper= .true.
+Redi               = .false. ! enable Redi isopycnal diffusion
+Redi_Ktaper        = .false. ! apply neutral slope tapering function also to the Redi coefficient
+Redi_Kmax          = 0.0	 ! Redi Diffusivity can be different from K_GM_max but recomment to be the same, if Redi_Kmax<=0 its synchronised with Redi_Kmax=K_GM_max 
+Redi_Kmin          = 100.0   ! minimum Redi difusivity thats left when Redi_Ktaper= .true.
 
 ! --- Vertical Mixing Scheme ---
-visc_sh_limit      = 5.0e-3    ! maximum viscosity due to shear instability [m²/s] (for KPP)
-mix_scheme         = 'TOY'      ! vertical mixing scheme: 'KPP' (K-Profile Parameterization), 'PP' (Pacanowski-Philander), or 'TKE' (Turbulent Kinetic Energy)
+visc_sh_limit      = 5.0e-3  ! maximum viscosity due to shear instability [m²/s] (for KPP)
+mix_scheme         = 'TOY'   ! vertical mixing scheme: 'KPP' (K-Profile Parameterization), 'PP' (Pacanowski-Philander), or 'cvmix_TKE' (Turbulent Kinetic Energy). For complete list of available shemes look at the oce_setup_step.F90. 
 
 ! --- Convection Parameters ---
-Ricr               = 0.3       ! critical bulk Richardson number (for convection onset)
-concv              = 1.6       ! constant for pure convection (eq. 23 in Large et al.)
-                               ! typical values: Large 1.5-1.6, MOM default 1.8
+Ricr               = 0.3     ! critical bulk Richardson number (for convection onset)
+concv              = 1.6     ! constant for pure convection (eq. 23 in Large et al.)
+                             ! typical values: Large 1.5-1.6, MOM default 1.8
 
 ! --- Tidal Forcing ---
-use_global_tides   = .false.   ! enable global tidal potential forcing
+use_global_tides   = .false. ! enable global tidal potential forcing
 
 ! --- State Equation ---
 state_equation     = 0         ! 0: use linear equation of state
-
 /
+
+! ===================================================================
+! Initial condition perturbation settings
+! ===================================================================
+! This section controls random perturbation of initial temperature
+! and salinity fields. Useful for ensemble modeling and uncertainty
+! quantification.
+!
+! lperturb       : Enable/disable perturbation (.true./.false.)
+! perturb_mode   : When to apply perturbations
+!                  'initial_only' - Apply only during initial runs (not restarts)
+!                  'first_step'   - Apply during first time step (initial or restart)
+! perturb_method : Type of random distribution
+!                  'uniform'   - Uniform distribution between [min_val, max_val]
+!                  'gaussian'  - Gaussian distribution with mean=min_val, std_dev=max_val
+! perturb_seed   : Random seed for reproducible perturbations
+!                  -1 = use system time (different each run)
+!                  >0 = use specified seed (reproducible)
+! temp_perturb   : Temperature perturbation parameters
+!                  For uniform: [min_val, max_val] in Kelvin
+!                  For gaussian: [mean(=0.0), std_dev] in Kelvin
+! salt_perturb   : Salinity perturbation parameters
+!                  For uniform: [min_val, max_val] in PSU
+!                  For gaussian: [mean(=0.0), std_dev] in PSU
+!
+! Example for ensemble forecasting with Gaussian perturbations:
+!&oce_perturb
+!lperturb       = .true.
+!perturb_mode   = 'first_step'
+!perturb_method = 'gaussian'
+!perturb_seed   = 12345
+!temp_perturb   = 0.0, 1.D-13
+!salt_perturb   = 0.0, 2.D-13
+!/
+!
+! Example for sensitivity study with uniform perturbations:
+!&oce_perturb
+!lperturb       = .true.
+!perturb_mode   = 'initial_only'
+!perturb_method = 'uniform'
+!perturb_seed   = -1
+!temp_perturb   = -1.D-12, 1.D-12
+!salt_perturb   = -2.D-12, 2.D-12
+!/
+
+! Default behavior (no perturbations):
+!&oce_perturb
+!lperturb       = .false.
+!perturb_mode   = 'initial_only'
+!perturb_method = 'uniform'
+!perturb_seed   = -1
+!temp_perturb   = 0.0, 0.0
+!salt_perturb   = 0.0, 0.0
+!/
 
 ! ============================================================================
 ! NEVERWORLD2 TOY CONFIG (Toy_Neverworld2 module, only read if which_toy='neverworld2')
@@ -195,4 +248,3 @@ do_Tseasonal        = .False.
 north_seasonal_amp  = 3.0     ! [degC], DINO Eq. B3 amplitude
 south_seasonal_amp  = 0.5     ! [degC], DINO Eq. B4 amplitude
 /
-

--- a/config/namelist.oce.toy_soufflet
+++ b/config/namelist.oce.toy_soufflet
@@ -15,71 +15,123 @@
 ! ============================================================================
 &oce_dyn
 state_equation     = 0          ! 1 - full equation of state, 0 - linear equation of state
-
 ! --- Basic ocean dynamics parameters ---
-C_d                = 0.0025     ! bottom drag coefficient (dimensionless, typical: 0.0025)
-A_ver              = 1.e-4      ! background vertical viscosity [m²/s]
-scale_area         = 5.8e9      ! reference element area for viscosity/diffusivity scaling [m²]
+C_d                = 0.0025  ! bottom drag coefficient (dimensionless, typical: 0.0025)
+A_ver              = 1.e-4   ! background vertical viscosity [m²/s]
+scale_area         = 5.8e9   ! reference element area for viscosity/diffusivity scaling [m²]
 
 ! --- Salt Plume Parameterization ---
-SPP                = .false.    ! enable Salt Plume Parameterization (for brine rejection under sea ice)
+SPP                = .false. ! enable Salt Plume Parameterization (for brine rejection under sea ice)
 
 ! --- Gent-McWilliams (GM) Eddy Parameterization ---
-Fer_GM             = .false.    ! to swith on/off GM after Ferrari et al. 2010
-K_GM_max           = 1000.0     ! max. GM thickness diffusivity (m2/s)
-K_GM_min           = 2.0        ! max. GM thickness diffusivity (m2/s)
-K_GM_bvref         = 2          ! def of bvref in ferreira scaling 0=srf,1=bot mld,2=mean over mld,3=weighted mean over mld
-K_GM_rampmax       = -1.0       ! Resol >K_GM_rampmax[km] GM on
-K_GM_rampmin       = -1.0       ! Resol <K_GM_rampmin[km] GM off, in between linear scaled down
-K_GM_resscalorder  = 1          ! scaling order 1: resol scaling, 2: area scaling 
-K_GM_cm            = 3.0        ! which baroclinic velocity used for GM ferrari method 1st, 2nd, 3rd, ...   
-K_GM_cmin          = 0.1        ! cutoff for near coastal minimum velocity
-K_GM_Ktaper        = .false.    ! apply neutral slope tapering function also to the GM coefficient
+Fer_GM             = .false. ! to swith on/off GM after Ferrari et al. 2010
+K_GM_max           = 1000.0  ! max. GM thickness diffusivity (m2/s)
+K_GM_min           = 2.0     ! min. GM thickness diffusivity (m2/s)
+K_GM_bvref         = 2       ! def of bvref in ferreira scaling 0=srf,1=bot mld,2=mean over mld,3=weighted mean over mld
+K_GM_rampmax       = -1.0    ! Resol >K_GM_rampmax[km] GM on
+K_GM_rampmin       = -1.0    ! Resol <K_GM_rampmin[km] GM off, in between linear scaled down
+K_GM_resscalorder  = 1       ! scaling order 1: resol scaling, 2: area scaling 
+K_GM_cm            = 3.0     ! which baroclinic velocity used for GM ferrari method 1st, 2nd, 3rd, ...   
+K_GM_cmin          = 0.1     ! cutoff for near coastal minimum velocity
+K_GM_Ktaper        = .false. ! apply neutral slope tapering function also to the GM coefficient
 
 ! --- GM Scaling Options ---
-scaling_Ferreira   = .false.    ! enable GM vertical scaling (Ferreira et al. 2005, as in FESOM 1.4)
-scaling_Rossby     = .false.    ! scale GM with Rossby radius (1.0 in coarse regions, 0.0 at 2 points/Rossby radius)
-scaling_resolution = .true.     ! scale GM with horizontal resolution (K_GM corresponds to 100km resolution)
-scaling_FESOM14    = .false.    ! use FESOM 1.4 GM treatment in Northern Hemisphere (zero within boundary layer)
+scaling_Ferreira   = .false. ! enable GM vertical scaling (Ferreira et al. 2005, as in FESOM 1.4)
+scaling_Rossby     = .false. ! scale GM with Rossby radius (1.0 in coarse regions, 0.0 at 2 points/Rossby radius)
+scaling_resolution = .true.  ! scale GM with horizontal resolution (K_GM corresponds to 100km resolution)
+scaling_FESOM14    = .false. ! use FESOM 1.4 GM treatment in Northern Hemisphere (zero within boundary layer)
 
-scaling_GMzexp     = .false.    ! do downscaling of GM & Redi over depth by exp(-z/z_ref)
-GMzexp_zref        = 500.0      ! reference for vertical exp GM scaling 
-GMzexp_smin        = 0.6        ! minimum scaling factor
+scaling_GMzexp     = .false. ! do downscaling of GM & Redi over depth by exp(-z/z_ref)
+GMzexp_zref        = 500.0   ! reference for vertical exp GM scaling 
+GMzexp_smin        = 0.6     ! minimum scaling factor
 
-scaling_GINsea     = .false.    ! Increase K_GM resolution scaling only in the GIN sea by factor 
-GINsea_fac         = 2.0        ! GIN sea K_GM upscaling factor 
+scaling_GINsea     = .false. ! Increase K_GM resolution scaling only in the GIN sea by factor 
+GINsea_fac         = 2.0     ! GIN sea K_GM upscaling factor 
 
-scaling_ODM95      = .true.     ! tapering based on critical slope, Danabasoglu and McWilliams, 1995
-ODM95_Scr          = 0.2e-2     ! Critical slope for tapering
-ODM95_Sd           = 1.0e-3     ! slope width of tapering smoothing zone
+scaling_ODM95      = .true.  ! tapering based on critical slope, Danabasoglu and McWilliams, 1995
+ODM95_Scr          = 0.2e-2  ! Critical slope for tapering
+ODM95_Sd           = 1.0e-3  ! slope width of tapering smoothing zone
 
-scaling_LDD97      = .false.    ! tapering in surface, William G. Large, Gokhan Danabasoglu, Scott C. Doney, 1997
-LDD97_c            = 2.0        ! [m/s] is the first baroclinic wave speed
-LDD97_rmin         = 15.0e3     ! rossby radius min cutoff [m]
-LDD97_rmax         = 100.0e3    ! rossby radius max cutoff [m]
+scaling_LDD97      = .false. ! tapering in surface, William G. Large, Gokhan Danabasoglu, Scott C. Doney, 1997
+LDD97_c            = 2.0     ! [m/s] is the first baroclinic wave speed
+LDD97_rmin         = 15.0e3  ! rossby radius min cutoff [m]
+LDD97_rmax         = 100.0e3 ! rossby radius max cutoff [m]
 
 ! --- Redi Isopycnal Diffusion ---
-Redi               = .false.    ! enable Redi isopycnal diffusion
-Redi_Ktaper        = .false.    ! apply neutral slope tapering function also to the Redi coefficient
-Redi_Kmax          = 0.0        ! Redi Diffusivity can be different from K_GM_max but recomment to be the same, if Redi_Kmax<=0 its synchronised with Redi_Kmax=K_GM_max 
-Redi_Kmin          = 100.0      ! minimum Redi difusivity thats left when Redi_Ktaper= .true.
+Redi               = .false. ! enable Redi isopycnal diffusion
+Redi_Ktaper        = .false. ! apply neutral slope tapering function also to the Redi coefficient
+Redi_Kmax          = 0.0	 ! Redi Diffusivity can be different from K_GM_max but recomment to be the same, if Redi_Kmax<=0 its synchronised with Redi_Kmax=K_GM_max 
+Redi_Kmin          = 100.0   ! minimum Redi difusivity thats left when Redi_Ktaper= .true.
 
 ! --- Vertical Mixing Scheme ---
-visc_sh_limit      = 5.0e-3     ! maximum viscosity due to shear instability [m²/s] (for KPP)
-mix_scheme         = 'PP'       ! vertical mixing scheme: 'KPP' (K-Profile Parameterization), 'PP' (Pacanowski-Philander), or 'TKE' (Turbulent Kinetic Energy)
+visc_sh_limit      = 5.0e-3  ! maximum viscosity due to shear instability [m²/s] (for KPP)
+mix_scheme         = 'PP'    ! vertical mixing scheme: 'KPP' (K-Profile Parameterization), 'PP' (Pacanowski-Philander), or 'cvmix_TKE' (Turbulent Kinetic Energy). For complete list of available shemes look at the oce_setup_step.F90. 
 
 ! --- Convection Parameters ---
-Ricr               = 0.3        ! critical bulk Richardson number (for convection onset)
-concv              = 1.6        ! constant for pure convection (eq. 23 in Large et al.)
-                                ! typical values: Large 1.5-1.6, MOM default 1.8
+Ricr               = 0.3     ! critical bulk Richardson number (for convection onset)
+concv              = 1.6     ! constant for pure convection (eq. 23 in Large et al.)
+                             ! typical values: Large 1.5-1.6, MOM default 1.8
 
 ! --- Tidal Forcing ---
-use_global_tides   = .false.    ! enable global tidal potential forcing
+use_global_tides   = .false. ! enable global tidal potential forcing
 /
+
+! ===================================================================
+! Initial condition perturbation settings
+! ===================================================================
+! This section controls random perturbation of initial temperature
+! and salinity fields. Useful for ensemble modeling and uncertainty
+! quantification.
+!
+! lperturb       : Enable/disable perturbation (.true./.false.)
+! perturb_mode   : When to apply perturbations
+!                  'initial_only' - Apply only during initial runs (not restarts)
+!                  'first_step'   - Apply during first time step (initial or restart)
+! perturb_method : Type of random distribution
+!                  'uniform'   - Uniform distribution between [min_val, max_val]
+!                  'gaussian'  - Gaussian distribution with mean=min_val, std_dev=max_val
+! perturb_seed   : Random seed for reproducible perturbations
+!                  -1 = use system time (different each run)
+!                  >0 = use specified seed (reproducible)
+! temp_perturb   : Temperature perturbation parameters
+!                  For uniform: [min_val, max_val] in Kelvin
+!                  For gaussian: [mean(=0.0), std_dev] in Kelvin
+! salt_perturb   : Salinity perturbation parameters
+!                  For uniform: [min_val, max_val] in PSU
+!                  For gaussian: [mean(=0.0), std_dev] in PSU
+!
+! Example for ensemble forecasting with Gaussian perturbations:
+!&oce_perturb
+!lperturb       = .true.
+!perturb_mode   = 'first_step'
+!perturb_method = 'gaussian'
+!perturb_seed   = 12345
+!temp_perturb   = 0.0, 1.D-13
+!salt_perturb   = 0.0, 2.D-13
+!/
+!
+! Example for sensitivity study with uniform perturbations:
+!&oce_perturb
+!lperturb       = .true.
+!perturb_mode   = 'initial_only'
+!perturb_method = 'uniform'
+!perturb_seed   = -1
+!temp_perturb   = -1.D-12, 1.D-12
+!salt_perturb   = -2.D-12, 2.D-12
+!/
+
+! Default behavior (no perturbations):
+!&oce_perturb
+!lperturb       = .false.
+!perturb_mode   = 'initial_only'
+!perturb_method = 'uniform'
+!perturb_seed   = -1
+!temp_perturb   = 0.0, 0.0
+!salt_perturb   = 0.0, 0.0
+!/
 
 ! ============================================================================
 ! NEVERWORLD2 (Toy_Neverworld2 module) -- only read if which_toy='neverworld2', unused here
 ! ============================================================================
 &oce_neverworld2
 /
-

--- a/config/namelist.recom.2p3z2d
+++ b/config/namelist.recom.2p3z2d
@@ -1,355 +1,501 @@
-! This is the namelist file for recom
+! ============================================================================
+! ============ Namelist file for FESOM2 REcoM biogeochemistry ================
+! ============================================================================
+! This file contains configuration for the REcoM biogeochemical model:
+! - Surface boundary condition input files
+! - Model switches, tracer counts and sinking
+! - Phytoplankton, zooplankton and detritus parameters
+! - Carbonate chemistry, iron, calcite and benthos
+! - Ballasting and carbon isotopes
+!
+! Phytoplankton parameters come in sets: no suffix = small phytoplankton,
+! _d = diatoms, _c = coccolithophores, _p = Phaeocystis (where present).
+! Zooplankton: first = mesozooplankton, second (suffix 2) = macrozooplankton,
+! third (suffix 3) = microzooplankton.
+! ============================================================================
 
+! ============================================================================
+! SURFACE BOUNDARY CONDITION FILES
+! ============================================================================
+! Relative names of the dust, aeolian nitrogen and CO2 files are taken from
+! ClimateDataPath; the river and erosion files are used as given.
+! ============================================================================
 &nam_rsbc
-fe_data_source        ='Albani'
-nm_fe_data_file       ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/DustClimMonthlyAlbani.nc'
-nm_aen_data_file      ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/AeolianNitrogenDep.nc'
-nm_river_data_file    ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/RiverineInput.nc'
-nm_erosion_data_file  ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/ErosionInput.nc'
-nm_co2_data_file      ='/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/MonthlyAtmCO2_gcb2023.nc'
+fe_data_source        = 'Albani'    ! 'Albani' reads nm_fe_data_file; any other value switches the Albani dust input off
+nm_fe_data_file       = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/DustClimMonthlyAlbani.nc'
+                                    ! monthly dust deposition climatology (Albani)
+nm_aen_data_file      = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/AeolianNitrogenDep.nc'
+                                    ! aeolian nitrogen deposition (useAeolianN)
+nm_river_data_file    = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/RiverineInput.nc'
+                                    ! riverine nutrient input (useRivers)
+nm_erosion_data_file  = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/ErosionInput.nc'
+                                    ! input from erosion (useErosion)
+nm_co2_data_file      = '/albedo/work/projects/p_pool_recom/input/mesh_CORE2_finaltopo_mean/MonthlyAtmCO2_gcb2023.nc'
+                                    ! atmospheric CO2 time series, read when constant_CO2 = .false.
 /
 
+! ============================================================================
+! MODEL SWITCHES, TRACER COUNTS AND SINKING
+! ============================================================================
 &pavariables
-use_REcoM             =.true.
-REcoM_restart         =.true.
+! --- Main Switches ---
+use_REcoM             = .true.      ! switch REcoM on
+REcoM_restart         = .true.      ! read the REcoM tracers from the restart (false = initialize from climatology)
+recom_debug           = .false.     ! extra REcoM debug output
+Diags                 = .true.      ! compute REcoM diagnostics
 
-bgc_num               = 31 !22 !33 !24 !38
-diags3d_num           = 28          ! Number of diagnostic 3d tracers to be saved
-bgc_base_num          = 22          ! standard tracers
-VDet                  = 20.d0       ! Sinking velocity, constant through the water column and positive downwards
-VDet_zoo2             = 200.d0      ! Sinking velocity, constant through the water column
-VPhy                  = 0.d0        !!! If the number of sinking velocities are different from 3, code needs to be changed !!!
-VDia                  = 0.d0
-VCocco	       	      = 0.d0       
-allow_var_sinking     = .true.   
-biostep               = 1           ! Number of times biology should be stepped forward for each time step		 
-REcoM_Geider_limiter  = .false.     ! Decides what routine should be used to calculate limiters in sms
-REcoM_Grazing_Variable_Preference = .true. ! Decides if grazing should have preference for phyN or DiaN 
-Grazing_detritus      = .true.
-het_resp_noredfield   = .true.    ! Decides respiratation of copepod group
-diatom_mucus          = .true.    ! Decides nutrient limitation effect on aggregation
-O2dep_remin           = .false.    ! O2remin Add option for O2 dependency of organic matter remineralization
-use_ballasting        = .false.    ! BALL
-use_density_scaling   = .false.    ! BALL
-use_viscosity_scaling = .false.    ! BALL
-OmegaC_diss           = .false.    ! DISS Use OmegaC from Mocsy to compute calcite dissolution (after Aumont et al. 2015 and Gehlen et al. 2007)
-CO2lim                = .false.    ! CO2 dependence of growth and calcification
-Diags                 = .true.
-constant_CO2          = .true.
-UseFeDust             = .true.      ! Turns dust input of iron off when set to.false.
-UseDustClim           = .true.
-UseDustClimAlbani     = .true.     ! Use Albani dustclim field (If it is false Mahowald will be used)
-use_photodamage       = .true.      ! use Alvarez et al (2018) for chlorophyll degradation
-HetRespFlux_plus      = .true.      !MB More stable computation of zooplankton respiration fluxes adding a small number to HetN
+! --- Tracer Counts ---
+bgc_num               = 31          ! number of REcoM tracers, checked at startup against enable_3zoo2det and enable_coccos
+diags3d_num           = 28          ! number of 3D diagnostic tracers to be saved
+bgc_base_num          = 22          ! number of standard (base) BGC tracers
+benthos_num           = 4           ! number of benthic BGC tracers: 8 with ciso = .true., otherwise 4
+Nmocsy                = 1           ! length of the vector passed to mocsy (always 1 for REcoM)
+biostep               = 1           ! number of biology steps per ocean time step
+
+! --- Sinking ---
+VDet                  = 20.d0       ! sinking velocity of small detritus [m/day], positive downwards
+VDet_zoo2             = 200.d0      ! sinking velocity of large detritus [m/day]
+VPhy                  = 0.d0        ! sinking velocity of small phytoplankton [m/day]
+VDia                  = 0.d0        ! sinking velocity of diatoms [m/day]
+VCocco                = 0.d0        ! sinking velocity of coccolithophores [m/day]
+allow_var_sinking     = .true.      ! detritus sinking speed increases with depth (Vdet_a in &pasinking)
+
+! --- Process Options ---
+REcoM_Geider_limiter  = .false.     ! selects the routine that calculates the limiters in the sources-minus-sinks
+REcoM_Grazing_Variable_Preference = .true. ! grazing preferences weighted by prey abundance
+Grazing_detritus      = .true.      ! zooplankton also graze on detritus
+het_resp_noredfield   = .true.      ! respiration formulation of the first zooplankton (copepods)
+diatom_mucus          = .true.      ! nutrient limitation enhances diatom aggregation
+O2dep_remin           = .false.     ! oxygen-dependent remineralization of organic matter (k_o2_remin)
+use_photodamage       = .true.      ! light-dependent chlorophyll degradation after Alvarez et al. (2018)
+HetRespFlux_plus      = .true.      ! more stable zooplankton respiration flux (not used by the current code)
+CO2lim                = .false.     ! CO2 dependence of growth and calcification (&paco2lim)
+OmegaC_diss           = .false.     ! calcite dissolution from the mocsy saturation state OmegaC
+                                    ! (Aumont et al. 2015, Gehlen et al. 2007); set calc_diss_guts = 0 when .false.
+
+! --- Ballasting ---
+use_ballasting        = .false.     ! mineral ballasting of detritus sinking (&paballasting)
+use_density_scaling   = .false.     ! scale sinking with seawater density (ballasting)
+use_viscosity_scaling = .false.     ! scale sinking with seawater viscosity (ballasting)
+
+! --- External Sources ---
+UseFeDust             = .true.      ! iron input from dust (not used by the current code, see fe_data_source)
+UseDustClim           = .true.      ! dust deposition climatology (not used by the current code)
+UseDustClimAlbani     = .true.      ! Albani dust climatology, otherwise Mahowald (not used by the current code)
+useRivers             = .false.     ! riverine nutrient input (nm_river_data_file)
+useRivFe              = .false.     ! riverine iron source
+useErosion            = .false.     ! input from erosion (nm_erosion_data_file)
+NitrogenSS            = .false.     ! external nitrogen sources and sinks (riverine, aeolian and denitrification)
+useAeolianN           = .false.     ! aeolian nitrogen deposition (nm_aen_data_file)
 REcoMDataPath         = '/albedo/work/projects/MarESys/ogurses/input/mesh_CORE2_finaltopo_mean/'
-restore_alkalinity    = .true.
-useRivers             = .false.
-useRivFe              = .false.      ! When set to true, riverine Fe source is activated
-useErosion            = .false.
-NitrogenSS            = .false.     ! When set to true, external sources and sinks of nitrogen are activated (Riverine, aeolian and denitrification)
-useAeolianN           = .false.      ! When set to true, aeolian nitrogen deposition is activated
-firstyearoffesomcycle = 1958        ! The first year of the actual physical forcing (e.g. JRA-55) used
-lastyearoffesomcycle  = 2024        ! Last year of the actual physical forcing used
-numofCO2cycles        = 1           ! Number of cycles of the forcing planned 
-currentCO2cycle       = 1           ! Which CO2 cycle we are currently running
-DIC_PI                = .true.
-Nmocsy                = 1           ! Length of the vector that is passed to mocsy (always one for recom)
-recom_debug           =.false.
-ciso                  =.false.     ! Main switch to enable/disable carbon isotopes (13|14C)
-benthos_num           = 4          ! number of benthic BGC tracers -> 8 if (ciso == .true.) otherwise -> 4
-use_MEDUSA            = .false.      ! Main switch for the sediment model MEDUSA
-sedflx_num            = 0           ! if 0: no file from MEDUSA is read but default sediment
-bottflx_num           = 4           ! if ciso&ciso_14: =8; if .not.ciso_14: =6; no ciso: =4
-use_atbox             = .false.
-add_loopback          = .false.     ! add loopback fluxes through rivers to the surface
-lb_tscale             = 1.0         ! /year: fraction of loopback fluxes yearly added to the surface
+                                    ! REcoM input directory (not used by the current code)
+
+! --- Carbon Chemistry and Atmospheric CO2 ---
+constant_CO2          = .true.      ! use CO2_for_spinup instead of the time series in nm_co2_data_file
+DIC_PI                = .true.      ! initialize DIC with the preindustrial GLODAP field
+restore_alkalinity    = .true.      ! restore surface alkalinity (surf_relax_Alk)
+use_atbox             = .false.     ! atmospheric box model for CO2
+firstyearoffesomcycle = 1958        ! first year of the physical forcing used (e.g. JRA55)
+lastyearoffesomcycle  = 2024        ! last year of the physical forcing used
+numofCO2cycles        = 1           ! number of forcing cycles planned
+currentCO2cycle       = 1           ! forcing cycle currently running
+
+! --- Carbon Isotopes and Sediment ---
+ciso                  = .false.     ! main switch for carbon isotopes (13C, 14C), see &paciso
+use_MEDUSA            = .false.     ! main switch for the sediment model MEDUSA
+sedflx_num            = 0           ! number of sediment fluxes read from MEDUSA (0 = none, default sediment)
+bottflx_num           = 4           ! number of bottom fluxes: 8 with ciso and ciso_14, 6 with ciso only, 4 without ciso
+add_loopback          = .false.     ! return loopback fluxes to the surface through rivers
+lb_tscale             = 1.0         ! fraction of the loopback fluxes added to the surface per year [1/year]
 /
 
+! ============================================================================
+! DEPTH-DEPENDENT SINKING
+! ============================================================================
 &pasinking
-Vdet_a                = 0.0288      ! [1/day]
-Vcalc                 = 0.0144      ! [1/day]
+Vdet_a                = 0.0288      ! increase of detritus sinking speed with depth [1/day] (allow_var_sinking)
+Vcalc                 = 0.0144      ! depth dependence of calcite dissolution [1/day]
 /
 
+! ============================================================================
+! INITIALIZATION
+! ============================================================================
 &painitialization_N
-cPhyN                 = 0.2d0
-cHetN                 = 0.2d0
-cZoo2N                = 0.2d0
+cPhyN                 = 0.2d0       ! initial small phytoplankton N (not used by the current code)
+cHetN                 = 0.2d0       ! initial first zooplankton N (not used by the current code)
+cZoo2N                = 0.2d0       ! initial second zooplankton N (not used by the current code)
 /
 
+! ============================================================================
+! TEMPERATURE DEPENDENCE
+! ============================================================================
 &paArrhenius
-recom_Tref            = 288.15d0    ! [K]
-C2K                   = 273.15d0    ! Conversion from degrees C to K
-Ae                    = 4500.d0     ! [K] Slope of the linear part of the Arrhenius function
-reminSi               = 0.02d0
-k_o2_remin            = 15.d0       ! NEW O2remin mmol m-3; Table 1 in Cram 2018 cites DeVries & Weber 2017 for a range of 0-30 mmol m-3
+recom_Tref            = 288.15d0    ! reference temperature of the Arrhenius function [K]
+C2K                   = 273.15d0    ! conversion from degrees C to K
+Ae                    = 4500.d0     ! slope of the linear part of the Arrhenius function [K]
+reminSi               = 0.02d0      ! lower bound of the silica remineralization rate [1/day]
+k_o2_remin            = 15.d0       ! half-saturation O2 for O2-dependent remineralization [mmol/m3] (O2dep_remin)
+                                    ! Cram et al. (2018), Table 1, cite 0-30 mmol/m3 (DeVries & Weber 2017)
 /
 
+! ============================================================================
+! LIMITATION FUNCTIONS
+! ============================================================================
 &palimiter_function
-NMinSlope             = 50.d0 
-SiMinSlope            = 1000.d0
-NCmin                 = 0.04d0 !0.05d0
-NCmin_d               = 0.04d0 !0.05d0
-NCmin_c		      = 0.04d0      ! NEW
-SiCmin                = 0.04d0
-k_Fe                  = 0.04d0
-k_Fe_d                = 0.12d0
-k_Fe_c		      = 0.09d0      ! NEW
-k_si                  = 4.d0
-P_cm                  = 3.0d0       ! [1/day]            Rate of C-specific photosynthesis 
-P_cm_d                = 3.5d0
-P_cm_c		      = 2.8d0	    ! NEW
+! --- Limitation Function Slopes ---
+NMinSlope             = 50.d0       ! steepness of the nitrogen limitation function at the minimum quota
+SiMinSlope            = 1000.d0     ! steepness of the silicon limitation function at the minimum quota
+
+! --- Minimum Quotas ---
+NCmin                 = 0.04d0      ! minimum N:C quota, small phytoplankton [mmol N/mmol C]
+NCmin_d               = 0.04d0      ! minimum N:C quota, diatoms [mmol N/mmol C]
+NCmin_c               = 0.04d0      ! minimum N:C quota, coccolithophores [mmol N/mmol C]
+SiCmin                = 0.04d0      ! minimum Si:C quota, diatoms [mmol Si/mmol C]
+
+! --- Nutrient Half-Saturation ---
+k_Fe                  = 0.04d0      ! half-saturation constant for iron uptake, small phytoplankton [µmol Fe/m3]
+k_Fe_d                = 0.12d0      ! half-saturation constant for iron uptake, diatoms [µmol Fe/m3]
+k_Fe_c                = 0.09d0      ! half-saturation constant for iron uptake, coccolithophores [µmol Fe/m3]
+k_si                  = 4.d0        ! half-saturation constant for silicate uptake, diatoms [mmol Si/m3]
+
+! --- Maximum Photosynthesis ---
+P_cm                  = 3.0d0       ! maximum C-specific photosynthesis rate, small phytoplankton [1/day]
+P_cm_d                = 3.5d0       ! maximum C-specific photosynthesis rate, diatoms [1/day]
+P_cm_c                = 2.8d0       ! maximum C-specific photosynthesis rate, coccolithophores [1/day] (not used by the current code)
 /
 
+! ============================================================================
+! LIGHT
+! ============================================================================
 &palight_calculations
-k_w                   = 0.04d0      ! [1/m]              Light attenuation coefficient
-a_chl                 = 0.03d0      ! [1/m * 1/(mg Chl)] Chlorophyll specific attenuation coefficients
+k_w                   = 0.04d0      ! light attenuation coefficient of water [1/m]
+a_chl                 = 0.03d0      ! chlorophyll-specific attenuation coefficient [1/m * 1/(mg Chl)]
 /
 
+! ============================================================================
+! PHOTOSYNTHESIS
+! ============================================================================
 &paphotosynthesis
-alfa                  = 0.14d0	    ! [(mmol C*m2)/(mg Chl*W*day)] 
-alfa_d                = 0.19d0      ! An initial slope of the P-I curve
-alfa_c		      = 0.10d0      ! NEW
-parFrac               = 0.43d0
+alfa                  = 0.14d0      ! initial slope of the P-I curve, small phytoplankton [(mmol C m²)/(mg Chl W day)]
+alfa_d                = 0.19d0      ! initial slope of the P-I curve, diatoms [(mmol C m²)/(mg Chl W day)]
+alfa_c                = 0.10d0      ! initial slope of the P-I curve, coccolithophores [(mmol C m²)/(mg Chl W day)]
+parFrac               = 0.43d0      ! photosynthetically active fraction of the shortwave radiation
 /
 
+! ============================================================================
+! NUTRIENT ASSIMILATION
+! ============================================================================
 &paassimilation
-V_cm_fact             = 0.7d0       ! scaling factor for temperature dependent maximum of C-specific N-uptake
-V_cm_fact_d           = 0.7d0  
-V_cm_fact_c	      = 0.7d0       ! NEW
-NMaxSlope             = 1000.d0     ! Max slope for limiting function
-SiMaxSlope            = 1000.d0
-NCmax                 = 0.2d0       ! [mmol N/mmol C] Maximum cell quota of nitrogen (N:C)
-NCmax_d               = 0.2d0
-NCmax_c		      = 0.15d0      ! NEW
-SiCmax                = 0.8d0
-NCuptakeRatio         = 0.2d0       ! [mmol N/mmol C] Maximum uptake ratio of N:C
-NCUptakeRatio_d       = 0.2d0
-NCUptakeRatio_c	      = 0.2d0       ! NEW
-SiCUptakeRatio        = 0.2d0
-k_din                 = 0.55d0      ! [mmol N/m3] Half-saturation constant for nitrate uptake
-k_din_d               = 1.0d0
-k_din_c		      = 0.9d0       ! NEW
-Chl2N_max             = 3.15d0      ! [mg CHL/mmol N] Maximum CHL a : N ratio = 0.3 gCHL gN^-1
-Chl2N_max_d           = 4.2d0
-Chl2N_max_c	      = 3.5d0       ! NEW
-res_phy               = 0.01d0      ! [1/day] Maintenance respiration rate constant
-res_phy_d             = 0.01d0
-res_phy_c	      = 0.01d0      ! NEW
-biosynth              = 2.33d0      ! [mmol C/mmol N] Cost of biosynthesis
-biosynthSi            = 0.d0
+! --- Nitrogen Uptake ---
+V_cm_fact             = 0.7d0       ! scaling of the temperature-dependent maximum C-specific N uptake, small phytoplankton
+V_cm_fact_d           = 0.7d0       ! scaling of the temperature-dependent maximum C-specific N uptake, diatoms
+V_cm_fact_c           = 0.7d0       ! scaling of the temperature-dependent maximum C-specific N uptake, coccolithophores
+NMaxSlope             = 1000.d0     ! steepness of the limitation function at the maximum N quota
+NCmax                 = 0.2d0       ! maximum N:C quota, small phytoplankton [mmol N/mmol C]
+NCmax_d               = 0.2d0       ! maximum N:C quota, diatoms [mmol N/mmol C]
+NCmax_c               = 0.15d0      ! maximum N:C quota, coccolithophores [mmol N/mmol C]
+NCuptakeRatio         = 0.2d0       ! maximum N:C uptake ratio, small phytoplankton [mmol N/mmol C]
+NCUptakeRatio_d       = 0.2d0       ! maximum N:C uptake ratio, diatoms [mmol N/mmol C]
+NCUptakeRatio_c       = 0.2d0       ! maximum N:C uptake ratio, coccolithophores [mmol N/mmol C]
+k_din                 = 0.55d0      ! half-saturation constant for nitrate uptake, small phytoplankton [mmol N/m3]
+k_din_d               = 1.0d0       ! half-saturation constant for nitrate uptake, diatoms [mmol N/m3]
+k_din_c               = 0.9d0       ! half-saturation constant for nitrate uptake, coccolithophores [mmol N/m3]
+
+! --- Silicon Uptake (Diatoms) ---
+SiMaxSlope            = 1000.d0     ! steepness of the limitation function at the maximum Si quota
+SiCmax                = 0.8d0       ! maximum Si:C quota [mmol Si/mmol C]
+SiCUptakeRatio        = 0.2d0       ! maximum Si:C uptake ratio [mmol Si/mmol C]
+
+! --- Chlorophyll ---
+Chl2N_max             = 3.15d0      ! maximum Chl:N ratio, small phytoplankton [mg Chl/mmol N]
+Chl2N_max_d           = 4.2d0       ! maximum Chl:N ratio, diatoms [mg Chl/mmol N]
+Chl2N_max_c           = 3.5d0       ! maximum Chl:N ratio, coccolithophores [mg Chl/mmol N]
+
+! --- Respiration ---
+res_phy               = 0.01d0      ! maintenance respiration rate, small phytoplankton [1/day]
+res_phy_d             = 0.01d0      ! maintenance respiration rate, diatoms [1/day]
+res_phy_c             = 0.01d0      ! maintenance respiration rate, coccolithophores [1/day]
+biosynth              = 2.33d0      ! cost of biosynthesis [mmol C/mmol N]
+biosynthSi            = 0.d0        ! cost of silica biosynthesis [mmol C/mmol Si]
 /
 
+! ============================================================================
+! IRON CHEMISTRY
+! ============================================================================
 &pairon_chem
-totalligand           = 1.d0        ! [mumol/m3] order 1. Total free ligand
-ligandStabConst       = 100.d0      ! [m3/mumol] order 100. Ligand-free iron stability constant
+totalligand           = 1.d0        ! total free ligand [µmol/m3] (order 1)
+ligandStabConst       = 100.d0      ! ligand-free iron stability constant [m3/µmol] (order 100)
 /
 
+! ============================================================================
+! FIRST ZOOPLANKTON (MESOZOOPLANKTON)
+! ============================================================================
 &pazooplankton
-graz_max              = 0.31d0       ! [mmol N/(m3 * day)] Maximum grazing loss parameter 
-epsilonr              = 0.09d0      ! [(mmol N)2 /m6] Half saturation constant for grazing loss 
-res_het               = 0.028d0      ! [1/day] Respiration by heterotrophs and mortality (loss to detritus)
-Redfield              = 6.625       ! [mmol C/mmol N] Redfield ratio of C:N = 106:16
-loss_het              = 0.04d0      ! [1/day] Temperature dependent N degradation of extracellular organic N (EON)
-pzDia                 = 1.0d0 !0.5d0       ! Maximum diatom preference
-sDiaNsq               = 0.d0
-pzPhy                 = 0.5d0 !0.25d0 !1.0d0       ! Maximum nano-phytoplankton preference (NEW: 3/12)
-sPhyNsq               = 0.d0
-pzCocco		      = 0.666d0     ! NEW (8/12)
-sCoccoNsq	      = 0.d0        ! NEW
-pzMicZoo              = 1.0d0       ! NEW 3Zoo Maximum nano-phytoplankton preference
-sMicZooNsq            = 0.d0        ! NEW 3Zoo
-tiny_het              = 1.d-5       ! for more stable computation of HetRespFlux (_plus). Value can be > tiny because HetRespFlux ~ hetC**2.
+graz_max              = 0.31d0      ! maximum grazing rate [mmol N/(m3 day)]
+epsilonr              = 0.09d0      ! half-saturation constant for grazing [(mmol N)^2/m^6]
+res_het               = 0.028d0     ! respiration and mortality (loss to detritus) [1/day]
+Redfield              = 6.625       ! Redfield C:N ratio (106:16) [mmol C/mmol N]
+loss_het              = 0.04d0      ! temperature-dependent N degradation of extracellular organic N (EON) [1/day]
+tiny_het              = 1.d-5       ! small number for a more stable HetRespFlux; may exceed tiny since HetRespFlux ~ HetC^2
+
+! --- Prey Preferences ---
+pzDia                 = 1.0d0       ! maximum diatom preference
+sDiaNsq               = 0.d0        ! not used by the current code
+pzPhy                 = 0.5d0       ! maximum small phytoplankton preference
+sPhyNsq               = 0.d0        ! not used by the current code
+pzCocco               = 0.666d0     ! maximum coccolithophore preference
+sCoccoNsq             = 0.d0        ! not used by the current code
+pzMicZoo              = 1.0d0       ! maximum microzooplankton preference
+sMicZooNsq            = 0.d0        ! not used by the current code
 /
 
+! ============================================================================
+! SECOND ZOOPLANKTON (MACROZOOPLANKTON)
+! ============================================================================
 &pasecondzooplankton
-graz_max2      = 0.1d0              ! [mmol N/(m3 * day)] Maximum grazing loss parameter                                                                                        
-epsilon2       = 0.0144d0           ! [(mmol N)2 /m6] Half saturation constant for grazing loss                                                                              
-res_zoo2       = 0.0107d0           ! [1/day] Respiration by heterotrophs and mortality (loss to detritus)                                                            
-loss_zoo2      = 0.003d0            ! [1/day] Temperature dependent N degradation of extracellular organic N (EON)
-fecal_rate_n      = 0.104d0         ! [1/day] Temperature dependent N degradation of \
-fecal_rate_c      = 0.236d0  
-fecal_rate_n_mes = 0.25d0           ! NEW 3Zoo
-fecal_rate_c_mes = 0.32d0           ! NEW 3Zoo                                                          
-pzDia2         = 1.5d0 !1.d0        ! Maximum diatom preference                                                                                                                 
-sDiaNsq2       = 0.d0
-pzPhy2         = 0.5d0              ! Maximum diatom preference                                                                                                                
-sPhyNsq2       = 0.d0
-pzCocco2       = 0.5d0              ! NEW
-sCoccoNsq2     = 0.d0		    ! NEW
-pzHet          = 1.5d0 !0.8d0              ! Maximum diatom preference                                                                                                               
-sHetNsq        = 0.d0
-pzMicZoo2      = 1.0d0              ! NEW 3Zoo Maximum nano-phytoplankton preference
-sMicZooNsq2    = 0.d0   
-t1_zoo2        = 28145.d0           ! Krill temp. function constant1                                                                                                       
-t2_zoo2        = 272.5d0            ! Krill temp. function constant2                                                                                                         
-t3_zoo2        = 105234.d0          ! Krill temp. function constant3                                                                                                      
-t4_zoo2        = 274.15d0           ! Krill temp. function constant3
+graz_max2             = 0.1d0       ! maximum grazing rate [mmol N/(m3 day)]
+epsilon2              = 0.0144d0    ! half-saturation constant for grazing [(mmol N)^2/m^6]
+res_zoo2              = 0.0107d0    ! respiration and mortality (loss to detritus) [1/day]
+loss_zoo2             = 0.003d0     ! temperature-dependent N degradation of extracellular organic N (EON) [1/day]
+
+! --- Fecal Pellets ---
+fecal_rate_n          = 0.104d0     ! fraction of the grazed nitrogen egested as fecal pellets
+fecal_rate_c          = 0.236d0     ! fraction of the grazed carbon egested as fecal pellets
+fecal_rate_n_mes      = 0.25d0      ! as fecal_rate_n, for the first zooplankton (mesozooplankton)
+fecal_rate_c_mes      = 0.32d0      ! as fecal_rate_c, for the first zooplankton (mesozooplankton)
+
+! --- Prey Preferences ---
+pzDia2                = 1.5d0       ! maximum diatom preference
+sDiaNsq2              = 0.d0        ! not used by the current code
+pzPhy2                = 0.5d0       ! maximum small phytoplankton preference
+sPhyNsq2              = 0.d0        ! not used by the current code
+pzCocco2              = 0.5d0       ! maximum coccolithophore preference
+sCoccoNsq2            = 0.d0        ! not used by the current code
+pzHet                 = 1.5d0       ! maximum preference for the first zooplankton
+sHetNsq               = 0.d0        ! not used by the current code
+pzMicZoo2             = 1.0d0       ! maximum microzooplankton preference
+sMicZooNsq2           = 0.d0        ! not used by the current code
+
+! --- Temperature Function (Krill) ---
+t1_zoo2               = 28145.d0    ! krill temperature function constant 1
+t2_zoo2               = 272.5d0     ! krill temperature function constant 2
+t3_zoo2               = 105234.d0   ! krill temperature function constant 3
+t4_zoo2               = 274.15d0    ! krill temperature function constant 4
 /
 
+! ============================================================================
+! THIRD ZOOPLANKTON (MICROZOOPLANKTON)
+! ============================================================================
 &pathirdzooplankton
-graz_max3      = 0.46d0             ! NEW 3Zoo [mmol N/(m3 * day)] Maximum grazing loss parameter
-epsilon3       = 0.64d0             ! NEW 3Zoo [(mmol N)2 /m6] Half saturation constant for grazing loss
-loss_miczoo    = 0.01d0             ! NEW 3Zoo [1/day] Temperature dependent N degradation of extracellular organic N (EON)
-res_miczoo     = 0.01d0             ! NEW 3Zoo [1/day] Respiration by heterotrophs and mortality (loss to detritus)
-pzDia3         = 0.5d0              ! NEW 3Zoo Maximum diatom preference
-sDiaNsq3       = 0.d0               ! NEW 3Zoo
-pzPhy3         = 1.0d0              ! NEW 3Zoo Maximum nano-phytoplankton preference
-sPhyNsq3       = 0.d0               ! NEW 3Zoo
-pzCocco3       = 0.d0               ! NEW 3Zoo Maximum coccolithophore preference ! ATTENTION: This value needs to be tuned; I start with zero preference!
-sCoccoNsq3     = 0.d0               ! NEW 3Zoo
+graz_max3             = 0.46d0      ! maximum grazing rate [mmol N/(m3 day)]
+epsilon3              = 0.64d0      ! half-saturation constant for grazing [(mmol N)^2/m^6]
+loss_miczoo           = 0.01d0      ! temperature-dependent N degradation of extracellular organic N (EON) [1/day]
+res_miczoo            = 0.01d0      ! respiration and mortality (loss to detritus) [1/day]
+
+! --- Prey Preferences ---
+pzDia3                = 0.5d0       ! maximum diatom preference
+sDiaNsq3              = 0.d0        ! not used by the current code
+pzPhy3                = 1.0d0       ! maximum small phytoplankton preference
+sPhyNsq3              = 0.d0        ! not used by the current code
+pzCocco3              = 0.d0        ! maximum coccolithophore preference (still to be tuned)
+sCoccoNsq3            = 0.d0        ! not used by the current code
 /
 
+! ============================================================================
+! GRAZING ON DETRITUS
+! ============================================================================
 &pagrazingdetritus
-pzDet         = 0.5d0           ! Maximum small detritus prefence by first zooplankton
-sDetNsq       = 0.d0
-pzDetZ2       = 0.5d0         ! Maximum large detritus preference by first zooplankton                                 
-sDetZ2Nsq     = 0.d0
-pzDet2         = 0.5d0           ! Maximum small detritus prefence by second zooplankton                               
-sDetNsq2       = 0.d0
-pzDetZ22       = 0.5d0           ! Maximum large detritus preference by second zooplankton
-sDetZ2Nsq2     = 0.d0
+pzDet                 = 0.5d0       ! maximum small detritus preference, first zooplankton
+sDetNsq               = 0.d0        ! not used by the current code
+pzDetZ2               = 0.5d0       ! maximum large detritus preference, first zooplankton
+sDetZ2Nsq             = 0.d0        ! not used by the current code
+pzDet2                = 0.5d0       ! maximum small detritus preference, second zooplankton
+sDetNsq2              = 0.d0        ! not used by the current code
+pzDetZ22              = 0.5d0       ! maximum large detritus preference, second zooplankton
+sDetZ2Nsq2            = 0.d0        ! not used by the current code
 /
 
+! ============================================================================
+! AGGREGATION
+! ============================================================================
 &paaggregation
-agg_PD                = 0.165d0     ! [m3/(mmol N * day)] Maximum aggregation loss parameter for DetN
-agg_PP                = 0.015d0     ! [m3/(mmol N * day)] Maximum aggregation loss parameter for PhyN and DiaN (plankton)
+agg_PD                = 0.165d0     ! maximum aggregation loss parameter for detritus [m3/(mmol N day)]
+agg_PP                = 0.015d0     ! maximum aggregation loss parameter for phytoplankton [m3/(mmol N day)]
 /
 
+! ============================================================================
+! DISSOLVED ORGANIC MATTER
+! ============================================================================
 &padin_rho_N
-rho_N                 = 0.11d0      ! [1/day] Temperature dependent N degradation of extracellular organic N (EON) (Remineralization of DON)
+rho_N                 = 0.11d0      ! temperature-dependent remineralization of DON (degradation of EON) [1/day]
 /
 
 &padic_rho_C1
-rho_C1                = 0.1d0       ! [1/day] Temperature dependent C degradation of extracellular organic C (EOC)
+rho_C1                = 0.1d0       ! temperature-dependent degradation of extracellular organic C (EOC) [1/day]
 /
 
+! ============================================================================
+! PHYTOPLANKTON LOSSES
+! ============================================================================
 &paphytoplankton_N
-lossN                 = 0.05d0      ! [1/day] Phytoplankton loss of organic N compounds
-lossN_d               = 0.05d0
-lossN_c		      = 0.05d0      ! NEW
+lossN                 = 0.05d0      ! loss of organic N compounds, small phytoplankton [1/day]
+lossN_d               = 0.05d0      ! loss of organic N compounds, diatoms [1/day]
+lossN_c               = 0.05d0      ! loss of organic N compounds, coccolithophores [1/day]
 /
 
 &paphytoplankton_C
-lossC                 = 0.10d0      ! [1/day] Phytoplankton loss of carbon 
-lossC_d               = 0.10d0
-lossC_c		      = 0.10d0      ! NEW
+lossC                 = 0.10d0      ! loss of carbon, small phytoplankton [1/day]
+lossC_d               = 0.10d0      ! loss of carbon, diatoms [1/day]
+lossC_c               = 0.10d0      ! loss of carbon, coccolithophores [1/day]
 /
 
 &paphytoplankton_ChlA
-deg_Chl               = 0.25d0 !0.2d0 !0.25d0      ! [1/day]
-deg_Chl_d             = 0.15d0 !0.2d0 !0.15d0
-deg_Chl_c	      = 0.2d0       ! NEW (has been 0.5)
+deg_Chl               = 0.25d0      ! chlorophyll degradation rate, small phytoplankton [1/day]
+deg_Chl_d             = 0.15d0      ! chlorophyll degradation rate, diatoms [1/day]
+deg_Chl_c             = 0.2d0       ! chlorophyll degradation rate, coccolithophores [1/day]
 /
 
+! ============================================================================
+! DETRITUS
+! ============================================================================
 &padetritus_N
-gfin                  = 0.3d0         ! NEW 3Zoo [] Grazing efficiency (fraction of grazing flux into zooplankton pool)
-grazEff2              = 0.8d0         ! [] Grazing efficiency (fraction of grazing flux into second zooplankton pool)
-grazEff3              = 0.8d0         ! NEW 3Zoo [] Grazing efficiency (fraction of grazing flux into microzooplankton pool)
-reminN                = 0.165d0       ! [1/day] Temperature dependent remineralisation rate of detritus	
+gfin                  = 0.3d0       ! grazing efficiency of the first zooplankton (fraction of the grazing flux it retains)
+grazEff2              = 0.8d0       ! grazing efficiency of the second zooplankton
+grazEff3              = 0.8d0       ! grazing efficiency of the microzooplankton
+reminN                = 0.165d0     ! temperature-dependent remineralization rate of detrital N [1/day]
 /
 
 &padetritus_C
-reminC                = 0.15d0      ! [1/day] Temperature dependent remineralisation rate of detritus
-rho_c2                = 0.1d0       ! [1/day] Temperature dependent C degradation of TEP-C
+reminC                = 0.15d0      ! temperature-dependent remineralization rate of detrital C [1/day]
+rho_c2                = 0.1d0       ! temperature-dependent degradation of TEP-C [1/day]
 /
 
+! ============================================================================
+! ZOOPLANKTON EXCRETION
+! ============================================================================
 &paheterotrophs
-lossN_z               = 0.1d0
-lossC_z               = 0.1d0
+lossN_z               = 0.1d0       ! DON excretion by the first zooplankton [1/day]
+lossC_z               = 0.1d0       ! DOC excretion by the first zooplankton [1/day]
 /
 
 &paseczooloss
-lossN_z2              = 0.02d0
-lossC_z2              = 0.02d0
+lossN_z2              = 0.02d0      ! DON excretion by the second zooplankton [1/day]
+lossC_z2              = 0.02d0      ! DOC excretion by the second zooplankton [1/day]
 /
 
 &pathirdzooloss
-lossN_z3              = 0.05d0       ! NEW 3Zoo
-lossC_z3              = 0.05d0       ! NEW 3Zoo 
+lossN_z3              = 0.05d0      ! DON excretion by the microzooplankton [1/day]
+lossC_z3              = 0.05d0      ! DOC excretion by the microzooplankton [1/day]
 /
 
-&paco2lim                    ! NEW
-Cunits         = 976.5625    ! Conversion factor between [mol/m3] (model) and [umol/kg] (function): (1000 * 1000) / 1024                                                                                                                      
-a_co2_phy      = 1.162e+00   ! [dimensionless]
-a_co2_dia      = 1.040e+00   ! [dimensionless]
-a_co2_cocco    = 1.109e+00   ! [dimensionless]
-a_co2_calc     = 1.102e+00   ! [dimensionless]
-b_co2_phy      = 4.888e+01   ! [mol/kg]
-b_co2_dia      = 2.890e+01   ! [mol/kg]
-b_co2_cocco    = 3.767e+01   ! [mol/kg]
-b_co2_calc     = 4.238e+01   ! [mol/kg]
-c_co2_phy      = 2.255e-01   ! [kg/mol]
-c_co2_dia      = 8.778e-01   ! [kg/mol]
-c_co2_cocco    = 3.912e-01   ! [kg/mol]
-c_co2_calc     = 7.079e-01   ! [kg/mol]
-d_co2_phy      = 1.023e+07   ! [kg/mol]
-d_co2_dia      = 2.640e+06   ! [kg/mol]
-d_co2_cocco    = 9.450e+06   ! [kg/mol]
-d_co2_calc     = 1.343e+07   ! [kg/mol]
+! ============================================================================
+! CO2 DEPENDENCE OF GROWTH AND CALCIFICATION (CO2lim)
+! ============================================================================
+! Response = a*HCO3/(b + HCO3) - exp(-c*CO2) - d*10**(-pH), with HCO3 and
+! CO2 converted by Cunits; one set per phytoplankton group and calcification.
+! ============================================================================
+&paco2lim
+Cunits         = 976.5625    ! conversion between [mol/m3] (model) and [umol/kg] (function): (1000 * 1000) / 1024
+a_co2_phy      = 1.162e+00   ! HCO3 response coefficient a, small phytoplankton [dimensionless]
+a_co2_dia      = 1.040e+00   ! HCO3 response coefficient a, diatoms [dimensionless]
+a_co2_cocco    = 1.109e+00   ! HCO3 response coefficient a, coccolithophores [dimensionless]
+a_co2_calc     = 1.102e+00   ! HCO3 response coefficient a, calcification [dimensionless]
+b_co2_phy      = 4.888e+01   ! HCO3 half-saturation b, small phytoplankton [mol/kg]
+b_co2_dia      = 2.890e+01   ! HCO3 half-saturation b, diatoms [mol/kg]
+b_co2_cocco    = 3.767e+01   ! HCO3 half-saturation b, coccolithophores [mol/kg]
+b_co2_calc     = 4.238e+01   ! HCO3 half-saturation b, calcification [mol/kg]
+c_co2_phy      = 2.255e-01   ! CO2 inhibition coefficient c, small phytoplankton [kg/mol]
+c_co2_dia      = 8.778e-01   ! CO2 inhibition coefficient c, diatoms [kg/mol]
+c_co2_cocco    = 3.912e-01   ! CO2 inhibition coefficient c, coccolithophores [kg/mol]
+c_co2_calc     = 7.079e-01   ! CO2 inhibition coefficient c, calcification [kg/mol]
+d_co2_phy      = 1.023e+07   ! H+ inhibition coefficient d, small phytoplankton [kg/mol]
+d_co2_dia      = 2.640e+06   ! H+ inhibition coefficient d, diatoms [kg/mol]
+d_co2_cocco    = 9.450e+06   ! H+ inhibition coefficient d, coccolithophores [kg/mol]
+d_co2_calc     = 1.343e+07   ! H+ inhibition coefficient d, calcification [kg/mol]
 /
 
+! ============================================================================
+! IRON
+! ============================================================================
 &pairon
-Fe2N                  = 0.033d0     ! Fe2C * 6.625
-Fe2N_benthos          = 0.15d0      ! test, default was 0.14 Fe2C_benthos * 6.625 - will have to be tuned. [umol/m2/day]
-kScavFe               = 0.07d0
-dust_sol              = 0.02d0      ! Dissolution of Dust for bioavaliable
-RiverFeConc           = 100
+Fe2N                  = 0.033d0     ! Fe:N ratio of organic matter (Fe2C * 6.625)
+Fe2N_benthos          = 0.15d0      ! Fe:N ratio of the benthic iron release (Fe2C_benthos * 6.625; was 0.14, still to be tuned)
+kScavFe               = 0.07d0      ! scavenging rate of free iron onto detritus
+dust_sol              = 0.02d0      ! soluble (bioavailable) fraction of dust iron
+RiverFeConc           = 100         ! mean dissolved iron concentration in rivers (useRivFe)
 /
 
+! ============================================================================
+! CALCITE
+! ============================================================================
 &pacalc
-calc_prod_ratio       = 0.02
-calc_diss_guts        = 0.0d0
-calc_diss_rate        = 0.005714    ! 20.d0/3500.d0
-calc_diss_rate2       = 0.005714d0
-calc_diss_omegac      = 0.197d0     ! NEW DISS Value from Aumont et al. 2015, will be used with OmegaC_diss flag
-calc_diss_exp         = 1.d0        ! NEW DISS Exponent in the dissolution rate of calcite, will be used with OmegaC_diss flag
+calc_prod_ratio       = 0.02        ! calcite production as a fraction of small phytoplankton carbon fixation
+calc_diss_guts        = 0.0d0       ! calcite dissolution in zooplankton guts (set to 0 when OmegaC_diss = .false.)
+calc_diss_rate        = 0.005714    ! calcite dissolution rate (20/3500) [1/day]
+calc_diss_rate2       = 0.005714d0  ! calcite dissolution rate of large detritus, scaled by its sinking speed / 20
+calc_diss_omegac      = 0.197d0     ! value from Aumont et al. (2015), used with OmegaC_diss
+calc_diss_exp         = 1.d0        ! exponent of the calcite dissolution rate, used with OmegaC_diss
 /
 
+! ============================================================================
+! BENTHOS
+! ============================================================================
 &pabenthos_decay_rate
-decayRateBenN         = 0.005d0
-decayRateBenC         = 0.005d0
-decayRateBenSi        = 0.005d0
+decayRateBenN         = 0.005d0     ! decay rate of benthic nitrogen [1/day]
+decayRateBenC         = 0.005d0     ! decay rate of benthic carbon [1/day]
+decayRateBenSi        = 0.005d0     ! decay rate of benthic silicon [1/day]
 q_NC_Denit            = 0.86d0      ! N:C quota of the denitrification process
 /
 
+! ============================================================================
+! AIR-SEA CO2 FLUX
+! ============================================================================
 &paco2_flux_param
-permil                = 0.000000976 ! 1.e-3/1024.5d0              ! Converting DIC from [mmol/m3] to [mol/kg]
-permeg                = 1.e-6                       ! [atm/uatm] Changes units from uatm to atm
+permil                = 0.000000976 ! converts DIC from [mmol/m3] to [mol/kg] (1.e-3/1024.5)
+permeg                = 1.e-6       ! converts uatm to atm [atm/uatm]
 !X1                    = exp(-5.d0*log(10.d0))       ! Lowest ph-value = 7.7 (phlo)
 !X2                    = exp(-9.d0*log(10.d0))       ! Highest ph-value = 9.5 (phhi)
-Xacc                  = 1.e-12                      ! Accuracy for ph-iteration (phacc)
-CO2_for_spinup        = 278.d0                      ! [uatm] Atmospheric partial pressure of CO2
+Xacc                  = 1.e-12      ! accuracy of the pH iteration
+CO2_for_spinup        = 278.d0      ! atmospheric pCO2 used with constant_CO2 = .true. [uatm]
 /
 
+! ============================================================================
+! ALKALINITY RESTORING
+! ============================================================================
 &paalkalinity_restoring
-surf_relax_Alk      = 3.2e-07 !10.d0/31536000.d0
+surf_relax_Alk        = 3.2e-07     ! surface alkalinity restoring velocity, 10 m per year [m/s] (restore_alkalinity)
 /
 
+! ============================================================================
+! BALLASTING (use_ballasting, see Cram et al. 2018)
+! ============================================================================
 &paballasting
-rho_POC              = 1033.d0   ! kg m-3; density of POC (see Table 1 in Cram et al., 2018)
-rho_PON              = 1033.d0   ! kg m-3; density of PON (see Table 1 in Cram et al., 2018)
-rho_CaCO3            = 2830.d0   ! kg m-3; density of CaCO3 (see Table 1 in Cram et al., 2018) 
-rho_opal             = 2090.d0   ! kg m-3; density of Opal (see Table 1 in Cram et al., 2018)
-rho_ref_part         = 1230.d0   ! kg m-3; reference particle density (see Cram et al., 2018)
-rho_ref_water        = 1027.d0   ! kg m-3; reference seawater density (see Cram et al., 2018)
-visc_ref_water       = 0.00158d0 ! kg m-1 s-1; reference seawater viscosity, at Temp=4 degC (see Cram et al., 2018)
-w_ref1               = 10.d0     ! m s-1; reference sinking velocity of small detritus
-w_ref2               = 200.d0    ! m s-1; reference sinking velocity of large detritus
-depth_scaling1       = 0.015d0   ! s-1; factor to increase sinking speed of det1 with depth, set to 0 if not wanted
-depth_scaling2       = 0.d0      ! s-1; factor to increase sinking speed of det2 with depth, set to 0 if not wanted
-max_sinking_velocity = 250.d0    ! d-1; for numerical stability, set a maximum possible sinking velocity here (applies to both detritus classes)
+rho_POC              = 1033.d0   ! density of POC [kg/m3] (Cram et al. 2018, Table 1)
+rho_PON              = 1033.d0   ! density of PON [kg/m3] (Cram et al. 2018, Table 1)
+rho_CaCO3            = 2830.d0   ! density of CaCO3 [kg/m3] (Cram et al. 2018, Table 1)
+rho_opal             = 2090.d0   ! density of opal [kg/m3] (Cram et al. 2018, Table 1)
+rho_ref_part         = 1230.d0   ! reference particle density [kg/m3]
+rho_ref_water        = 1027.d0   ! reference seawater density [kg/m3]
+visc_ref_water       = 0.00158d0 ! reference seawater viscosity at 4 degC [kg/(m s)]
+w_ref1               = 10.d0     ! reference sinking velocity of small detritus [m/day]
+w_ref2               = 200.d0    ! reference sinking velocity of large detritus [m/day]
+depth_scaling1       = 0.015d0   ! increase of small detritus sinking speed with depth [1/day], 0 = off
+depth_scaling2       = 0.d0      ! increase of large detritus sinking speed with depth [1/day], 0 = off
+max_sinking_velocity = 250.d0    ! upper limit of the sinking speed for numerical stability [m/day], both detritus classes
 /
 
+! ============================================================================
+! CARBON ISOTOPES (ciso)
+! ============================================================================
 &paciso
 ciso_init         = .false.     ! initial fractionation of bulk organic matter
-ciso_14           = .false.      ! include inorganic radiocarbon
+ciso_14           = .false.     ! include inorganic radiocarbon
 ciso_organic_14   = .false.     ! include organic radiocarbon
-lambda_14         = 3.8561e-12  ! corresponding to 1 year = 365.00 days
-delta_CO2_13      = -6.61       ! atmospheric d13C (permil), global-mean value
-big_delta_CO2_14(1)  = 0. ! atmospheric D14C (permil), northern hemisphere polewards of 30°N
-big_delta_CO2_14(2)  = 0. ! atmospheric D14C (permil), (sub) tropical zone 30°N - 30°S
-big_delta_CO2_14(3)  = 0. ! atmospheric D14C (permil), southern hemisphere polewards of 30°S
-atbox_spinup      = .false.
-cosmic_14_init    = 2.0
+lambda_14         = 3.8561e-12  ! radiocarbon decay constant [1/s] (1 year = 365.00 days)
+delta_CO2_13      = -6.61       ! atmospheric d13C, global mean [permil]
+big_delta_CO2_14(1)  = 0. ! atmospheric D14C north of 30°N [permil]
+big_delta_CO2_14(2)  = 0. ! atmospheric D14C between 30°N and 30°S [permil]
+big_delta_CO2_14(3)  = 0. ! atmospheric D14C south of 30°S [permil]
+atbox_spinup      = .false.     ! spin-up mode of the atmospheric 14C box
+cosmic_14_init    = 2.0         ! initial cosmogenic 14C production [atoms/(s cm²)]
 /
-

--- a/config/namelist.tra.recom.2p3z2d
+++ b/config/namelist.tra.recom.2p3z2d
@@ -1,9 +1,37 @@
+! ============================================================================
+! ============ Namelist file for FESOM2 tracer configuration =================
+! ============================================================================
+! This file contains configuration for ocean tracers (temperature, salinity,
+! and passive tracers):
+! - Tracer list and advection/diffusion schemes
+! - Initial conditions (3D ocean and 2D sea ice)
+! - Biharmonic diffusion options
+! - Vertical diffusion and time stepping
+! - Physical parameterizations (mixing, restoring)
+! ============================================================================
+
+! ============================================================================
+! TRACER ARRAY ALLOCATION
+! ============================================================================
 &tracer_listsize
-num_tracers=100 !number of tracers to allocate. shallbe large or equal to the number of streams in &nml_list
+num_tracers = 100         ! number of tracers to allocate (must be ≥ actual number of tracers)
 /
 
+! ============================================================================
+! TRACER LIST AND ADVECTION SCHEMES
+! ============================================================================
+! Format: ID, horizontal_advection, vertical_advection, horizontal_diffusion, Kh_factor, Kv_factor
+! Advection schemes: 'MFCT' (Multidimensional FCT), 'UPW1' (1st-order upwind), 'QR4C' (4th-order)
+! Diffusion schemes: 'FCT' (Flux-Corrected Transport), 'NON' (none)
+! Order switches   : hor./vert. Ord.=1.0 --> 4th order, =0.0 --> 3rd order, =0.5 --> mixed 3rd&4th order
+! ============================================================================
+! nml_tracer_list =
+! idx, hor. Adv, vert. Adv., use FCT, hor.Ord., vert. Ord. 
+! 1  , 'MFCT'  , 'QR4C'    , 'FCT ' , 1.      , 1.        ,   ! temperature
+! 2  , 'MFCT'  , 'QR4C'    , 'FCT ' , 1.      , 1.        ,   ! salinity
+!101 , 'UPW1'  , 'UPW1'    , 'NON ' , 0.      , 0.            ! example passive tracer
 &tracer_list
-nml_tracer_list =  
+nml_tracer_list =
 1  ,   'MFCT',       'QR4C',       'FCT ',        1.,          1., 
 2  ,   'MFCT',       'QR4C',       'FCT ',        1.,          1.,
 1001,  'MFCT',       'QR4C',       'FCT ',        1.,          1.,
@@ -43,49 +71,81 @@ nml_tracer_list =
 !101, 'UPW1',       'UPW1',       'NON ',        0.,          0.
 /
 
-&tracer_init3d                            ! initial conditions for tracers
-n_ic3d   = 8                              ! number of tracers to initialize
-idlist   = 1019, 1022, 1018, 1003, 1002, 1001, 2, 1 ! their IDs (0 is temperature, 1 is salinity, etc.). The reading order is defined here!
-filelist = 'fe_pisces_opa_eq_init_3D_changed_name.nc', 'woa18_all_o00_01_mmol_fesom2.nc', 'woa13_all_i00_01_fesom2.nc', 'GLODAPv2.2016b.TAlk_fesom2_mmol_fix_z_Fillvalue.nc', 'GLODAPv2.2016b.TCO2_fesom2_mmol_fix_z_Fillvalue.nc', 'woa13_all_n00_01_fesom2.nc', 'phc3.0_winter.nc', 'phc3.0_winter.nc'  ! list of files in ClimateDataPath to read (one file per tracer), same order as idlist
-varlist  = 'Fe', 'oxygen_mmol', 'i_an', 'TAlk_mmol', 'TCO2_mmol', 'n_an', 'salt', 'temp'                 ! variables to read from specified files
-t_insitu = .true.                         ! if T is insitu it will be converted to potential after reading it
+! ============================================================================
+! 3D TRACER INITIAL CONDITIONS (OCEAN)
+! ============================================================================
+&tracer_init3d
+n_ic3d   = 8  ! number of 3D tracers to initialize from files
+idlist   = 1019, 1022, 1018, 1003, 1002, 1001, 2, 1 ! tracer IDs to initialize (1=temperature, 2=salinity)
+filelist = 'fe_pisces_opa_eq_init_3D_changed_name.nc', 'woa18_all_o00_01_mmol_fesom2.nc', 'woa13_all_i00_01_fesom2.nc', 'GLODAPv2.2016b.TAlk_fesom2_mmol_fix_z_Fillvalue.nc', 'GLODAPv2.2016b.TCO2_fesom2_mmol_fix_z_Fillvalue.nc', 'woa13_all_n00_01_fesom2.nc', 'phc3.0_winter.nc', 'phc3.0_winter.nc' ! netCDF files in ClimateDataPath (one per tracer)
+varlist  = 'Fe', 'oxygen_mmol', 'i_an', 'TAlk_mmol', 'TCO2_mmol', 'n_an', 'salt', 'temp' ! variable names in the netCDF files
+t_insitu = .true.                                  ! if true, convert in-situ temperature to potential temperature
 /
 
-&tracer_init2d                                      ! initial conditions for 2D tracers (sea ice)
-n_ic2d   = 3                                        ! number of tracers to initialize
-idlist   = 1, 2, 3                                  ! their IDs (0 is a_ice, 1 is m_ice, 3 m_snow). The reading order is defined here!
-filelist = 'a_ice.nc', 'm_ice.nc', 'm_snow.nc' ! list of files in ClimateDataPath to read (one file per tracer), same order as idlist
-varlist  = 'a_ice', 'm_ice', 'm_snow'                 ! variables to read from specified files
-ini_ice_from_file=.false.
+! ============================================================================
+! 2D TRACER INITIAL CONDITIONS (SEA ICE)
+! ============================================================================
+&tracer_init2d
+n_ic2d            = 3                                    ! number of 2D tracers to initialize from files
+idlist            = 1, 2, 3                              ! tracer IDs (1=ice concentration, 2=ice thickness, 3=snow thickness)
+filelist          = 'a_ice.nc', 'm_ice.nc', 'm_snow.nc'  ! netCDF files in ClimateDataPath
+varlist           = 'a_ice', 'm_ice', 'm_snow'           ! variable names in the netCDF files
+ini_ice_from_file = .false.                              ! enable initialization from files (false = use default values)
 /
 
+! ============================================================================
+! TRACER GENERAL SETTINGS
+! ============================================================================
 &tracer_general
-! bharmonic diffusion for tracers. We recommend to use this option in very high resolution runs (Redi is generally off there).
-smooth_bh_tra =.false.     ! use biharmonic diffusion (filter implementation) for tracers
-gamma0_tra    = 0.0005     ! gammaX_tra are analogous to those in the dynamical part
-gamma1_tra    = 0.0125
-gamma2_tra    = 0.
-i_vert_diff   =.true.
+! --- Biharmonic Diffusion ---
+! Recommended for very high resolution runs (where Redi is typically disabled)
+smooth_bh_tra = .false.       ! enable biharmonic diffusion (filter implementation) for tracers
+gamma0_tra    = 0.0005        ! background biharmonic diffusion coefficient [dimensionless]
+gamma1_tra    = 0.0125        ! flow-aware biharmonic diffusion coefficient [dimensionless]
+gamma2_tra    = 0.            ! additional biharmonic diffusion coefficient [dimensionless]
+
+! --- Vertical Diffusion and Time Stepping ---
+i_vert_diff   = .true.        ! use implicit vertical diffusion (recommended for stability)
 /
 
+! ============================================================================
+! TRACER PHYSICS AND PARAMETERIZATIONS
+! ============================================================================
 &tracer_phys
-use_momix     = .true.     ! switch on/off  !Monin-Obukhov -> TB04 mixing
-momix_lat     = -50.0      ! latitidinal treshhold for TB04, =90 --> global
-momix_kv      = 0.01       ! PP/KPP, mixing coefficient within MO length
-use_instabmix = .true.     ! enhance convection in case of instable stratification
-instabmix_kv  = 0.1
-use_windmix   = .false.    ! enhance mixing trough wind only for PP mixing (for stability)
-windmix_kv    = 1.e-3
-windmix_nl    = 2
-diff_sh_limit=5.0e-3       ! for KPP, max diff due to shear instability
-Kv0_const=.true.
-double_diffusion=.false.   ! for KPP,dd switch
-K_ver=1.0e-5
-K_hor=3000.
-surf_relax_T=0.0
-surf_relax_S=1.929e-06   ! 50m/300days 6.43e-07! m/s 10./(180.*86400.)
-balance_salt_water =.true. ! balance virtual-salt or freshwater flux or not
-clim_relax=0.0	           ! 1/s, geometrical information has to be supplied
-ref_sss_local=.true.
-ref_sss=34.
+! --- Monin-Obukhov Mixing (TB04) ---
+use_momix          = .true.            ! enable Monin-Obukhov mixing (Timmermann & Beckmann 2004)
+momix_lat          = -50.0             ! latitude threshold for TB04 [degrees] (90 = global, -50 = south of 50°S)
+momix_kv           = 0.01              ! mixing coefficient within MO length [m²/s]
+
+! --- Convective Instability Mixing ---
+use_instabmix      = .true.            ! enhance mixing for unstable stratification (convection)
+instabmix_kv       = 0.1               ! mixing coefficient for unstable stratification [m²/s]
+
+! --- Wind Mixing (PP scheme only) ---
+use_windmix        = .false.           ! enhance near-surface mixing by wind (for PP mixing stability)
+windmix_kv         = 1.e-3             ! wind mixing coefficient [m²/s]
+windmix_nl         = 2                 ! number of surface layers for wind mixing
+
+! --- Shear Instability (KPP) ---
+diff_sh_limit      = 5.0e-3            ! maximum diffusivity due to shear instability [m²/s] (for KPP)
+
+! --- Background Diffusivity ---
+Kv0_const          = .true.            ! use constant background vertical diffusivity
+K_ver              = 1.0e-5            ! background vertical diffusivity [m²/s]
+K_hor              = 3000.             ! background horizontal diffusivity [m²/s]
+
+! --- Double Diffusion (KPP) ---
+double_diffusion   = .false.           ! enable double diffusion parameterization (for KPP)
+
+! --- Surface Restoring ---
+surf_relax_T       = 0.0               ! surface temperature restoring coefficient [m/s] (0 = disabled)
+surf_relax_S       = 1.929e-06         ! surface salinity restoring coefficient [m/s]
+balance_salt_water = .true.            ! balance virtual salt flux with freshwater flux
+
+! --- Climatology Restoring ---
+clim_relax         = 0.0               ! 3D climatology restoring coefficient [1/s] (0 = disabled)
+
+! --- Reference Salinity ---
+ref_sss_local      = .true.            ! use local reference SSS (true) or global constant (false)
+ref_sss            = 34.               ! global reference salinity [psu] (if ref_sss_local=false)
 /

--- a/config/namelist.tra.toy_dbgyre
+++ b/config/namelist.tra.toy_dbgyre
@@ -116,4 +116,3 @@ clim_relax         = 0.0               ! 3D climatology restoring coefficient [1
 ref_sss_local      = .true.            ! use local reference SSS (true) or global constant (false)
 ref_sss            = 34.               ! global reference salinity [psu] (if ref_sss_local=false)
 /
-

--- a/config/namelist.tra.toy_neverworld2
+++ b/config/namelist.tra.toy_neverworld2
@@ -99,7 +99,7 @@ diff_sh_limit      = 5.0e-3            ! maximum diffusivity due to shear instab
 ! --- Background Diffusivity ---
 Kv0_const          = .false.           ! use constant background vertical diffusivity
 K_ver              = 1.0e-5            ! background vertical diffusivity [m²/s]
-K_hor              = 0.               ! background horizontal diffusivity [m²/s]
+K_hor              = 0.                ! background horizontal diffusivity [m²/s]
 
 ! --- Double Diffusion (KPP) ---
 double_diffusion   = .false.           ! enable double diffusion parameterization (for KPP)
@@ -116,4 +116,3 @@ clim_relax         = 0.0               ! 3D climatology restoring coefficient [1
 ref_sss_local      = .true.            ! use local reference SSS (true) or global constant (false)
 ref_sss            = 34.               ! global reference salinity [psu] (if ref_sss_local=false)
 /
-

--- a/config/namelist.tra.toy_soufflet
+++ b/config/namelist.tra.toy_soufflet
@@ -116,4 +116,3 @@ clim_relax         = 0.0               ! 3D climatology restoring coefficient [1
 ref_sss_local      = .true.            ! use local reference SSS (true) or global constant (false)
 ref_sss            = 34.               ! global reference salinity [psu] (if ref_sss_local=false)
 /
-


### PR DESCRIPTION
Follow-up to #1004: every remaining namelist in `config/` gets the treatment the default namelists already have, a header, section banners and a description with units for every parameter. No setting changes anywhere.

## Diffs against the default show only real differences

People diff these files against the defaults, so a variant now copies the default's line byte for byte wherever its value is the same. Where a value differs only the value text changes and the description stays. Keys a variant does not set are removed rather than added (adding them would silently switch them from the Fortran built-in to the default file's value), and keys only a variant has keep their own lines. A multi-line value such as `io_list` or a tracer table is taken from the variant as it was.

Notes that only a variant carries are kept: the CORE2 `ForcingDataPath` line, the tracer IDs, DIC and gfortran notes in `bin_2p3z2d/namelist.tra`, and the commented-out alternatives in `bin_4p3z2d/namelist.recom`. Dropped are stale commented alternatives (old `/work/ollie` paths), old file headers, and notes the defaults already carry.

## Commits

1. **Variants of the described defaults (48 files):** the `bin_*` configurations, the toy setups, the forcing and io variants, `ice_ERA5`, `oce.core2` and `tra.recom.2p3z2d`. This commit also fixes four wrong descriptions in the defaults (`nm_nc_freq`, `nm_snow_var`, the wind and stress variable names, `K_GM_min`). Those edits are byte-identical to the ones in #1004, so whichever PR merges second sees no conflict there.
2. **icepack:** `namelist.icepack` is itself the default and only its array sizes were described. The rest comes from the Icepack documentation and from the checks in `icedrv_set.F90` that tie options together. Its nine variants are rebuilt from it.
3. **REcoM:** there was no REcoM default, so `namelist.recom.2p3z2d` becomes the reference and the four `bin_*` files are rebuilt from it. Units are corrected where the code disagrees with the old comments: the ballasting sinking speeds, depth scaling and maximum sinking velocity are in m/day, since `recom_sinking.F90` divides by `SecondsPerDay` afterwards.

## For the REcoM people

27 parameters are read from the namelist but never used by the code, and are marked "not used by the current code": the 19 `s*Nsq` grazing terms, `cPhyN`, `cHetN`, `cZoo2N`, `P_cm_c`, `UseFeDust`, `UseDustClim`, `UseDustClimAlbani` and `HetRespFlux_plus`. `REcoMDataPath` carries the same marker. Please check these, since they may be meant to do something.

Separately, and not changed here, the `bgc_num` shipped in `bin_2p3z2d`, `bin_3p3z2d` and `bin_4p3z2d` does not match the value the startup check expects from `enable_3zoo2det` and `enable_coccos`, so those setups print a warning.

## Verification

- All 65 changed namelist files compare equal to `main` for all 3998 settings, both with f90nml and with a separate comment-stripping comparison.
- No inline comment was added on a row of a continued value list, since gfortran aborts on that.
- The `sed` patterns the REcoM CI job applies to `bin_2p3z2d` still match.
- The checks are static; the CI runs here are the first time the model reads the rebuilt files.

Not touched: `test/input/recom/*.working` (test data) and `fpost2/namelist.interp` (a post-processing tool).
