### PR TITLE
cpl(__oifs): optionally take the ice skin temperature from OpenIFS; fix send action on OASIS_Waitgroup

### DIFF
--- a/src/cpl_driver.F90
+++ b/src/cpl_driver.F90
@@ -115,6 +115,9 @@ module cpl_driver
   public seconds_til_now 
   public send_id, recv_id
   public nsend, nrecv, cpl_send, cpl_recv
+
+  ! position of tsk_ico in cpl_recv; 0 when use_atm_ice_tskin is off
+  integer, public            :: recv_tsk_ico = 0
   public source_root, target_root, commRank
   public a2o_fcorr_stat
 
@@ -751,6 +754,7 @@ include "associate_mesh_ass.h"
 #if defined (__recom)
     cpl_recv(16) = 'XCO2_oce'
 #endif
+    if (recv_tsk_ico > 0) cpl_recv(recv_tsk_ico) = 'tsk_ico'
 !Not oifs
 #else
     cpl_recv(1)  = 'taux_oce'
@@ -916,7 +920,9 @@ include "associate_mesh_ass.h"
     endif     
 #endif
     call oasis_put(send_id(ind), seconds_til_now, exfld, info)
-    action=(info==4 .OR. info==8)
+    ! Fields put before the last one of a coupling group return OASIS_Waitgroup;
+    ! they are buffered and transmitted together with the last one.
+    action=(info==OASIS_Sent .OR. info==OASIS_SentOut .OR. info==OASIS_Waitgroup)
     if (action) then
        if (ind==nsend) then
           cplsnd=0.

--- a/src/fesom_module.F90
+++ b/src/fesom_module.F90
@@ -468,6 +468,11 @@ contains
         IF (use_icebergs) THEN
           nrecv = nrecv + 2
         END IF
+#else
+        IF (use_atm_ice_tskin) THEN
+          nrecv = nrecv + 1
+          recv_tsk_ico = nrecv
+        END IF
 #endif
 #endif
 

--- a/src/gen_forcing_couple.F90
+++ b/src/gen_forcing_couple.F90
@@ -477,14 +477,6 @@ subroutine update_atm_forcing(istep, ice, tracers, dynamics, partit, mesh)
          if(partit%my_fesom_group == 0) then
 #endif
          call cpl_oasis3mct_send(i, exchange, action, partit)
-#if defined (__oifs)
-         ! Anchor for the implicit ice surface-temperature solve
-         ! (ice_thermo_cpl.F90/ice_surftemp): remember the ist as ACTUALLY
-         ! transmitted -- the temperature OIFS evaluates its ice-tile fluxes
-         ! at for the coming coupling interval. `action` is only true on real
-         ! OASIS transmissions, so this stays frozen between coupling events.
-         if (i==4 .and. action) ice%atmcoupl%ist_ref(:) = exchange(:)
-#endif
 #if defined(__recom) && defined(__usetp)
          endif
 #endif
@@ -605,6 +597,10 @@ subroutine update_atm_forcing(istep, ice, tracers, dynamics, partit, mesh)
          elseif (i.eq.15) then
              if (action) then
                 v_wind(:)                     = exchange(:)        ! meridional wind
+             end if
+         elseif (i.eq.recv_tsk_ico) then
+             if (action) then
+                ice%atmcoupl%ist_ref(:)       = exchange(:)        ! ice-tile skin temperature
              end if
 #if defined (__recom)
          elseif (i.eq.16) then

--- a/src/gen_modules_config.F90
+++ b/src/gen_modules_config.F90
@@ -223,6 +223,7 @@ module g_config
   character(10)                 :: hosing_mode='surf'     ! 'surf' = surface virtual salinity flux, 'depth' = distributed over depth
   real(kind=WP)                 :: hosing_hSv=0.0_WP      ! freshwater anomaly magnitude [Sv]
   logical                       :: compute_oasis_corners=.false. ! switches on corner calculation for 1st order conserv remapping 
+  logical                       :: use_atm_ice_tskin=.false.  ! OpenIFS: receive the ice-tile skin temperature (tsk_ico) and use it as the ice surface temperature
 
 #if defined(__recom) && defined(__usetp)
 ! number of groups for multi FESOM group loop parallelization
@@ -230,13 +231,13 @@ module g_config
   namelist /run_config/ use_ice,use_floatice, use_sw_pene, use_cavity, &
                         use_cavity_partial_cell, cavity_partial_cell_thresh, &
                         use_cavity_fw2press, toy_ocean, which_toy, flag_debug, flag_warn_cflz, lwiso, &
-                        use_transit, compute_oasis_corners, num_fesom_groups, &
+                        use_transit, compute_oasis_corners, use_atm_ice_tskin, num_fesom_groups, &
                         use_hosing, hosing_mode, hosing_hSv
 #else
   namelist /run_config/ use_ice,use_floatice, use_sw_pene, use_cavity, & 
                         use_cavity_partial_cell, cavity_partial_cell_thresh, &
                         use_cavity_fw2press, toy_ocean, which_toy, flag_debug, flag_warn_cflz, lwiso, &
-                        use_transit, compute_oasis_corners, &
+                        use_transit, compute_oasis_corners, use_atm_ice_tskin, &
                         use_hosing, hosing_mode, hosing_hSv
 #endif
 

--- a/src/ice_setup_step.F90
+++ b/src/ice_setup_step.F90
@@ -286,7 +286,14 @@ subroutine ice_timestep(step, ice, partit, mesh)
 #if defined (__oifs) || defined (__ifsinterface)
 !$OMP PARALLEL DO
     do i=1,myDim_nod2D+eDim_nod2D
-        if (a_ice(i)>0.0_WP) ice_temp(i) = ice_temp(i)/max(a_ice(i), 1.e-6_WP)
+        ! ice_temp was advected as ice_temp*a_ice. Where a_ice is (near) zero
+        ! there is no ice surface; use the freezing point rather than the
+        ! near-zero-Kelvin product.
+        if (a_ice(i) > 1.e-6_WP) then
+            ice_temp(i) = ice_temp(i)/a_ice(i)
+        else
+            ice_temp(i) = 271.35_WP
+        end if
     end do
 !$OMP END PARALLEL DO
 #endif /* (__oifs) */

--- a/src/ice_thermo_cpl.F90
+++ b/src/ice_thermo_cpl.F90
@@ -178,11 +178,14 @@ subroutine thermodynamics(ice, partit, mesh)
      qres     = 0.0_WP
      qcon     = 0.0_WP
      if(A>Aimin) then
-        ! Anchor temperature for the implicit flux linearization: the ist OIFS
-        ! actually evaluated a2ihf at (captured at the OASIS send). Fall back
-        ! to the local t before the first transmission (cold start / restart).
-        tref = ist_ref(inod)
-        if (tref < 100.0_WP) tref = t
+        if (use_atm_ice_tskin) then
+           ! Skin temperature received from the atmosphere (tsk_ico); freezing
+           ! point before the first receive.
+           tref = ist_ref(inod)
+           if (tref < 173.15_WP .or. tref > 400.0_WP) tref = 271.35_WP
+        else
+           tref = t
+        end if
         call ice_surftemp(ice%thermo, max(h/(max(A,Aimin)),0.05), hsn/(max(A,Aimin)), a2ihf, tref, t)
         ice_temp(inod)  = t
      else
@@ -559,8 +562,8 @@ contains
   ! A  - Ice fraction
   ! h  - Ice thickness
   ! hsn   - Snow thickness
-  ! tref  - ist the atmosphere evaluated a2ihf at (last transmitted ist);
-  !         linearization anchor for the implicit flux term
+  ! tref  - linearization anchor for the implicit flux term; with
+  !         use_atm_ice_tskin the atmosphere's ice-tile skin temperature
   !
   ! INPUT/OUTPUT:
   ! t     - Ice surface temperature
@@ -615,7 +618,7 @@ contains
   zcpdte=zcpdt !+zcprosn*hsn            ! Combined Energy required to change temperature of snow + 0.05m of upper ice
 
   !---- Implicit (dQ/dT-linearized) atmospheric flux.
-  ! a2ihf was computed by the atmosphere at tref (the last transmitted ist)
+  ! a2ihf was computed by the atmosphere at tref
   ! and is held constant over the coupling interval. As the surface departs
   ! from tref, the flux's dominant temperature response is the surface's own
   ! longwave emission, linearized here:
@@ -625,8 +628,14 @@ contains
   ! wherever the surface tracks the coupling temperature. In coupled-slab mode
   ! the growth budget is driven by the atmosphere flux (-a2ihf), so this solve
   ! only sets the internal skin temperature (albedo/melt-pond state).
+  ! With use_atm_ice_tskin the atmosphere owns the skin and already formed it
+  ! from a2ihf, so it is taken as is.
   zlam=4.0_WP*emiss_ice*boltzmann*tref**3 + zlam_turb
-  t=(zcpdte*t+a2ihf+zlam*tref+zicefl)/(zcpdte+con/zsniced+zlam) ! New sea ice surf temp [K]
+  if (use_atm_ice_tskin) then
+     t=tref
+  else
+     t=(zcpdte*t+a2ihf+zlam*tref+zicefl)/(zcpdte+con/zsniced+zlam) ! New sea ice surf temp [K]
+  end if
   if (t>273.15_WP) then
      qres=(con/zsniced+zcpdte+zlam)*(t-273.15_WP)
      t=273.15_WP


### PR DESCRIPTION
## What

Adds a switch `use_atm_ice_tskin` (`namelist.config`, `&run_config`, default `.false.`) for OpenIFS-coupled builds. When on, FESOM receives the ice-tile skin temperature from OpenIFS as an extra field `tsk_ico` and uses it as the ice surface temperature for albedo and melt ponds, instead of solving its own in `ice_surftemp`.

Also fixes two things in the `__oifs` coupling path, independent of the switch.

## Why

In coupled-slab mode (`LNEMOLIMTEMP=.false.`, #957) OpenIFS owns the ice skin: it forms it from its own surface energy balance using the thickness, snow and concentration FESOM sends. The implicit solve in `ice_surftemp` is meant to be anchored on the temperature the atmosphere evaluated `heat_ico` at, but FESOM had no way to know it. `ist_ref` was supposed to be captured from our own field-4 send, and that never worked (see below), so `tref` fell back to `t`. Then the `zlam` terms cancel, the surface is held only by snow-damped conduction (~0.5 W/m²/K), and any cold state is a fixed point. In AWI-ESM3 (TCO95 / CORE3) the skin settled around 70 K below the atmosphere's. With the switch on, FESOM takes the skin OpenIFS actually used, so there is one ice surface temperature in the coupled system, not two.

## Changes

- `use_atm_ice_tskin` in `g_config`. When on (and `__oifs`), `nrecv` grows by one and `tsk_ico` is appended to `cpl_recv`. Its index is kept in `cpl_driver::recv_tsk_ico` (0 when off), so it does not collide with `XCO2_oce` in recom builds.
- `ice_thermo_cpl.F90`: with the switch on, `t = tref` = received skin (freezing point before the first receive or for values outside 173–400 K). The `qres` / `qcon` diagnostics are unchanged. With the switch off, the solve runs as before with `tref = t`.
- `cpl_oasis3mct_send`: OASIS3-MCT returns `OASIS_Sent` only to the put that completes a coupling group and `OASIS_Waitgroup` to the earlier ones. That data is buffered and sent together with the last field. `action=(info==4 .OR. info==8)` therefore reported `.false.` for every field but the last. Now: `action=(info==OASIS_Sent .OR. info==OASIS_SentOut .OR. info==OASIS_Waitgroup)`. The only consumer of the send-side `action` besides the buffer reset (last field, unchanged) was the `ist_ref` capture below.
- Removed the `ist_ref` capture from the field-4 send. Because of the above, it never fired. It also stored the concentration-weighted field (`ice_temp*a_ice`), which would give a cold-biased anchor as soon as it did fire.
- `ice_timestep`: `ice_temp` is advected as `ice_temp*a_ice`. The recovery `if (a_ice>0) ice_temp = ice_temp/max(a_ice,1e-6)` left the ~0 K product where `a_ice` was exactly 0, and returned `T*a_ice/1e-6` where it was small but nonzero. Now: divide where `a_ice > 1e-6`, else freezing point.

## Compatibility

- **Default off**: namcouple unchanged. Results change only through the `ice_temp` recovery fix, where the concentration is (near) zero.
- **Switch on**: needs an OpenIFS that sends `A_Ice_tskin` and a namcouple entry `A_Ice_tskin -> tsk_ico` (no conservation). The OpenIFS side is in the EC-Earth OpenIFS 48r1 fork used by AWI-ESM3.
- Non-OIFS builds: untouched.

## Validation

- The physics (skin from `tsk_ico`, the `OASIS_Waitgroup` fix, the `ice_temp` recovery) has run in several multi-decade AWI-ESM3 TCO95L91 / CORE3 PI spin-ups, on an earlier base that received `tsk_ico` in a fixed slot.
- This branch (main 758138a0 + this commit) builds in the coupled single-precision AWI-ESM3 configuration. It has not yet been run on this base.