### PR TITLE
icebergs: two false "left the domain" reports in the element search, and wrap longitude

### DIFF
--- a/src/icb_elem.F90
+++ b/src/icb_elem.F90
@@ -472,6 +472,14 @@ do m=1, 3
          cycle
       end if
    endif
+   ! A valid element WAS found.  Clear any left_mype raised by a cavity
+   ! element rejected earlier in this same search: the `cycle` above leaves
+   ! left_mype=1.0 set, and without this reset the routine returns a perfectly
+   ! good element while still reporting failure.  The caller then treats it as
+   ! "left the domain", resets the position and re-advects through
+   ! parallel2coast -- projecting the velocity along a coast the berg is not
+   ! near.  Only a search that finds nothing may report left_mype=1.0.
+   left_mype=0.0
    RETURN 
   end if
  end do
@@ -671,6 +679,17 @@ subroutine com_integer(partit, i_have_element, iceberg_element, ib)
  !leave most of a 2h20 compute-job walltime for a rerun once the root cause
  !is fixed, instead of burning the whole budget on a silent hang.
  real(kind=8), parameter :: com_integer_timeout = 300.0
+ ! Send buffer for the non-owning branch.  It MUST be a named variable, not the
+ ! literal 0 that used to be passed directly: MPI_IAllreduce is non-blocking, so
+ ! the send buffer has to stay valid until the MPI_TEST loop below completes, and
+ ! a literal may be passed via a compiler temporary that does not.  A non-owning
+ ! PE could therefore contribute garbage instead of 0, making the MPI_SUM
+ ! non-zero when NO PE owns the element.  iceberg_step2 then sees a non-zero
+ ! iceberg_elem, skips its "iceberg_elem == 0 -> restore old position" branch,
+ ! and the berg keeps a position no element contains -- observed in new_ism38 as
+ ! 22-30 % of bergs ending each year a median 620 km OUTSIDE the mesh, sitting
+ ! over grounded ice under ~2.5 km of ice.
+ integer:: zero_send
 type(t_partit), intent(inout), target :: partit
 !#include "associate_part_def.h"
 !#include "associate_part_ass.h"
@@ -682,7 +701,8 @@ type(t_partit), intent(inout), target :: partit
 !$omp end critical
  else
 !$omp critical
-     call MPI_IAllreduce(0,            iceberg_element, 1, MPI_INTEGER, MPI_SUM, partit%MPI_COMM_FESOM_IB, req, partit%MPIERR_IB)
+     zero_send = 0
+     call MPI_IAllreduce(zero_send,    iceberg_element, 1, MPI_INTEGER, MPI_SUM, partit%MPI_COMM_FESOM_IB, req, partit%MPIERR_IB)
 !$omp end critical
  end if
 

--- a/src/icb_step.F90
+++ b/src/icb_step.F90
@@ -1052,6 +1052,27 @@ subroutine trajectory( lon_rad,lat_rad, old_u,old_v, new_u,new_v, &
  lon_rad = lon_rad + (0.5*(deltax1 + deltax2) / (r_earth*cos_lat_safe) )
  lat_rad = lat_rad + (0.5*(deltay1 + deltay2) /  r_earth )
  lat_rad = max(-lat_rad_max, min(lat_rad_max, lat_rad))
+ ! Wrap longitude to (-pi,pi].  Latitude is clamped on the line above but
+ ! longitude was left unbounded, so lon_deg drifted out of [-180,180]: a berg
+ ! carried across several legs accumulates westward drift with nothing to reset
+ ! it (down to -268 deg in new_ism38 over 1900-1925).
+ !
+ ! This is PRECAUTIONARY, not a bug fix.  locbafu_2D re-centres the test point
+ ! on the element's first node with two if-statements, i.e. at most ONE +/-360
+ ! correction, which suffices for any |lon| < 360.  Every value this run
+ ! produced was inside that, and locbafu_2D returns identical basis functions
+ ! with and without this line (checked over the full observed range: 200000
+ ! cases, max discrepancy 3e-14 deg).  The unwrapped values were harmless and
+ ! removing this line would change no result today.
+ !
+ ! It is kept because the single correction DOES fail beyond |lon| = 360, and a
+ ! berg at ~3 cm/s near 60S laps Antarctica in roughly 20 years -- unreachable
+ ! in a 26-cycle run, reachable in the 50-cycle configuration.  It also keeps
+ ! iceberg.restart and buoys_track in a sane range for anything reading them.
+ ! Safe by construction: old_lon is intent(out), assigned before the move and
+ ! used only to restore position on the left_mype path, so nothing differences
+ ! longitude across steps and no spurious 360 deg jump can be manufactured.
+ lon_rad = modulo(lon_rad + pi, 2.0*pi) - pi
  lon_deg=lon_rad/rad
  lat_deg=lat_rad/rad
    


### PR DESCRIPTION
Two commits by @xihao001 (Xiaojie Hao), who found these while running AWI-ESM3 with icebergs calved from PISM discharge. I am opening the PR on her behalf; the commits are hers.

## `find_new_iceberg_elem` / `com_integer`: stop reporting failure when an element was found

`iceberg_step2` treats `left_mype = 1` or `iceberg_elem == 0` as the berg having left the domain. It then restores the old position and re-advects through `parallel2coast`, projecting the velocity along a coast. Two defects in `icb_elem.F90` make it take that path for a berg that is inside the mesh.

**1. `left_mype` is never cleared on success.** When the search rejects a cavity element it sets `left_mype = 1.0` and cycles, so that a neighbouring non-cavity element can still match:

```fortran
if(reject_tmp) then
   left_mype=1.0
   old_iceberg_elem=ibelem_tmp
   cycle
end if
```

If a later candidate matches, the routine returns a good element with `left_mype` still at 1. The fix clears it before the `RETURN`. Only a search that finds nothing may report failure.

**2. A literal is passed as the send buffer of a non-blocking reduction.**

```fortran
call MPI_IAllreduce(0, iceberg_element, 1, MPI_INTEGER, MPI_SUM, ...)
```

`MPI_IAllreduce` needs its send buffer to stay valid until the `MPI_TEST` loop completes. A literal can be passed through a compiler temporary that does not live that long, so a rank that does not own the element can contribute garbage instead of 0. The sum is then non-zero when no rank owns the element, `iceberg_step2` skips its `iceberg_elem == 0` branch, and the berg keeps a position that no element contains. The fix passes a named variable.

In a 26-year coupled run, 22 to 30 % of bergs ended each year a median 620 km outside the mesh, over grounded ice. Both defects are there by inspection. Neither has been isolated in a controlled rerun, so how much of that each one accounts for is not established.

## `trajectory`: wrap longitude to (-pi, pi]

Latitude is clamped after each step and longitude is not, so a berg carried across many legs drifts without bound. We saw -268° after 26 years. This one is a precaution rather than a fix. `locbafu_2D` applies at most one ±360° correction, which is enough for any |lon| < 360°. Over the observed range it returns identical basis functions with and without the wrap (200000 cases, largest difference 3e-14°), so no current result changes. The single correction fails beyond 360°. A berg at about 3 cm/s near 60°S gets there in roughly 20 years, which a long coupled run reaches. `old_lon` is only used to restore the position on the `left_mype` path, so the wrap cannot create a 360° jump between steps.

## Testing

AWI-ESM3 (OpenIFS 48r1 + FESOM2 CORE3 cavity mesh + PISM), levante, 1792 FESOM ranks. The coupled run `ism40` has completed 40 one-year legs with both commits, across a mesh change every leg, with icebergs carried and calved each year.
