### PR TITLE
Make CORE3 with ice-shelf cavities the default mesh

### DIFF
--- a/cmake/FesomTesting.cmake
+++ b/cmake/FesomTesting.cmake
@@ -769,7 +769,7 @@ endfunction()
 
 # Function to add a FESOM meshdiag test with custom options
 function(add_fesom_meshdiag_test_with_options TEST_NAME MESH_NAME RUNID)
-    set(oneValueArgs NP TIMEOUT PREFIX)
+    set(oneValueArgs NP TIMEOUT PREFIX USE_CAVITY)
     set(multiValueArgs COMMAND_ARGS)
     cmake_parse_arguments(FESOM_TEST "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     
@@ -785,6 +785,22 @@ function(add_fesom_meshdiag_test_with_options TEST_NAME MESH_NAME RUNID)
     if(NOT DEFINED FESOM_TEST_TIMEOUT)
         set(FESOM_TEST_TIMEOUT 120)  # 2 minutes default (much faster than full FESOM)
     endif()
+    # A mesh with cavity files must be read with use_cavity=.true., otherwise
+    # the model stops. Take it from the mesh registry unless given explicitly.
+    if(NOT DEFINED FESOM_TEST_USE_CAVITY)
+        set(FESOM_TEST_USE_CAVITY ".false.")
+        set(_registry "${FESOM_TESTING_ROOT}/tests/mesh_registry.json")
+        if(EXISTS "${_registry}")
+            file(READ "${_registry}" _registry_content)
+            string(REGEX MATCH "\"${MESH_NAME}\"[^}]*\"use_cavity\"[ ]*:[ ]*([^,}]+)" _cavity_match "${_registry_content}")
+            if(_cavity_match)
+                string(STRIP "${CMAKE_MATCH_1}" _cavity)
+                if(_cavity STREQUAL "true")
+                    set(FESOM_TEST_USE_CAVITY ".true.")
+                endif()
+            endif()
+        endif()
+    endif()
     
     # Create test run directory
     set(TEST_RUN_DIR "${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME}")
@@ -793,7 +809,7 @@ function(add_fesom_meshdiag_test_with_options TEST_NAME MESH_NAME RUNID)
     
     # Configure namelists with custom runid to avoid conflicts
     configure_fesom_namelists_with_options("${TEST_RUN_DIR}" "${TEST_DATA_DIR}" "${RESULT_DIR}"
-        "${MESH_NAME}" "96" "1" "d" "1" "d" "10" ".true." ".false.")
+        "${MESH_NAME}" "96" "1" "d" "1" "d" "10" ".true." "${FESOM_TEST_USE_CAVITY}")
     
     # Update runid in namelist.config to create unique output file
     file(READ "${TEST_RUN_DIR}/namelist.config" CONTENT)
@@ -865,7 +881,7 @@ function(add_fesom_meshdiag_test_with_options TEST_NAME MESH_NAME RUNID)
         RUN_SERIAL FALSE
     )
     
-    message(STATUS "Added FESOM meshdiag test: ${TEST_NAME} with mesh: ${MESH_NAME}, runid: ${RUNID}")
+    message(STATUS "Added FESOM meshdiag test: ${TEST_NAME} with mesh: ${MESH_NAME}, runid: ${RUNID}, cavity: ${FESOM_TEST_USE_CAVITY}")
 endfunction()
 
 #===============================================================================

--- a/config/namelist.config
+++ b/config/namelist.config
@@ -26,7 +26,7 @@ runid = 'fesom'        ! run identifier (used in output filenames)
 ! TIME STEPPING AND RUN LENGTH
 ! ============================================================================
 &timestep
-step_per_day      = 36         ! number of time steps per day (determines dt = 86400/step_per_day seconds)
+step_per_day      = 48         ! number of time steps per day (determines dt = 86400/step_per_day seconds)
                                 ! common values: 32 (45min), 48 (30min), 72 (20min), 96 (15min), 192 (7min 30sec), 
                                 ! 216 (6min 40sec), 240 (6min), 288 (5min), 360 (4min), 720 (2min), 1440 (1min), 2880 (30sec)
 run_length        = 1          ! total length of simulation run
@@ -46,7 +46,7 @@ yearnew = 1958                 ! initial year
 ! MESH, INITIALIZATION & OUTPUT PATHS
 ! ============================================================================
 &paths
-MeshPath         = '/pool/data/AWICM/FESOM2/MESHES_FESOM2.1/core2/'   ! path to mesh files (nod2d.out, elem2d.out, etc.)
+MeshPath         = '/pool/data/AWICM/FESOM2/MESHES_FESOM2.1/core3/'   ! path to mesh files (nod2d.out, elem2d.out, etc.)
 ClimateDataPath  = '/pool/data/AWICM/FESOM2/INITIAL/phc3.0/'          ! path to initial conditions (temperature, salinity)
 ForcingDataPath  = '/pool/data/AWICM/FESOM2/FORCING/JRA55-do-v1.4.0/'  ! path prepended to relative file names in namelist.forcing
 ResultPath       = '/work/ab0246/$USER/runtime/fesom2/'               ! path for output files and fesom.clock file
@@ -105,7 +105,7 @@ include_fleapyear = .true.       ! include leap years in calendar (false = 365-d
 ! ============================================================================
 &run_config
 use_ice                  = .true.        ! enable sea ice model
-use_cavity               = .false.       ! enable ice shelf cavities
+use_cavity               = .true.        ! enable ice shelf cavities
 use_cavity_partial_cell  = .false.       ! use partial cells in ice shelf cavities (not recommended)
 use_floatice             = .false.       ! enable floating ice (icebergs)
 use_sw_pene              = .true.        ! enable shortwave radiation penetration into ocean

--- a/docs/general_configuration/general_configuration.rst
+++ b/docs/general_configuration/general_configuration.rst
@@ -16,7 +16,7 @@ Section &modelname
 Section &timestep
 """""""""""""""""
 
-- **step_per_day=36** number of baroclinic steps per day. The code enforces that ``86400 mod step_per_day == 0`` and prints the supported values when the check fails. It sets the fundamental time step ``dt = 86400/step_per_day`` seconds that is shared by ocean and ice components. Valid values are, for example: 32(45min), 36(40min), 48(30min), 60(24min), 72(20min), 144(10min), 288(5min), 1440(1min).
+- **step_per_day=48** number of baroclinic steps per day. The code enforces that ``86400 mod step_per_day == 0`` and prints the supported values when the check fails. It sets the fundamental time step ``dt = 86400/step_per_day`` seconds that is shared by ocean and ice components. Valid values are, for example: 32(45min), 36(40min), 48(30min), 60(24min), 72(20min), 144(10min), 288(5min), 1440(1min).
 - **run_length=1** length of the submitted integration segment.
 - **run_length_unit='y'** unit for ``run_length``; one of ``'y'`` (years), ``'m'`` (months), ``'d'`` (days), or ``'s'`` (time steps). The calendar in :ref:`Section &calendar<chap_general_configuration_calendar>` determines how months/years are counted.
 
@@ -80,7 +80,8 @@ Section &run_config
 - **use_ice=.true.** enable the dynamic/thermodynamic sea ice model.
 - **use_floatice=.false.** allow floating ice above the ocean (ice shelf/iceberg loading); requires ``zlevel`` or ``zstar`` ALE.
 - **use_sw_pene=.true.** apply shortwave penetration below the surface; requires chlorophyll data or a constant value (see ``namelist.forcing``).
-- **use_cavity=.false.**, **use_cavity_partial_cell=.false.** activate ice-shelf cavities and optional surface partial cells inside cavities.
+- **use_cavity=.true.**, **use_cavity_partial_cell=.false.** activate ice-shelf cavities and optional surface partial cells inside cavities.
+- The default mesh, CORE3, resolves the Antarctic ice-shelf cavities, so ``use_cavity`` is ``.true.`` by default. Meshes without cavity files (``cavity_depth@node.out``), such as CORE2 or pi, need ``use_cavity=.false.``.
 - **cavity_partial_cell_thresh=0.0** minimum cavity layer thickness before applying surface partial cells (prevents extremely thin top cavity layers).
 - **use_cavity_fw2press=.true.** whether freshwater fluxes in cavities affect the hydrostatic pressure field.
 - **toy_ocean=.false.**, **which_toy='soufflet'** enable idealised “toy” forcing/geometry setups.

--- a/setups/core3/setup.yml
+++ b/setups/core3/setup.yml
@@ -1,19 +1,21 @@
-mesh: core2
+mesh: core3
 forcing: JRA55
 clim:
     type: phc
     filelist: ['phc3.0_winter.nc','phc3.0_winter.nc']
     varlist: ['salt', 'temp']
-ntasks: 288
+ntasks: 512
 time: "08:00:00"
 
 namelist.config:
     run_config:
-        use_cavity: False
+        use_cavity: True
     timestep:
-        step_per_day: 32
-        run_length: 10
+        # Cold start: the CORE3 spin-up runs used 300 s for the first months
+        # before switching to the default 1800 s (step_per_day: 48).
+        step_per_day: 288
+        run_length: 1
         run_length_unit: "y"
-    inout:
+    restart_log:
         restart_length: 1
         restart_length_unit: "y"

--- a/setups/farc/setup.yml
+++ b/setups/farc/setup.yml
@@ -8,6 +8,8 @@ ntasks: 1296
 time: "08:00:00"
 
 namelist.config:
+    run_config:
+        use_cavity: False
     timestep:
         step_per_day: 288
         run_length: 10

--- a/setups/paths.yml
+++ b/setups/paths.yml
@@ -36,6 +36,7 @@ levante:
         test_neverworld2: ./test/meshes/neverworld2/
         pi: /pool/data/AWICM/FESOM2/MESHES_FESOM2.1/pi/
         core2: /pool/data/AWICM/FESOM2/MESHES_FESOM2.1/core2/
+        core3: /pool/data/AWICM/FESOM2/MESHES_FESOM2.1/core3/
         mr: /pool/data/AWICM/FESOM2/MESHES_FESOM2.1/mr/
         hr: /pool/data/AWICM/FESOM2/MESHES_FESOM2.1/hr/
         orca25: /pool/data/AWICM/FESOM2/MESHES_FESOM2.1/orca25/

--- a/setups/pi/setup.yml
+++ b/setups/pi/setup.yml
@@ -8,6 +8,8 @@ ntasks: 8
 time: "08:00:00"
 
 namelist.config:
+    run_config:
+        use_cavity: False
     timestep:
         step_per_day: 96
         run_length: 10

--- a/setups/souf/setup.yml
+++ b/setups/souf/setup.yml
@@ -23,6 +23,7 @@ namelist.config:
         rotated_grid: False
         force_rotation: False
     run_config:
+        use_cavity: False
         use_ice: False
         toy_ocean: True
         which_toy: "soufflet"

--- a/setups/test_core2/setup.yml
+++ b/setups/test_core2/setup.yml
@@ -8,6 +8,8 @@ ntasks: 288
 time: "00:30:00"
 
 namelist.config:
+    run_config:
+        use_cavity: False
     timestep:
         step_per_day: 32
         run_length: 1

--- a/setups/test_neverworld2/setup.yml
+++ b/setups/test_neverworld2/setup.yml
@@ -9,6 +9,7 @@ time: "00:10:00"
 
 namelist.config:
     timestep:
+        step_per_day: 36
         run_length: 1
         run_length_unit: "d"
     restart_log:

--- a/setups/test_neverworld2/setup.yml
+++ b/setups/test_neverworld2/setup.yml
@@ -25,6 +25,7 @@ namelist.config:
         rotated_grid: False
         force_rotation: False
     run_config:
+        use_cavity: False
         use_ice: False
         toy_ocean: True
         which_toy: "neverworld2"

--- a/setups/test_pi/setup.yml
+++ b/setups/test_pi/setup.yml
@@ -11,6 +11,7 @@ namelist.config:
     run_config:
         use_cavity: False
     timestep:
+        step_per_day: 36
         run_length: 1
         run_length_unit: "d"
     geometry:

--- a/setups/test_pi/setup.yml
+++ b/setups/test_pi/setup.yml
@@ -8,6 +8,8 @@ ntasks: 2
 time: "00:10:00"
 
 namelist.config:
+    run_config:
+        use_cavity: False
     timestep:
         run_length: 1
         run_length_unit: "d"

--- a/setups/test_pi_cavity/setup.yml
+++ b/setups/test_pi_cavity/setup.yml
@@ -12,6 +12,7 @@ namelist.config:
       use_cavity: True
       use_cavity_partial_cell: True
     timestep:
+        step_per_day: 36
         run_length: 1
         run_length_unit: "d"
     geometry:

--- a/setups/test_pi_floatice/setup.yml
+++ b/setups/test_pi_floatice/setup.yml
@@ -18,6 +18,7 @@ namelist.config:
         restart_length_unit: "d"
         logfile_outfreq: 10
     run_config:
+        use_cavity: False
         use_floatice: True
 
 namelist.dyn:

--- a/setups/test_pi_floatice/setup.yml
+++ b/setups/test_pi_floatice/setup.yml
@@ -9,6 +9,7 @@ time: "00:10:00"
 
 namelist.config:
     timestep:
+        step_per_day: 36
         run_length: 1
         run_length_unit: "d"
     geometry:

--- a/setups/test_pi_icebergs/setup.yml
+++ b/setups/test_pi_icebergs/setup.yml
@@ -20,6 +20,7 @@ namelist.config:
       use_cavity: True
       use_cavity_partial_cell: False
     timestep:
+        step_per_day: 36
         run_length: 1
         run_length_unit: "d"
     geometry:

--- a/setups/test_pi_icepack/setup.yml
+++ b/setups/test_pi_icepack/setup.yml
@@ -11,6 +11,7 @@ namelist.config:
     run_config:
         use_cavity: False
     timestep:
+        step_per_day: 36
         run_length: 1
         run_length_unit: "d"
     geometry:

--- a/setups/test_pi_icepack/setup.yml
+++ b/setups/test_pi_icepack/setup.yml
@@ -8,6 +8,8 @@ ntasks: 2
 time: "00:10:00"
 
 namelist.config:
+    run_config:
+        use_cavity: False
     timestep:
         run_length: 1
         run_length_unit: "d"

--- a/setups/test_pi_linfs/setup.yml
+++ b/setups/test_pi_linfs/setup.yml
@@ -11,6 +11,7 @@ namelist.config:
     run_config:
         use_cavity: False
     timestep:
+        step_per_day: 36
         run_length: 1
         run_length_unit: "d"
     geometry:

--- a/setups/test_pi_linfs/setup.yml
+++ b/setups/test_pi_linfs/setup.yml
@@ -8,6 +8,8 @@ ntasks: 2
 time: "00:10:00"
 
 namelist.config:
+    run_config:
+        use_cavity: False
     timestep:
         run_length: 1
         run_length_unit: "d"

--- a/setups/test_pi_partial/setup.yml
+++ b/setups/test_pi_partial/setup.yml
@@ -11,6 +11,7 @@ namelist.config:
     run_config:
         use_cavity: False
     timestep:
+        step_per_day: 36
         run_length: 1
         run_length_unit: "d"
     geometry:

--- a/setups/test_pi_partial/setup.yml
+++ b/setups/test_pi_partial/setup.yml
@@ -8,6 +8,8 @@ ntasks: 2
 time: "00:10:00"
 
 namelist.config:
+    run_config:
+        use_cavity: False
     timestep:
         run_length: 1
         run_length_unit: "d"

--- a/setups/test_pi_visc7/setup.yml
+++ b/setups/test_pi_visc7/setup.yml
@@ -11,6 +11,7 @@ namelist.config:
     run_config:
         use_cavity: False
     timestep:
+        step_per_day: 36
         run_length: 1
         run_length_unit: "d"
     geometry:

--- a/setups/test_pi_visc7/setup.yml
+++ b/setups/test_pi_visc7/setup.yml
@@ -8,6 +8,8 @@ ntasks: 2
 time: "00:10:00"
 
 namelist.config:
+    run_config:
+        use_cavity: False
     timestep:
         run_length: 1
         run_length_unit: "d"

--- a/setups/test_pi_zstar/setup.yml
+++ b/setups/test_pi_zstar/setup.yml
@@ -11,6 +11,7 @@ namelist.config:
     run_config:
         use_cavity: False
     timestep:
+        step_per_day: 36
         run_length: 1
         run_length_unit: "d"
     geometry:

--- a/setups/test_pi_zstar/setup.yml
+++ b/setups/test_pi_zstar/setup.yml
@@ -8,6 +8,8 @@ ntasks: 2
 time: "00:10:00"
 
 namelist.config:
+    run_config:
+        use_cavity: False
     timestep:
         run_length: 1
         run_length_unit: "d"

--- a/setups/test_souf/setup.yml
+++ b/setups/test_souf/setup.yml
@@ -25,6 +25,7 @@ namelist.config:
         rotated_grid: False
         force_rotation: False
     run_config:
+        use_cavity: False
         use_ice: False
         toy_ocean: True
         which_toy: "soufflet"

--- a/setups/test_souf/setup.yml
+++ b/setups/test_souf/setup.yml
@@ -9,6 +9,7 @@ time: "00:10:00"
 
 namelist.config:
     timestep:
+        step_per_day: 36
         run_length: 1
         run_length_unit: "d"
     restart_log:

--- a/tests/mesh_registry.json
+++ b/tests/mesh_registry.json
@@ -26,6 +26,31 @@
         "checksum": "optional"
       }
     },
+    "core3": {
+      "name": "CORE3 Global Ocean Mesh",
+      "description": "Default global ocean mesh: CORE2 successor with Antarctic ice-shelf cavities",
+      "url": "https://swift.dkrz.de/v1/dkrz_035d8f6ff058403bb42f8302e6badfbc/FESOM_MESHES2.1/core3.tar.gz",
+      "archive_type": "tar.gz",
+      "config": {
+        "force_rotation": true,
+        "use_cavity": true,
+        "typical_processors": [16],
+        "timing": {
+          "step_per_day": 48,
+          "run_length": 1,
+          "run_length_unit": "s"
+        }
+      },
+      "mesh_stats": {
+        "nodes_2d": 220509,
+        "elements_2d": 426403,
+        "vertical_levels": 48
+      },
+      "verification": {
+        "required_files": ["nod2d.out", "elem2d.out", "aux3d.out", "cavity_depth@node.out"],
+        "checksum": "optional"
+      }
+    },
     "orca25": {
       "name": "Global ~0.25-degree Ocean Mesh", 
       "description": "Global ocean mesh at ~1 degree resolution",

--- a/tests/remote/CMakeLists.txt
+++ b/tests/remote/CMakeLists.txt
@@ -75,6 +75,47 @@ else()
 endif()
 
 # =============================================================================
+# CORE3 Remote Mesh Tests
+# =============================================================================
+
+if(HAS_DOWNLOAD_CAPABILITY)
+    message(STATUS "Adding CORE3 remote mesh download test...")
+    
+    # Add mesh pipeline for core3 (download + partitioning for 16 processes);
+    # CORE3 has ice-shelf cavities, use_cavity comes from tests/mesh_registry.json
+    add_mesh_pipeline("core3" PREFIX remote PROCESS_COUNTS 16)
+    
+    if(BUILD_MESHPARTITIONER)
+        message(STATUS "Adding CORE3 mesh partitioning test...")
+        # Partitioning is included in add_mesh_pipeline above
+    else()
+        message(STATUS "CORE3 mesh partitioning test skipped - BUILD_MESHPARTITIONER=OFF")
+    endif()
+    
+    if(BUILD_MESHDIAG)
+        message(STATUS "Adding CORE3 mesh diagnostics test...")
+        
+        # Add meshdiag test that generates mesh diagnostics file
+        add_fesom_meshdiag_test_with_options(generate_meshdiag_core3_mpi16 "core3" "fesom"
+            NP 16
+            TIMEOUT 600
+            PREFIX remote
+        )
+        
+        # Make meshdiag test depend on mesh pipeline
+        set_tests_properties(remote_generate_meshdiag_core3_mpi16 PROPERTIES
+            FIXTURES_REQUIRED "mesh_core3_16"
+            LABELS "generate_meshdiag"
+        )
+    else()
+        message(STATUS "CORE3 mesh diagnostics test skipped - BUILD_MESHDIAG=OFF")
+    endif()
+    
+else()
+    message(STATUS "CORE3 remote mesh tests skipped - no download capability (wget or curl required)")
+endif()
+
+# =============================================================================
 # DARS Remote Mesh Tests
 # =============================================================================
 


### PR DESCRIPTION
Makes CORE3 with Antarctic ice-shelf cavities the default mesh, as discussed in #703. Open questions that this PR does not answer are collected in #703.

## Default namelist

`config/namelist.config` changes exactly three settings:

| setting | before | after |
|---|---|---|
| `MeshPath` | `.../MESHES_FESOM2.1/core2/` | `.../MESHES_FESOM2.1/core3/` |
| `use_cavity` | `.false.` | `.true.` |
| `step_per_day` | 36 (2400 s) | 48 (1800 s) |

1800 s is the step the CORE3 runs use after spin-up, so the default is meant for runs that branch off from a spun-up state. A cold start at 1800 s has not been shown to work, and FESOM has no timestep ramp; see #703.

`use_cavity` stays `.false.` as the code default in `gen_modules_config.F90`, since that only applies when a namelist omits the key.

## CI and setups

Every mkrun setup that relied on the namelist default now sets `use_cavity: False` explicitly, otherwise it would look for cavity files its mesh does not have: `core2`, `farc`, `pi`, `souf`, `test_core2`, `test_neverworld2`, `test_pi`, `test_pi_floatice`, `test_pi_icepack`, `test_pi_linfs`, `test_pi_partial`, `test_pi_visc7`, `test_pi_zstar`, `test_souf`. Setups that relied on the default timestep now also set `step_per_day: 36`, the old default, so their `fcheck` reference values stay valid: `test_neverworld2`, `test_pi`, `test_pi_cavity`, `test_pi_floatice`, `test_pi_icebergs`, `test_pi_icepack`, `test_pi_linfs`, `test_pi_partial`, `test_pi_visc7`, `test_pi_zstar`, `test_souf`. Each file differs from `main` only by these two keys. The CTest harness, `mesh_partition.cmake`, the `bin_*` REcoM configs and the toy configs already set `use_cavity` explicitly and need no change.

New:

- `setups/core3/setup.yml` for mkrun, cold-starting at 300 s as in the CORE3 spin-up runs, and a `core3` entry for Levante in `setups/paths.yml`.
- A `core3` entry in `tests/mesh_registry.json`. Its `config` block comes before `mesh_stats` on purpose: the harness reads the registry with `"<mesh>"[^}]*"<key>"` patterns, which cannot cross a nested object, so `use_cavity: true` would otherwise not be found and fall back to `.false.`.
- A CORE3 remote pipeline in `tests/remote/`: download, partition for 16 ranks, mesh diagnostics. Remote tests are skipped in CI.

The docs state the new defaults and that meshes without cavity files need `use_cavity=.false.`.

## Before merging

- ~~`core3.tar.gz` has to be uploaded next to `core2.tar.gz` in the `FESOM_MESHES2.1` container.~~ Done, see the comment below.
- The pool path is assumed to be `/pool/data/AWICM/FESOM2/MESHES_FESOM2.1/core3/`. `setups/paths.yml` has no albedo section, so only Levante is added.

## Verification

- `namelist.config` compared setting by setting: only the three settings above differ.
- All setup files parse, and apart from the new `core3` setup they differ from `main` only by the added `use_cavity` and `step_per_day` keys.
- CMake configures and lists the three CORE3 remote tests. The registry patterns resolve `use_cavity=true` and `step_per_day=48` for `core3`, and `false` for `dars` and `pi_remote`. The existing `core2` entry has its `mesh_stats` first, so none of its `config` values are reachable either; it falls back to the harness defaults, which happen to be right for CORE2.
